### PR TITLE
Fix typo

### DIFF
--- a/src/main/java/emu/grasscutter/data/ResourceLoader.java
+++ b/src/main/java/emu/grasscutter/data/ResourceLoader.java
@@ -128,7 +128,7 @@ public class ResourceLoader {
 
 	private static void loadScenePoints() {
 		Pattern pattern = Pattern.compile("(?<=scene)(.*?)(?=_point.json)");
-		File folder = new File(Grasscutter.getConfig().RESOURCE_FOLDER + "BinOutPut/Scene/Point");
+		File folder = new File(Grasscutter.getConfig().RESOURCE_FOLDER + "BinOutput/Scene/Point");
 
 		if (!folder.isDirectory() || !folder.exists() || folder.listFiles() == null) {
 			Grasscutter.getLogger().error("Scene point files cannot be found, you cannot use teleport waypoints!");


### PR DESCRIPTION
"When you create a new account via auto register or console server then during scene select a character and write a name on it press it it will get stuck and make the server disconnected. Some can get through and some can't passed it, so currently I'm still on the stable version . even how many times have I deleted the datebase and tried it on some linux and directly on windows too :/ btw https://github.com/Grasscutters/Grasscutter/blob/686360086569d52467a95b289b8bbe5c85cb2fe4/src/main/java/emu/grasscutter/data/ResourceLoader.java#L131 in scene folder there is a typo name "BinOutPut" it should be "BinOutput" so scene file can't be found." - [Yuki#4985](https://discord.com/channels/965284035985305680/965284036333424722/966756877100789760)
Thanks [Yuki#4985](https://discord.com/channels/965284035985305680/965284036333424722/966756877100789760)