### PR TITLE
Fix vbs generation when %MITMDUMP_PATH% or %MONGODB_PATH% is empty

### DIFF
--- a/start.cmd
+++ b/start.cmd
@@ -74,7 +74,9 @@ for /f "tokens=2*" %%a in ('reg query "HKCU\Software\Microsoft\Windows\CurrentVe
 
 @rem TODO: External proxy when ORIG_PROXY_ENABLE == 0x1
 echo set ws = createobject("wscript.shell") > "%temp%\proxy.vbs"
+if not "%MITMDUMP_PATH%" == "" (
 echo ws.currentdirectory = "%MITMDUMP_PATH%" >> "%temp%\proxy.vbs"
+)
 echo ws.run "cmd /c mitmdump.exe -s "^&chr(34)^&"%PROXY_SCRIPT_NAME%"^&chr(34)^&" -k",0 >> "%temp%\proxy.vbs"
 "%temp%\proxy.vbs"
 del /f /q "%temp%\proxy.vbs" >nul 2>nul
@@ -117,7 +119,9 @@ set DATABASE=true
 mkdir "%DATABASE_STORAGE_PATH%" >nul 2>nul
 
 echo set ws = createobject("wscript.shell") > "%temp%\db.vbs"
+if not "%MONGODB_PATH%" == "" (
 echo ws.currentdirectory = "%MONGODB_PATH%" >> "%temp%\db.vbs"
+)
 echo ws.run "cmd /c mongod.exe --dbpath "^&chr(34)^&"%DATABASE_STORAGE_PATH%"^&chr(34)^&"",0 >> "%temp%\db.vbs"
 "%temp%\db.vbs"
 del /f /q "%temp%\db.vbs" >nul 2>nul


### PR DESCRIPTION
`ws.currentdirectory = ""` causes crash, `wscript.shell` will execute what's in `%PATH%` without it.