### PR TITLE
Teleport Small Fix

### DIFF
--- a/src/main/java/emu/grasscutter/game/World.java
+++ b/src/main/java/emu/grasscutter/game/World.java
@@ -212,7 +212,10 @@ public class World implements Iterable<GenshinPlayer> {
 			return false;
 		}
 		
+		Integer oldSceneId = null;
+
 		if (player.getScene() != null) {
+			oldSceneId = player.getScene().getId();
 			player.getScene().removePlayer(player);
 		}
 		
@@ -221,7 +224,11 @@ public class World implements Iterable<GenshinPlayer> {
 		player.getPos().set(pos);
 		
 		// Teleport packet
-		player.sendPacket(new PacketPlayerEnterSceneNotify(player, EnterType.EnterSelf, EnterReason.TransPoint, sceneId, pos));
+		if (oldSceneId.equals(sceneId)) {
+			player.sendPacket(new PacketPlayerEnterSceneNotify(player, EnterType.EnterGoto, EnterReason.TransPoint, sceneId, pos));
+		} else {
+			player.sendPacket(new PacketPlayerEnterSceneNotify(player, EnterType.EnterJump, EnterReason.TransPoint, sceneId, pos));
+		}
 		return true;
 	}
 	

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketPlayerEnterSceneNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketPlayerEnterSceneNotify.java
@@ -52,7 +52,7 @@ public class PacketPlayerEnterSceneNotify extends GenshinPacket {
 				.setSceneId(newScene)
 				.setPos(newPos.toProto())
 				.setSceneBeginTime(System.currentTimeMillis())
-				.setType(EnterType.EnterSelf)
+				.setType(type)
 				.setTargetUid(target.getUid())
 				.setEnterSceneToken(player.getEnterSceneToken())
 				.setWorldLevel(target.getWorld().getWorldLevel())


### PR DESCRIPTION
Modified `transferPlayerToScene` in `World.java` to show the map loading screen (the screen with scene icons and tips) when players are teleporting while waiting.

`EnterType.EnterGoto` if the player is in the same scene as the scene where the teleport way is located, otherwise use `EnterType.EnterJump`.