### PR TITLE
Added a "help" player command and "sendmsg" server command. Separated commands and aliases 

### DIFF
--- a/src/main/java/emu/grasscutter/commands/ServerCommands.java
+++ b/src/main/java/emu/grasscutter/commands/ServerCommands.java
@@ -1,9 +1,11 @@
 package emu.grasscutter.commands;
 
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.GenshinData;
@@ -65,6 +67,35 @@ public class ServerCommands {
 			Grasscutter.loadConfig();
 			Grasscutter.getDispatchServer().loadQueries();
 			Grasscutter.getLogger().info("Reload complete.");
+		}
+	}
+
+	public static class sendMsg extends ServerCommand {
+		@Override
+		public void execute(String raw) {
+			List<String> split = Arrays.asList(raw.split(" "));
+
+			if (split.size() < 2) {
+				Grasscutter.getLogger().error("Invalid amount of args");
+				return;
+			}
+
+			String playerID = split.get(0);
+			String message = split.stream().skip(1).collect(Collectors.joining(" "));
+
+
+			emu.grasscutter.game.Account account = DatabaseHelper.getAccountByPlayerId(Integer.parseInt(playerID));
+			if (account != null) {
+				GenshinPlayer player = Grasscutter.getGameServer().getPlayerById(Integer.parseInt(playerID));
+				if(player != null) {
+					player.dropMessage(message);
+					Grasscutter.getLogger().info(String.format("Successfully sent message to %s: %s", playerID, message));
+				} else {
+					Grasscutter.getLogger().error("Player not online");
+				}
+			} else {
+				Grasscutter.getLogger().error(String.format("Player %s does not exist", playerID));
+			}
 		}
 	}
 	

--- a/src/main/java/emu/grasscutter/database/DatabaseHelper.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseHelper.java
@@ -95,7 +95,7 @@ public class DatabaseHelper {
 		return cursor.next();
 	}
 	
-	private static Account getAccountByPlayerId(int playerId) {
+	public static Account getAccountByPlayerId(int playerId) {
 		MorphiaCursor<Account> cursor = DatabaseManager.getDatastore().createQuery(Account.class).field("playerId").equal(playerId).find(FIND_ONE);
 		if (!cursor.hasNext()) return null;
 		return cursor.next();

--- a/src/main/java/emu/grasscutter/game/managers/ChatManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/ChatManager.java
@@ -1,5 +1,6 @@
 package emu.grasscutter.game.managers;
 
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.commands.PlayerCommands;
 import emu.grasscutter.game.GenshinPlayer;
 import emu.grasscutter.net.packet.GenshinPacket;
@@ -25,7 +26,7 @@ public class ChatManager {
 		}
 				
 		// Check if command
-		if (message.charAt(0) == '!') {
+		if (message.charAt(0) == '!' || message.charAt(0) == '/') {
 			PlayerCommands.handle(player, message);
 			return;
 		}


### PR DESCRIPTION
Changes:
- Help command for the player
     help me pls (Might be an issue later with the auto-scroll within genshin's chat)
- sendmsg command
     Sends a message to the player
     sendmsg [player id] [message]
- Players can now send a command using '/' and '!' 
     I did this because the helpText for existing commands seemed to assume that the commands used '/'.
- getAccountByPlayerId(int playerID) is now public within DatabaseHelper.
     This was for sendmsg. I don't know why getAccountById would be public and getAccountByPlayerId isn't. If there was a better way to do this, I'll happily change sendmsg to use that and revert my change.
- Separated commands and aliases into different HashMaps. It seems more logical not to have them grouped together (It also declutters the help command). I do have another way of doing this with one HashMap but I think it's better like this