### PR TITLE
Use count for level for equips (stable branch)

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/GiveCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveCommand.java
@@ -91,17 +91,16 @@ public final class GiveCommand implements CommandHandler {
 
         this.item(targetPlayer, itemData, amount);
 
-        CommandHandler.sendMessage(sender, String.format("Given %s of %s to %s.", amount, item, target));
+        if (!itemData.isEquip()) CommandHandler.sendMessage(sender, String.format("Given %s of %s to %s.", amount, item, target));
+        else CommandHandler.sendMessage(sender, String.format("Given %s with level %s to %s", item, amount, target));
     }
 
     private void item(GenshinPlayer player, ItemData itemData, int amount) {
         if (itemData.isEquip()) {
-            List<GenshinItem> items = new LinkedList<>();
-            for (int i = 0; i < amount; i++) {
-                items.add(new GenshinItem(itemData));
-            }
-            player.getInventory().addItems(items);
-            player.sendPacket(new PacketItemAddHintNotify(items, ActionReason.SubfieldDrop));
+            GenshinItem item = new GenshinItem(itemData);
+            item.setLevel(amount);
+            player.getInventory().addItem(item);
+            player.sendPacket(new PacketItemAddHintNotify(item, ActionReason.SubfieldDrop));
         } else {
             GenshinItem genshinItem = new GenshinItem(itemData);
             genshinItem.setCount(amount);

--- a/src/main/java/emu/grasscutter/game/inventory/GenshinItem.java
+++ b/src/main/java/emu/grasscutter/game/inventory/GenshinItem.java
@@ -90,7 +90,7 @@ public class GenshinItem {
 
 		// Equip data
 		if (getItemType() == ItemType.ITEM_WEAPON) {
-			this.level = 1;
+			this.level = this.count > 1 ? this.count : 1;
 			this.affixes = new ArrayList<>(2);
 			if (getItemData().getSkillAffix() != null) {
 				for (int skillAffix : getItemData().getSkillAffix()) {


### PR DESCRIPTION
Leveling up weapons is a pain in the ass. Instead of going through all of that pain, I've brought you a simple solution:

If the weapon is a weapon or artifact, use the count as level. For example:

- `!give 13501 90` will give you a lvl. 90 Staff of Homa