### PR TITLE
Add FrontHTTPS field to Dispatch server

### DIFF
--- a/src/main/java/emu/grasscutter/Config.java
+++ b/src/main/java/emu/grasscutter/Config.java
@@ -30,6 +30,7 @@ public final class Config {
 		public String KeystorePath = "./keystore.p12";
 		public String KeystorePassword = "";
 		public Boolean UseSSL = true;
+		public Boolean FrontHTTPS = true;
 
 		public boolean AutomaticallyCreateAccounts = false;
 

--- a/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
@@ -101,7 +101,7 @@ public final class DispatchServer {
 						.setName("os_usa")
 						.setTitle(Grasscutter.getConfig().getGameServerOptions().Name)
 						.setType("DEV_PUBLIC")
-						.setDispatchUrl("https://" + (Grasscutter.getConfig().getDispatchOptions().PublicIp.isEmpty() ? Grasscutter.getConfig().getDispatchOptions().Ip : Grasscutter.getConfig().getDispatchOptions().PublicIp) + ":" + getAddress().getPort() + "/query_cur_region_" + defaultServerName)
+						.setDispatchUrl("http" + (Grasscutter.getConfig().getDispatchOptions().FrontHTTPS ? "s" : "") + "://" + (Grasscutter.getConfig().getDispatchOptions().PublicIp.isEmpty() ? Grasscutter.getConfig().getDispatchOptions().Ip : Grasscutter.getConfig().getDispatchOptions().PublicIp) + ":" + getAddress().getPort() + "/query_cur_region_" + defaultServerName)
 						.build();
 				usedNames.add(defaultServerName);
 				servers.add(server);
@@ -131,7 +131,7 @@ public final class DispatchServer {
 						.setName(regionInfo.Name)
 						.setTitle(regionInfo.Title)
 						.setType("DEV_PUBLIC")
-						.setDispatchUrl("https://" + (Grasscutter.getConfig().getDispatchOptions().PublicIp.isEmpty() ? Grasscutter.getConfig().getDispatchOptions().Ip : Grasscutter.getConfig().getDispatchOptions().PublicIp) + ":" + getAddress().getPort() + "/query_cur_region_" + regionInfo.Name)
+						.setDispatchUrl("http" + (Grasscutter.getConfig().getDispatchOptions().FrontHTTPS ? "s" : "") + "://" + (Grasscutter.getConfig().getDispatchOptions().PublicIp.isEmpty() ? Grasscutter.getConfig().getDispatchOptions().Ip : Grasscutter.getConfig().getDispatchOptions().PublicIp) + ":" + getAddress().getPort() + "/query_cur_region_" + regionInfo.Name)
 						.build();
 				usedNames.add(regionInfo.Name);
 				servers.add(server);


### PR DESCRIPTION
When `UseSSL` is set to false, hardcoded HTTPS will make the client unable to connect.

However, if we add an HTTPS proxy (such as Nginx) outside the Dispatch server, hard coded HTTP will not work.

So add a `FrontHTTPS` field to make server work when `UseSSL` is false.