### PR TITLE
unlockAvatarConstellation fix

### DIFF
--- a/src/main/java/emu/grasscutter/game/managers/InventoryManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/InventoryManager.java
@@ -471,7 +471,7 @@ public class InventoryManager {
 		}
 		
 		// Consume weapon
-		player.getInventory().removeItem(feed);
+		player.getInventory().removeItem(feed, 1);
 		
 		// Get 
 		weapon.setRefinement(targetRefineLevel);
@@ -804,7 +804,11 @@ public class InventoryManager {
 		// Get talent
 		int currentTalentLevel = avatar.getCoreProudSkillLevel();
 		int nextTalentId = ((avatar.getAvatarId() % 10000000) * 10) + currentTalentLevel + 1;
-		AvatarTalentData talentData = GenshinData.getAvatarTalentDataMap().get(nextTalentId);
+		
+		if (avatar.getAvatarId() == 10000006) {
+			// Lisa is special in that her talentId starts with 4 instead of 6.
+			nextTalentId = 40 + currentTalentLevel + 1;
+		}
 		
 		if (talentData == null) {
 			return;

--- a/src/main/java/emu/grasscutter/game/managers/InventoryManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/InventoryManager.java
@@ -810,6 +810,8 @@ public class InventoryManager {
 			nextTalentId = 40 + currentTalentLevel + 1;
 		}
 		
+		AvatarTalentData talentData = GenshinData.getAvatarTalentDataMap().get(nextTalentId);
+		
 		if (talentData == null) {
 			return;
 		}


### PR DESCRIPTION
While I was testing, I found a problem with Lisa's Constellation activation.

Lisa's ID is `10000006`, so according to the code in the `InventoryManager`: 
```java
int nextTalentId = ((avatar.getAvatarId() % 10000000) * 10) + currentTalentLevel + 1;
```

the calculated `talentId` starts with `6`, but it doesn't. When I checked `AvatarTalentExcelConfigData.json`, I found that Lisa's `talentId` starts with `4`, which is a bit strange.

So I added a judgment specific to Lisa to fix her `talentId`, and tbh I'm not sure if there is a generic way of calculating `nextTalentId`, cause I don't actually know anything about it.