### PR TITLE
added wiki link, corrected some spelling and definition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,33 +12,33 @@ A WIP server emulator for Genshin Impact 2.3-2.6
 * Friends list
 * Gacha system
 
-# Running the server and client
-
+# Quick setup guide
+* For more information, we now have [Grasscutter Wiki](https://github.com/Melledy/Grasscutter/wiki/) page !
 ### Prerequisites
-* JDK-8u202 ([mirror link since Oracle required an account to download old builds](https://mirrors.huaweicloud.com/java/jdk/8u202-b08/))
+* JDK-8u202 ([mirror link](https://mirrors.huaweicloud.com/java/jdk/8u202-b08/) since Oracle required an account to download old builds)
 * Mongodb (recommended 4.0+)
 * Proxy daemon: mitmproxy (mitmdump, recommended), Fiddler Classic, etc.
 
 ### Starting up the server (Assuming you are on Windows)
 1. Setup compile environment `gradlew.bat`
 2. Compile the server with `gradlew jar`
-3. Create a folder named `resources` in your server directory, you will need to copy `BinOutput`, `ExcelBinOutput` folders and `TextMap*.json` which you can get from a repo like [https://github.com/Dimbreath/GenshinData](https://github.com/Dimbreath/GenshinData) into your resources folder.
+3. Create a folder named `resources` in your Grasscutter directory, bring your `BinOutput` and `ExcelBinOutput` folders into it *(Check the wiki for more details where to get those.)*
 4. Run the server with `java -jar grasscutter.jar`. Make sure mongodb is running as well.
 
 ### Connecting with the client
 ½. Create an account using command below
 1. Run a proxy daemon:
 	- mitmdump: `mitmdump -s proxy.py --ssl-insecure`
-	- Fiddler Classic: Run Fiddler Classic, turn on `Decrypt https traffic` in setting and change the default port there (Tools -> Options -> Connections) to anything other than `8888`, load [this script](https://github.lunatic.moe/fiddlerscript).
-	- hosts: Redirect at least `api-account-os.hoyoverse.com` and `dispatchosglobal.yuanshen.com` to your dispatch server ip.
+	- Fiddler Classic: Run Fiddler Classic, turn on `Decrypt https traffic` in setting and change the default port there (Tools -> Options -> Connections) to anything other than `8888`, and load [this script](https://github.lunatic.moe/fiddlerscript).
+	- [Hosts file](https://github.com/Melledy/Grasscutter/wiki/Running#traffic-route-map)
 2. Trust CA certificate:
 	- mitmdump: `certutil -addstore root %USERPROFILE%\.mitmproxy\mitmproxy-ca-cert.cer`
 2. Set network proxy to `127.0.0.1:8080` or the proxy port you specified.
-4. yoink
+4. *yoink*
 
 * or you can use `run.cmd` to start Server & Proxy daemon with one click
 
-### Server console commands
+### Grasscutter server console commands
 
 `account create [username] {playerid}` - Creates an account with the specified username and the in-game uid for that account. The playerid parameter is optional and will be auto generated if not set.
 
@@ -62,7 +62,7 @@ There is a dummy user named "Server" in every player's friends list that you can
 `!clearartifacts` - Deletes all unequipped and unlocked level 0 artifacts, **including yellow rarity ones** from your inventory
 
 ### Quick Troubleshooting
-* If compiling wasnt successful, please check your JDK installation (must be JDK 8 and JDK's bin PATH variable is correct)
-* My client doesn't connect, doesn't login, 4206, etc... - Mostly your fiddler is the issue, make sure it running on another port except 8888
-* Startup sequence: Mongodb > The server > Proxy daemon (mitmdump, fiddler, etc.) > Client
+* If compiling wasnt successful, please check your JDK installation (must be JDK 8 and validated JDK's bin PATH variable)
+* My client doesn't connect, doesn't login, 4206, etc... - Mostly your proxy daemon setup is the issue, if using Fiddler make sure it running on another port except 8888
+* Startup sequence: Mongodb > Grasscutter > Proxy daemon (mitmdump, fiddler, etc.) > Client
 * If `4206` error constantly prompt up, try to use [jdk-8u202-b08](https://mirrors.huaweicloud.com/java/jdk/8u202-b08/) instead of other versions of JDK


### PR DESCRIPTION
I should remove **setting up guide** section and leave the **wiki link** there but better rename it to **_Quick setup guide_** for more friendly guide looks.