### PR TITLE
GM handbook: Explicitly load and save UTF-8

### DIFF
--- a/src/main/java/emu/grasscutter/tools/Tools.java
+++ b/src/main/java/emu/grasscutter/tools/Tools.java
@@ -3,6 +3,7 @@ package emu.grasscutter.tools;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -30,13 +31,13 @@ public final class Tools {
 		ResourceLoader.loadResources();
 		
 		Map<Long, String> map;
-		try (FileReader fileReader = new FileReader(Utils.toFilePath(Grasscutter.getConfig().RESOURCE_FOLDER + "TextMap/TextMapEN.json"))) {
+		try (FileReader fileReader = new FileReader(Utils.toFilePath(Grasscutter.getConfig().RESOURCE_FOLDER + "TextMap/TextMapEN.json"), StandardCharsets.UTF_8)) {
 			map = Grasscutter.getGsonFactory().fromJson(fileReader, new TypeToken<Map<Long, String>>() {}.getType());
 		}
 		
 		List<Integer> list;
 		String fileName = "./GM Handbook.txt";
-		try (FileWriter fileWriter = new FileWriter(fileName); PrintWriter writer = new PrintWriter(fileWriter)) {
+		try (PrintWriter writer = new PrintWriter(fileName, StandardCharsets.UTF_8)) {
 			DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");  
 			LocalDateTime now = LocalDateTime.now();
 			   


### PR DESCRIPTION
This fixes potential output issues for non-Latin scripts when exporting the handbook by changing the filename in the code. This is likely only a problem for Windows users.