### PR TITLE
Give Artifact: Clear random props first before adding all picked props

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
@@ -79,6 +79,7 @@ public final class GiveArtifactCommand implements CommandHandler {
 		GameItem item = new GameItem(itemData);
 		item.setLevel(level);
 		item.setMainPropId(mainPropId);
+		item.getAppendPropIdList().clear();//Clear default random props first
 		item.getAppendPropIdList().addAll(appendPropIdList);
 		targetPlayer.getInventory().addItem(item, ActionReason.SubfieldDrop);
 


### PR DESCRIPTION
I run command giveart with following stat
```
/giveart 77524 50990 965002 965004,10 965007,10 965009 21
```
It will give me this artifact
![image](https://user-images.githubusercontent.com/27058572/166081651-94e75f07-7b20-4810-9dd2-d02a550b8069.png)
however this is not what command above says because propsIdList is appended without clearing it first. so this PR will add that.
After removing propsIdList first this is what i get 
![image](https://user-images.githubusercontent.com/27058572/166081822-29498cc9-5b75-4a4b-b760-77e8f15a0cdd.png)
