### PR TITLE
Revert "bugfix: portbind error when falling back to http server"

### DIFF
--- a/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
@@ -200,6 +200,8 @@ public final class DispatchServer {
 	public void start() throws Exception {
 		HttpServer server;
 		if (Grasscutter.getConfig().getDispatchOptions().UseSSL) {
+			HttpsServer httpsServer = HttpsServer.create(getAddress(), 0);
+			SSLContext sslContext = SSLContext.getInstance("TLS");
 			try (FileInputStream fis = new FileInputStream(Grasscutter.getConfig().getDispatchOptions().KeystorePath)) {
 				char[] keystorePassword = Grasscutter.getConfig().getDispatchOptions().KeystorePassword.toCharArray();
 				KeyManagerFactory _kmf;
@@ -232,9 +234,9 @@ public final class DispatchServer {
 						throw originalEx;
 					}
 				}
-				SSLContext sslContext = SSLContext.getInstance("TLS");
+
 				sslContext.init(_kmf.getKeyManagers(), null, null);
-				HttpsServer httpsServer = HttpsServer.create(getAddress(), 0);
+
 				httpsServer.setHttpsConfigurator(new HttpsConfigurator(sslContext));
 				server = httpsServer;
 			} catch (BindException ignored) {


### PR DESCRIPTION
This reverts all my work on my commit c14eb2204becedec5dd455990bd47de1d40123cd.

I'm very very sorry to find that it's an inappropriate commit and for certain reason, I shouldn't contribute to this project. It introduces new bug because if BindException occurs in https server, the problem will still exists in the first catch block. Second, After reading the docs of sun.net.httpserver, there are better ways to do it instead of the painstaking logic here. It is helpful to revert to the unmodified version and someone better than me may fix it later. 