### PR TITLE
Push a helpful error message to the console on bind failure

### DIFF
--- a/src/main/java/emu/grasscutter/netty/MihoyoKcpServer.java
+++ b/src/main/java/emu/grasscutter/netty/MihoyoKcpServer.java
@@ -64,9 +64,8 @@ public class MihoyoKcpServer extends Thread {
 
             // Wait until the server socket is closed.
             f.channel().closeFuture().sync();
-        } catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+        } catch (Exception exception) {
+			Grasscutter.getLogger().error("Unable to start game server.", exception);
 		} finally {
         	// Close
 			finish();


### PR DESCRIPTION
**Note**: This only sends a message on an **HTTP(S)** bind failure. I couldn't find where to catch a UDP bind exception, so I'll leave that up to someone else.