### PR TITLE
Fix weapon refine

### DIFF
--- a/src/main/java/emu/grasscutter/data/def/ItemData.java
+++ b/src/main/java/emu/grasscutter/data/def/ItemData.java
@@ -48,6 +48,7 @@ public class ItemData extends GenshinResource {
     private int WeaponBaseExp;
     private int StoryId;
     private int AvatarPromoteId;
+    private int AwakenMaterial;
     private int[] AwakenCosts;
     private int[] SkillAffix;
     private WeaponProperty[] WeaponProp;
@@ -159,6 +160,10 @@ public class ItemData extends GenshinResource {
 	public int getWeaponBaseExp() {
 		return WeaponBaseExp;
 	}
+	
+	public int getAwakenMaterial() {
+        	return AwakenMaterial;
+    	}
 	
 	public int[] getAwakenCosts() {
 		return AwakenCosts;

--- a/src/main/java/emu/grasscutter/game/managers/InventoryManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/InventoryManager.java
@@ -438,8 +438,14 @@ public class InventoryManager {
 			return;
 		}
 		
-		if (weapon.getItemType() != ItemType.ITEM_WEAPON || weapon.getItemId() != feed.getItemId()) {
-			return;
+		if (weapon.getItemData().getAwakenMaterial() == 0) {
+			if (weapon.getItemType() != ItemType.ITEM_WEAPON || weapon.getItemId() != feed.getItemId()) {
+				return;
+			}
+		} else {
+			if (weapon.getItemType() != ItemType.ITEM_WEAPON || weapon.getItemData().getAwakenMaterial() != feed.getItemId()) {
+				return;
+			}
 		}
 		
 		if (weapon.getRefinement() >= 4 || weapon.getAffixes() == null || weapon.getAffixes().size() == 0) {


### PR DESCRIPTION
Sometimes, for example, a weapon with ID `11415` has a refined material that is not itself but is based on its `AwakenMaterial` value (Some will be available, in `WeaponExcelConfigData.json`).