### PR TITLE
Fix the property prompt issue in fetter system

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/SetFetterLevelCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetFetterLevelCommand.java
@@ -35,7 +35,9 @@ public final class SetFetterLevelCommand implements CommandHandler {
             GenshinAvatar avatar = sender.getTeamManager().getCurrentAvatarEntity().getAvatar();
 
             avatar.setFetterLevel(fetterLevel);
-		    avatar.setFetterExp(GenshinData.getAvatarFetterLevelDataMap().get(fetterLevel).getExp());
+            if (fetterLevel != 10) {
+                avatar.setFetterExp(GenshinData.getAvatarFetterLevelDataMap().get(fetterLevel).getExp());
+            }
 		    avatar.save();
 		
 		    sender.sendPacket(new PacketAvatarFetterDataNotify(avatar));

--- a/src/main/java/emu/grasscutter/game/avatar/GenshinAvatar.java
+++ b/src/main/java/emu/grasscutter/game/avatar/GenshinAvatar.java
@@ -743,9 +743,14 @@ public class GenshinAvatar {
 	}
 	
 	public AvatarInfo toProto() {
+		int fetterLevel = this.getFetterLevel();
 		AvatarFetterInfo.Builder avatarFetter = AvatarFetterInfo.newBuilder()
-				.setExpLevel(this.getFetterLevel())
-				.setExpNumber(this.getFetterExp());
+				.setExpLevel(fetterLevel);
+		
+		if (fetterLevel != 10) {
+			avatarFetter.setExpNumber(this.getFetterExp());
+		}
+				
 		
 		if (this.getFetterList() != null) {
 			for (int i = 0; i < this.getFetterList().size(); i++) {
@@ -757,11 +762,10 @@ public class GenshinAvatar {
 			}
 		}
 
-		int rewardId = this.getNameCardRewardId();
 		int cardId = this.getNameCardId();
 
 		if (this.getPlayer().getNameCardList().contains(cardId)) {
-			avatarFetter.addRewardedFetterLevelList(rewardId);
+			avatarFetter.addRewardedFetterLevelList(10);
 		}
 
 		AvatarInfo.Builder avatarInfo = AvatarInfo.newBuilder()

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerAvatarFetterLevelRewardReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerAvatarFetterLevelRewardReq.java
@@ -9,6 +9,7 @@ import emu.grasscutter.net.packet.Opcodes;
 import emu.grasscutter.net.packet.PacketOpcodes;
 import emu.grasscutter.net.proto.AvatarFetterLevelRewardReqOuterClass.AvatarFetterLevelRewardReq;
 import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketAvatarDataNotify;
 import emu.grasscutter.server.packet.send.PacketAvatarFetterDataNotify;
 import emu.grasscutter.server.packet.send.PacketAvatarFetterLevelRewardRsp;
 import emu.grasscutter.server.packet.send.PacketItemAddHintNotify;
@@ -46,8 +47,9 @@ public class HandlerAvatarFetterLevelRewardReq extends PacketHandler {
             session.getPlayer().getInventory().addItem(item);
             session.getPlayer().sendPacket(new PacketItemAddHintNotify(item, ActionReason.FetterLevelReward));
             session.getPlayer().sendPacket(new PacketUnlockNameCardNotify(cardId));
-            session.send(new PacketAvatarFetterLevelRewardRsp(avatarGuid, req.getFetterLevel(), rewardId));
             session.send(new PacketAvatarFetterDataNotify(avatar));
+            session.send(new PacketAvatarDataNotify(avatar.getPlayer()));
+            session.send(new PacketAvatarFetterLevelRewardRsp(avatarGuid, req.getFetterLevel(), rewardId));
         }
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketAvatarFetterDataNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketAvatarFetterDataNotify.java
@@ -13,9 +13,14 @@ public class PacketAvatarFetterDataNotify extends GenshinPacket {
 	public PacketAvatarFetterDataNotify(GenshinAvatar avatar) {
 		super(PacketOpcodes.AvatarFetterDataNotify);
 
+		int fetterLevel = avatar.getFetterLevel();
+
 		AvatarFetterInfo.Builder avatarFetter = AvatarFetterInfo.newBuilder()
-				.setExpLevel(avatar.getFetterLevel())
-				.setExpNumber(avatar.getFetterExp());
+				.setExpLevel(avatar.getFetterLevel());
+		
+		if (fetterLevel != 10) {
+			avatarFetter.setExpNumber(avatar.getFetterExp());
+		}
 		
 		if (avatar.getFetterList() != null) {
 			for (int i = 0; i < avatar.getFetterList().size(); i++) {
@@ -27,11 +32,10 @@ public class PacketAvatarFetterDataNotify extends GenshinPacket {
 			}
 		}
 		
-		int rewardId = avatar.getNameCardRewardId();
 		int cardId = avatar.getNameCardId();
 
 		if (avatar.getPlayer().getNameCardList().contains(cardId)) {
-			avatarFetter.addRewardedFetterLevelList(rewardId);
+			avatarFetter.addRewardedFetterLevelList(10);
 		}
 
 		AvatarFetterInfo avatarFetterInfo = avatarFetter.build();


### PR DESCRIPTION
In a nutshell: After getting the card, the prompt for the treasure chest disappeared and the prompt for the property did not, now fixed.

Working list and main ideas:
- [x] Sniff the packets from the official server to check the real `AvatarDataNotify` data. It finds that at level 10 and after picking up the name card, there is no `ExpNumber` and the `RewardedFetterLevelList` has only one data, which is always `10`;
- [x] Modify all code that generates fetter data to match the above.

Image:
![img](https://user-images.githubusercontent.com/47273265/164964712-e531dbbe-2e06-4d0b-bf51-3ea86ec8696c.jpg)

Special Thanks:
- Discord User: @WetABQ#3417 (GitHub: @WetABQ https://github.com/WetABQ) He provided the packets because I don't have a full fetter level character :(