### PR TITLE
Task Improvement

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -901,6 +901,8 @@ public class Player {
 		session.send(new PacketPlayerStoreNotify(this));
 		session.send(new PacketAvatarDataNotify(this));
 
+		getTodayMoonCard(); // The timer works at 0:0, some users log in after that, use this method to check if they have received a reward today or not. If not, send the reward.
+
 		session.send(new PacketPlayerEnterSceneNotify(this)); // Enter game world
 		session.send(new PacketPlayerLevelRewardUpdateNotify(rewardedLevels));
 		session.send(new PacketOpenStateUpdateNotify());

--- a/src/main/java/emu/grasscutter/task/Task.java
+++ b/src/main/java/emu/grasscutter/task/Task.java
@@ -1,5 +1,7 @@
 package emu.grasscutter.task;
 
+import org.quartz.JobDataMap;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -27,4 +29,6 @@ public @interface Task {
     String taskName() default "NO_NAME";
     String taskCronExpression() default "0 0 0 0 0 ?";
     String triggerName() default "NO_NAME";
+    boolean executeImmediatelyAfterReset() default false;
+    boolean executeImmediately() default false;
 }

--- a/src/main/java/emu/grasscutter/task/TaskHandler.java
+++ b/src/main/java/emu/grasscutter/task/TaskHandler.java
@@ -1,11 +1,18 @@
 package emu.grasscutter.task;
 
-import org.quartz.Job;
-import org.quartz.JobExecutionContext;
-import org.quartz.JobExecutionException;
+import org.quartz.*;
 
-public interface TaskHandler extends Job {
-    default void execute(JobExecutionContext context) throws JobExecutionException {
-        
+@PersistJobDataAfterExecution
+public class TaskHandler implements Job {
+
+    public void restartExecute() throws JobExecutionException {
+        execute(null);
     }
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        // TODO Auto-generated method stub
+
+    }
+
 }

--- a/src/main/java/emu/grasscutter/task/TaskHandler.java
+++ b/src/main/java/emu/grasscutter/task/TaskHandler.java
@@ -9,6 +9,14 @@ public class TaskHandler implements Job {
         execute(null);
     }
 
+    public void onEnable() {
+
+    }
+
+    public void onDisable() {
+
+    }
+
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
         // TODO Auto-generated method stub

--- a/src/main/java/emu/grasscutter/task/TaskMap.java
+++ b/src/main/java/emu/grasscutter/task/TaskMap.java
@@ -30,7 +30,7 @@ public final class TaskMap {
     public void resetNow() {
         // Unregister all tasks
         for (TaskHandler task : this.tasks.values()) {
-            unregisterTask(task.getClass().getAnnotation(Task.class).taskName());
+            unregisterTask(task);
         }
 
         // Run all afterReset tasks
@@ -51,16 +51,18 @@ public final class TaskMap {
         }
     }
 
-    public TaskMap unregisterTask(String taskName) {
-        this.tasks.remove(taskName);
-        this.annotations.remove(taskName);
+    public TaskMap unregisterTask(TaskHandler task) {
+        this.tasks.remove(task.getClass().getAnnotation(Task.class).taskName());
+        this.annotations.remove(task.getClass().getAnnotation(Task.class).taskName());
 
         try {
             Scheduler scheduler = schedulerFactory.getScheduler();
-            scheduler.deleteJob(new JobKey(taskName));
+            scheduler.deleteJob(new JobKey(task.getClass().getAnnotation(Task.class).taskName()));
         } catch (SchedulerException e) {
             e.printStackTrace();
         }
+
+        task.onDisable();
 
         return this;
     }
@@ -88,6 +90,7 @@ public final class TaskMap {
             if (annotation.executeImmediately()) {
                 task.execute(null);
             }
+            task.onEnable();
         } catch (SchedulerException e) {
             e.printStackTrace();
         }

--- a/src/main/java/emu/grasscutter/task/TaskMap.java
+++ b/src/main/java/emu/grasscutter/task/TaskMap.java
@@ -1,20 +1,9 @@
 package emu.grasscutter.task;
 
 import emu.grasscutter.Grasscutter;
-import emu.grasscutter.game.Account;
-import emu.grasscutter.game.player.Player;
 
-import org.quartz.CronScheduleBuilder;
-import org.quartz.CronTrigger;
-import org.quartz.JobBuilder;
-import org.quartz.JobDetail;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
-import org.quartz.SchedulerFactory;
-import org.quartz.Trigger;
-import org.quartz.TriggerBuilder;
+import org.quartz.*;
 import org.quartz.impl.StdSchedulerFactory;
-import org.quartz.spi.MutableTrigger;
 import org.reflections.Reflections;
 
 import java.util.*;
@@ -23,6 +12,7 @@ import java.util.*;
 public final class TaskMap {
     private final Map<String, TaskHandler> tasks = new HashMap<>();
     private final Map<String, Task> annotations = new HashMap<>();
+    private final Map<String, TaskHandler> afterReset = new HashMap<>();
     private final SchedulerFactory schedulerFactory = new StdSchedulerFactory();
     
     public TaskMap() {
@@ -35,6 +25,44 @@ public final class TaskMap {
 
     public static TaskMap getInstance() {
         return Grasscutter.getGameServer().getTaskMap();
+    }
+
+    public void resetNow() {
+        // Unregister all tasks
+        for (TaskHandler task : this.tasks.values()) {
+            unregisterTask(task.getClass().getAnnotation(Task.class).taskName());
+        }
+
+        // Run all afterReset tasks
+        for (TaskHandler task : this.afterReset.values()) {
+            try {
+                task.restartExecute();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        // Remove all afterReset tasks
+        this.afterReset.clear();
+
+        // Register all tasks
+        for (TaskHandler task : this.tasks.values()) {
+            registerTask(task.getClass().getAnnotation(Task.class).taskName(), task);
+        }
+    }
+
+    public TaskMap unregisterTask(String taskName) {
+        this.tasks.remove(taskName);
+        this.annotations.remove(taskName);
+
+        try {
+            Scheduler scheduler = schedulerFactory.getScheduler();
+            scheduler.deleteJob(new JobKey(taskName));
+        } catch (SchedulerException e) {
+            e.printStackTrace();
+        }
+
+        return this;
     }
 
     public TaskMap registerTask(String taskName, TaskHandler task) {
@@ -56,7 +84,10 @@ public final class TaskMap {
                         .build();
             
             scheduler.scheduleJob(job, convTrigger);
-            scheduler.start();
+
+            if (annotation.executeImmediately()) {
+                task.execute(null);
+            }
         } catch (SchedulerException e) {
             e.printStackTrace();
         }
@@ -83,12 +114,24 @@ public final class TaskMap {
             try {
                 Task taskData = annotated.getAnnotation(Task.class);
                 Object object = annotated.newInstance();
-                if (object instanceof TaskHandler)
+                if (object instanceof TaskHandler) {
                     this.registerTask(taskData.taskName(), (TaskHandler) object);
-                else Grasscutter.getLogger().error("Class " + annotated.getName() + " is not a TaskHandler!");
+                    if (taskData.executeImmediatelyAfterReset()) {
+                        this.afterReset.put(taskData.taskName(), (TaskHandler) object);
+                    }
+                } else {
+                    Grasscutter.getLogger().error("Class " + annotated.getName() + " is not a TaskHandler!");
+                }
             } catch (Exception exception) {
                 Grasscutter.getLogger().error("Failed to register task handler for " + annotated.getSimpleName(), exception);
             }
         });
+        try {
+            Scheduler scheduler = schedulerFactory.getScheduler();
+            scheduler.start();
+        } catch (SchedulerException e) {
+            e.printStackTrace();
+        }
+
     }
 }

--- a/src/main/java/emu/grasscutter/task/tasks/MoonCard.java
+++ b/src/main/java/emu/grasscutter/task/tasks/MoonCard.java
@@ -11,6 +11,17 @@ import org.quartz.JobExecutionException;
 @Task(taskName = "MoonCard", taskCronExpression = "0 0 0 * * ?", triggerName = "MoonCardTrigger")
 // taskCronExpression: Fixed time period: 0:0:0 every day (twenty-four hour system)
 public class MoonCard extends TaskHandler {
+
+    @Override
+    public void onEnable() {
+        Grasscutter.getLogger().info("[Task] MoonCard task enabled.");
+    }
+
+    @Override
+    public void onDisable() {
+        Grasscutter.getLogger().info("[Task] MoonCard task disabled.");
+    }
+
     @Override
     public synchronized void execute(JobExecutionContext context) throws JobExecutionException {
         Grasscutter.getGameServer().getPlayers().forEach((uid, player) -> {

--- a/src/main/java/emu/grasscutter/task/tasks/MoonCard.java
+++ b/src/main/java/emu/grasscutter/task/tasks/MoonCard.java
@@ -1,27 +1,24 @@
 package emu.grasscutter.task.tasks;
 
-import emu.grasscutter.database.DatabaseManager;
-import emu.grasscutter.game.player.Player;
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.task.Task;
 import emu.grasscutter.task.TaskHandler;
 
-import java.util.List;
 
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
 @Task(taskName = "MoonCard", taskCronExpression = "0 0 0 * * ?", triggerName = "MoonCardTrigger")
 // taskCronExpression: Fixed time period: 0:0:0 every day (twenty-four hour system)
-public final class MoonCard implements TaskHandler {
+public class MoonCard extends TaskHandler {
     @Override
-    public void execute(JobExecutionContext context) throws JobExecutionException {
-        List<Player> players = DatabaseManager.getDatastore().find(Player.class).stream().toList();
-        for (Player player : players) {
+    public synchronized void execute(JobExecutionContext context) throws JobExecutionException {
+        Grasscutter.getGameServer().getPlayers().forEach((uid, player) -> {
             if (player.isOnline()) {
                 if (player.inMoonCard()) {
                     player.getTodayMoonCard();
                 }
             }
-        }
+        });
     }
 }


### PR DESCRIPTION
In a nutshell: Improved `Task`, introduced re-registration method after server reset, and added immediate execution of type annotation element.

Working list and main ideas:
- [x] The `Task` can now be executed once immediately, or once immediately after being reset by the server; (There doesn't seem to be a server-side `reset` implementation? If so, please let me know!)
- [x] Like a Java game whose name I'm not sure I can say here, you can override `onEnable` and `onDisable` inside the task now.

Example:
```java
package emu.grasscutter.task.tasks;

import emu.grasscutter.task.Task;
import emu.grasscutter.task.TaskHandler;

import org.quartz.JobExecutionContext;
import org.quartz.JobExecutionException;

@Task(taskName = "ImmediateTask", taskCronExpression = "0 0 0 * * ?", triggerName = "ImmediateTrigger", executeImmediately = true)
// taskCronExpression: Fixed time period: 0:0:0 every day (twenty-four hour system)
public class Immediate extends TaskHandler {
    @Override
    public synchronized void execute(JobExecutionContext context) throws JobExecutionException {
        System.out.println("I am here!");
    }
}
```

This code will be executed immediately after registration. After again it will wait until `00:00:00` to be executed again.
