### PR TITLE
Add default permissions

### DIFF
--- a/src/main/java/emu/grasscutter/Config.java
+++ b/src/main/java/emu/grasscutter/Config.java
@@ -33,6 +33,7 @@ public final class Config {
 		public Boolean FrontHTTPS = true;
 
 		public boolean AutomaticallyCreateAccounts = false;
+		public String[] defaultPermissions = new String[] { "" };
 
 		public RegionInfo[] GameServers = {};
 

--- a/src/main/java/emu/grasscutter/command/commands/AccountCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/AccountCommand.java
@@ -46,15 +46,10 @@ public final class AccountCommand implements CommandHandler {
                     CommandHandler.sendMessage(null, "Account already exists.");
                     return;
                 } else {
-                    CommandHandler.sendMessage(null, "Account created with UID " + account.getPlayerUid() + ".");
-
-                    for (String permission : Grasscutter.getConfig().getDispatchOptions().defaultPermissions) {
-                        if (!permission.isBlank()) {
-                            account.addPermission(permission);
-                        }
-                    }
-
+                    account.addPermission('*');
                     account.save(); // Save account to database.
+
+                    CommandHandler.sendMessage(null, "Account created with UID " + account.getPlayerUid() + ".");
                 }
                 return;
             case "delete":

--- a/src/main/java/emu/grasscutter/command/commands/AccountCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/AccountCommand.java
@@ -46,7 +46,7 @@ public final class AccountCommand implements CommandHandler {
                     CommandHandler.sendMessage(null, "Account already exists.");
                     return;
                 } else {
-                    account.addPermission('*');
+                    account.addPermission("*");
                     account.save(); // Save account to database.
 
                     CommandHandler.sendMessage(null, "Account created with UID " + account.getPlayerUid() + ".");

--- a/src/main/java/emu/grasscutter/command/commands/AccountCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/AccountCommand.java
@@ -1,5 +1,6 @@
 package emu.grasscutter.command.commands;
 
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.command.Command;
 import emu.grasscutter.command.CommandHandler;
 import emu.grasscutter.database.DatabaseHelper;
@@ -7,8 +8,7 @@ import emu.grasscutter.game.player.Player;
 
 import java.util.List;
 
-@Command(label = "account", usage = "account <create|delete> <username> [uid]",
-        description = "Modify user accounts")
+@Command(label = "account", usage = "account <create|delete> <username> [uid]", description = "Modify user accounts")
 public final class AccountCommand implements CommandHandler {
 
     @Override
@@ -47,7 +47,13 @@ public final class AccountCommand implements CommandHandler {
                     return;
                 } else {
                     CommandHandler.sendMessage(null, "Account created with UID " + account.getPlayerUid() + ".");
-                    account.addPermission("*"); // Grant the player superuser permissions.
+
+                    for (String permission : Grasscutter.getConfig().getDispatchOptions().defaultPermissions) {
+                        if (!permission.isBlank()) {
+                            account.addPermission(permission);
+                        }
+                    }
+
                     account.save(); // Save account to database.
                 }
                 return;

--- a/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
@@ -339,6 +339,10 @@ public final class DispatchServer {
 					// added.
 					account = DatabaseHelper.createAccountWithId(requestData.account, 0);
 
+					for (String permission : Grasscutter.getConfig().getDispatchOptions().defaultPermissions) {
+						account.addPermission(permission);
+					}
+
 					if (account != null) {
 						responseData.message = "OK";
 						responseData.data.account.uid = account.getId();


### PR DESCRIPTION
Added to:

- [X] Auto account system
- [ ] /account command

This PR adds an option in config.json to set default permissions while creating an account. It auto-generates blank, so no permissions are added on account creation.

Be sure to delete your config.json (and back it up!) for it to regenerate

EDIT: Removed from `/account` command by a suggestion from @Melledy 