### PR TITLE
Morphia call fixes; add `@Entity` to more classes

### DIFF
--- a/src/main/java/emu/grasscutter/database/DatabaseHelper.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseHelper.java
@@ -139,7 +139,7 @@ public final class DatabaseHelper {
 	}
 
 	public static List<GenshinAvatar> getAvatars(GenshinPlayer player) {
-		return DatabaseManager.getDatastore().find(GenshinAvatar.class).filter(Filters.eq("playerId", player.getUid())).stream().toList();
+		return DatabaseManager.getDatastore().find(GenshinAvatar.class).filter(Filters.eq("ownerId", player.getUid())).stream().toList();
 	}
 
 	public static void saveItem(GenshinItem item) {
@@ -155,7 +155,7 @@ public final class DatabaseHelper {
 		return DatabaseManager.getDatastore().find(GenshinItem.class).filter(Filters.eq("ownerId", player.getUid())).stream().toList();
 	}
 	public static List<Friendship> getFriends(GenshinPlayer player) {
-		return DatabaseManager.getDatastore().find(Friendship.class).filter(Filters.eq("playerId", player.getUid())).stream().toList();
+		return DatabaseManager.getDatastore().find(Friendship.class).filter(Filters.eq("ownerId", player.getUid())).stream().toList();
 	}
 
 	public static List<Friendship> getReverseFriends(GenshinPlayer player) {

--- a/src/main/java/emu/grasscutter/game/TeamInfo.java
+++ b/src/main/java/emu/grasscutter/game/TeamInfo.java
@@ -3,10 +3,12 @@ package emu.grasscutter.game;
 import java.util.ArrayList;
 import java.util.List;
 
+import dev.morphia.annotations.Entity;
 import emu.grasscutter.GenshinConstants;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.game.avatar.GenshinAvatar;
 
+@Entity
 public class TeamInfo {
 	private String name;
 	private List<Integer> avatars;

--- a/src/main/java/emu/grasscutter/game/TeamManager.java
+++ b/src/main/java/emu/grasscutter/game/TeamManager.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import dev.morphia.annotations.Entity;
 import dev.morphia.annotations.Transient;
 import emu.grasscutter.GenshinConstants;
 import emu.grasscutter.Grasscutter;
@@ -41,6 +42,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 
+@Entity
 public class TeamManager {
 	@Transient private GenshinPlayer player;
 	

--- a/src/main/java/emu/grasscutter/game/avatar/AvatarProfileData.java
+++ b/src/main/java/emu/grasscutter/game/avatar/AvatarProfileData.java
@@ -1,5 +1,8 @@
 package emu.grasscutter.game.avatar;
 
+import dev.morphia.annotations.Entity;
+
+@Entity
 public class AvatarProfileData {
 	private int avatarId;
 	private int level;

--- a/src/main/java/emu/grasscutter/game/friends/PlayerProfile.java
+++ b/src/main/java/emu/grasscutter/game/friends/PlayerProfile.java
@@ -4,6 +4,7 @@ import dev.morphia.annotations.*;
 import emu.grasscutter.game.GenshinPlayer;
 import emu.grasscutter.utils.Utils;
 
+@Entity
 public class PlayerProfile {
 	@Transient private GenshinPlayer player;
 	

--- a/src/main/java/emu/grasscutter/game/gacha/PlayerGachaBannerInfo.java
+++ b/src/main/java/emu/grasscutter/game/gacha/PlayerGachaBannerInfo.java
@@ -1,5 +1,8 @@
 package emu.grasscutter.game.gacha;
 
+import dev.morphia.annotations.Entity;
+
+@Entity
 public class PlayerGachaBannerInfo {
 	private int pity5 = 0;
 	private int pity4 = 0;

--- a/src/main/java/emu/grasscutter/game/gacha/PlayerGachaInfo.java
+++ b/src/main/java/emu/grasscutter/game/gacha/PlayerGachaInfo.java
@@ -1,5 +1,8 @@
 package emu.grasscutter.game.gacha;
 
+import dev.morphia.annotations.Entity;
+
+@Entity
 public class PlayerGachaInfo {
 	private PlayerGachaBannerInfo standardBanner;
 	private PlayerGachaBannerInfo eventCharacterBanner;

--- a/src/main/java/emu/grasscutter/utils/Position.java
+++ b/src/main/java/emu/grasscutter/utils/Position.java
@@ -2,8 +2,10 @@ package emu.grasscutter.utils;
 
 import java.io.Serializable;
 
+import dev.morphia.annotations.Entity;
 import emu.grasscutter.net.proto.VectorOuterClass.Vector;
 
+@Entity
 public class Position implements Serializable {
 	private static final long serialVersionUID = -2001232313615923575L;
 	


### PR DESCRIPTION
1. During the conversion of Morphia calls to the new API, some of the `Filter.eq()` calls had their `field` set to `playerId` due to a copy/paste typo.

2. Morphia 2 switches to the codec system, so anything that will be serialized in the pipeline requires the `@Entity` annotation.

This is enough to get into the game, but I haven't tested other functionality.