### PR TITLE
Remove stella constellation appeareance in gacha pull

### DIFF
--- a/src/main/java/emu/grasscutter/game/gacha/GachaManager.java
+++ b/src/main/java/emu/grasscutter/game/gacha/GachaManager.java
@@ -218,7 +218,6 @@ public class GachaManager {
 						addStarglitter = 2;
 						// Add 1 const
 						gachaItem.addTransferItems(GachaTransferItem.newBuilder().setItem(ItemParam.newBuilder().setItemId(constItemId).setCount(1)).setIsTransferItemNew(constItem == null));
-						gachaItem.addTokenItemList(ItemParam.newBuilder().setItemId(constItemId).setCount(1));
 						player.getInventory().addItem(constItemId, 1);
 					} else {
 						// Is max const


### PR DESCRIPTION
self explanatory, why? because it's not a vanilla behaviour

Before: 
![unknown](https://user-images.githubusercontent.com/56186498/164376160-4cd965c6-0ed0-4c0f-9f5f-f05fb7f84172.png)
.