### PR TITLE
Add a new alias to the command `setfetterlevel`

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/SetFetterLevelCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetFetterLevelCommand.java
@@ -11,7 +11,7 @@ import emu.grasscutter.server.packet.send.PacketAvatarFetterDataNotify;
 
 @Command(label = "setfetterlevel", usage = "setfetterlevel <level>",
         description = "Sets your fetter level for your current active character",
-        aliases = {"setfetterlvl"}, permission = "player.setfetterlevel")
+        aliases = {"setfetterlvl", "setfriendship"}, permission = "player.setfetterlevel")
 public final class SetFetterLevelCommand implements CommandHandler {
 
     @Override


### PR DESCRIPTION
In a nutshell: Since some players are not sure what fetter means, add a new alias to the command `setfetterlevel`: `setfriendship`.

Working list and main ideas:
- [x] Because the meaning of fetter may not be clear to everyone, or completely unknown, or misunderstood as something like `禁锢` (English: confinement) (especially for Chinese players). This is why I added the `setfriendship` alias.