### PR TITLE
Add PublicPort field to Dispatch server

### DIFF
--- a/src/main/java/emu/grasscutter/Config.java
+++ b/src/main/java/emu/grasscutter/Config.java
@@ -54,6 +54,7 @@ public final class Config {
 		public String Ip = "0.0.0.0";
 		public String PublicIp = "127.0.0.1";
 		public int Port = 22102;
+		public int PublicPort = 0;
 
 		public String DispatchServerDatabaseUrl = "mongodb://localhost:27017";
 		public String DispatchServerDatabaseCollection = "grasscutter";

--- a/src/main/java/emu/grasscutter/Config.java
+++ b/src/main/java/emu/grasscutter/Config.java
@@ -27,6 +27,7 @@ public final class Config {
 		public String Ip = "0.0.0.0";
 		public String PublicIp = "127.0.0.1";
 		public int Port = 443;
+		public int PublicPort = 0;
 		public String KeystorePath = "./keystore.p12";
 		public String KeystorePassword = "";
 		public Boolean UseSSL = true;

--- a/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
@@ -101,7 +101,7 @@ public final class DispatchServer {
 						.setName("os_usa")
 						.setTitle(Grasscutter.getConfig().getGameServerOptions().Name)
 						.setType("DEV_PUBLIC")
-						.setDispatchUrl("http" + (Grasscutter.getConfig().getDispatchOptions().FrontHTTPS ? "s" : "") + "://" + (Grasscutter.getConfig().getDispatchOptions().PublicIp.isEmpty() ? Grasscutter.getConfig().getDispatchOptions().Ip : Grasscutter.getConfig().getDispatchOptions().PublicIp) + ":" + getAddress().getPort() + "/query_cur_region_" + defaultServerName)
+						.setDispatchUrl("http" + (Grasscutter.getConfig().getDispatchOptions().FrontHTTPS ? "s" : "") + "://" + (Grasscutter.getConfig().getDispatchOptions().PublicIp.isEmpty() ? Grasscutter.getConfig().getDispatchOptions().Ip : Grasscutter.getConfig().getDispatchOptions().PublicIp) + ":" + (Grasscutter.getConfig().getDispatchOptions().PublicPort != 0 ? Grasscutter.getConfig().getDispatchOptions().PublicPort : Grasscutter.getConfig().getDispatchOptions().Port) + "/query_cur_region_" + defaultServerName)
 						.build();
 				usedNames.add(defaultServerName);
 				servers.add(server);

--- a/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
@@ -108,7 +108,7 @@ public final class DispatchServer {
 
 				RegionInfo serverRegion = regionQuery.getRegionInfo().toBuilder()
 						.setIp((Grasscutter.getConfig().getGameServerOptions().PublicIp.isEmpty() ? Grasscutter.getConfig().getGameServerOptions().Ip : Grasscutter.getConfig().getGameServerOptions().PublicIp))
-						.setPort(Grasscutter.getConfig().getGameServerOptions().Port)
+						.setPort(Grasscutter.getConfig().getGameServerOptions().PublicPort != 0 ? Grasscutter.getConfig().getGameServerOptions().PublicPort : Grasscutter.getConfig().getGameServerOptions().Port)
 						.setSecretKey(ByteString.copyFrom(FileUtils.read(Grasscutter.getConfig().KEY_FOLDER + "dispatchSeed.bin")))
 						.build();
 

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketPlayerLoginRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketPlayerLoginRsp.java
@@ -41,7 +41,7 @@ public class PacketPlayerLoginRsp extends GenshinPacket {
 
 					RegionInfo serverRegion = regionQuery.getRegionInfo().toBuilder()
 							.setIp((Grasscutter.getConfig().getGameServerOptions().PublicIp.isEmpty() ? Grasscutter.getConfig().getGameServerOptions().Ip : Grasscutter.getConfig().getGameServerOptions().PublicIp))
-							.setPort(Grasscutter.getConfig().getGameServerOptions().Port)
+							.setPort(Grasscutter.getConfig().getGameServerOptions().PublicPort != 0 ? Grasscutter.getConfig().getGameServerOptions().PublicPort : Grasscutter.getConfig().getGameServerOptions().Port)
 							.setSecretKey(ByteString.copyFrom(FileUtils.read(Grasscutter.getConfig().KEY_FOLDER + "dispatchSeed.bin")))
 							.build();
 


### PR DESCRIPTION
When using `nginx or other reverse proxy` tool, the `public port` may not match the original port. This will cause the client to report error 4206.

So add a `PublicPort` field to make server work when two ports do not match.