### PR TITLE
fixed encoding problem when generating gm handbook

### DIFF
--- a/src/main/java/emu/grasscutter/tools/Tools.java
+++ b/src/main/java/emu/grasscutter/tools/Tools.java
@@ -1,9 +1,11 @@
 package emu.grasscutter.tools;
 
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
@@ -39,7 +41,7 @@ public final class Tools {
 		
 		List<Integer> list;
 		String fileName = "./GM Handbook.txt";
-		try (FileWriter fileWriter = new FileWriter(fileName); PrintWriter writer = new PrintWriter(fileWriter)) {
+		try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(fileName), StandardCharsets.UTF_8), false)) {
 			DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");  
 			LocalDateTime now = LocalDateTime.now();
 			   

--- a/src/main/java/emu/grasscutter/tools/Tools.java
+++ b/src/main/java/emu/grasscutter/tools/Tools.java
@@ -1,8 +1,11 @@
 package emu.grasscutter.tools;
 
+import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -30,7 +33,7 @@ public final class Tools {
 		ResourceLoader.loadResources();
 		
 		Map<Long, String> map;
-		try (FileReader fileReader = new FileReader(Utils.toFilePath(Grasscutter.getConfig().RESOURCE_FOLDER + "TextMap/TextMapEN.json"))) {
+		try (InputStreamReader fileReader = new InputStreamReader(new FileInputStream(Utils.toFilePath(Grasscutter.getConfig().RESOURCE_FOLDER + "TextMap/TextMapEN.json")), StandardCharsets.UTF_8)) {
 			map = Grasscutter.getGsonFactory().fromJson(fileReader, new TypeToken<Map<Long, String>>() {}.getType());
 		}
 		


### PR DESCRIPTION
I've met the same problem as the message on [discord](https://discord.com/channels/965284035985305680/965284035985305688/965832388716404787), which is the result of default encoding in java.

When using FileReader, the default encoding will be applied. However, in some area utf8 is not the default charset, which will result in exception when loading text map file.

To solve the problem, InputStreamReader is applied in this branch, and charset is manually set to utf8. I've tested that works on my computer.