### PR TITLE
PluginManager : ClassLoader skip module-info.class

### DIFF
--- a/src/main/java/emu/grasscutter/plugin/PluginManager.java
+++ b/src/main/java/emu/grasscutter/plugin/PluginManager.java
@@ -66,7 +66,7 @@ public final class PluginManager {
                     Enumeration<JarEntry> entries = jarFile.entries();
                     while(entries.hasMoreElements()) {
                         JarEntry entry = entries.nextElement();
-                        if(entry.isDirectory() || !entry.getName().endsWith(".class")) continue;
+                        if(entry.isDirectory() || !entry.getName().endsWith(".class") || entry.getName().contains("module-info")) continue;
                         String className = entry.getName().replace(".class", "").replace("/", ".");
                         Class<?> clazz = loader.loadClass(className);
                     }


### PR DESCRIPTION
## Plugin system improvement
When loading `module-info.class` inside jar plugin file, it will trigger exception below
```
Exception in thread "main" java.lang.NoClassDefFoundError: module-info is not a class because access_flag ACC_MODULE is set
        at java.base/java.lang.ClassLoader.defineClass1(Native Method)
        at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1012)
        at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:150)
        at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:862)
        at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:760)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:681)
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:639)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:574)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
        at emu.grasscutter.plugin.PluginManager.lambda$loadPlugins$1(PluginManager.java:71)
        at java.base/java.lang.Iterable.forEach(Iterable.java:75)
        at emu.grasscutter.plugin.PluginManager.loadPlugins(PluginManager.java:51)
        at emu.grasscutter.plugin.PluginManager.<init>(PluginManager.java:27)
        at emu.grasscutter.Grasscutter.main(Grasscutter.java:74)
```
this PR will add check to prevent loading that `module-info.class`