### PR TITLE
Implement viewing character details in character showcase

### DIFF
--- a/proto/GetFriendShowAvatarInfoReq.proto
+++ b/proto/GetFriendShowAvatarInfoReq.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+message GetFriendShowAvatarInfoReq {
+	enum CmdId {
+		option allow_alias = true;
+		ENET_CHANNEL_ID = 0;
+		NONE = 0;
+		ENET_IS_RELIABLE = 1;
+		IS_ALLOW_CLIENT = 1;
+		CMD_ID = 4007;
+	}
+
+	uint32 uid = 1;
+}

--- a/proto/GetFriendShowAvatarInfoRsp.proto
+++ b/proto/GetFriendShowAvatarInfoRsp.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "ShowAvatarInfo.proto";
+
+message GetFriendShowAvatarInfoRsp {
+	enum CmdId {
+		option allow_alias = true;
+		NONE = 0;
+		ENET_CHANNEL_ID = 0;
+		ENET_IS_RELIABLE = 1;
+		CMD_ID = 4008;
+	}
+
+	int32 retcode = 1;
+	uint32 uid = 2;
+	repeated ShowAvatarInfo show_avatar_info_list = 3;
+}

--- a/proto/ShowAvatarInfo.proto
+++ b/proto/ShowAvatarInfo.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "AvatarFetterInfo.proto";
+import "AvatarExcelInfo.proto";
+import "PropValue.proto";
+import "ShowEquip.proto";
+
+message ShowAvatarInfo {
+	uint32 avatar_id = 1;
+	map<uint32, PropValue> prop_map = 2;
+	repeated uint32 talent_id_list = 3;
+	map<uint32, float> fight_prop_map = 4;
+	uint32 skill_depot_id = 5;
+	uint32 core_proud_skill_level = 6;
+	repeated uint32 inherent_proud_skill_list = 7;
+	map<uint32, uint32> skill_level_map = 8;
+	map<uint32, uint32> proud_skill_extra_level_map = 9;
+	repeated ShowEquip equip_list = 10;
+	AvatarFetterInfo fetter_info = 11;
+	uint32 costume_id = 12;
+	AvatarExcelInfo excel_info = 13;
+}

--- a/proto/ShowEquip.proto
+++ b/proto/ShowEquip.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "Reliquary.proto";
+import "Weapon.proto";
+
+message ShowEquip {
+	oneof Detail {
+		Reliquary reliquary = 2;
+		Weapon weapon = 3;
+	}
+	uint32 item_id = 1;
+}

--- a/src/main/java/emu/grasscutter/game/inventory/GameItem.java
+++ b/src/main/java/emu/grasscutter/game/inventory/GameItem.java
@@ -375,6 +375,32 @@ public class GameItem {
 		return relicInfo;
 	}
 
+	public Weapon toWeaponProto() {
+		Weapon.Builder weapon = Weapon.newBuilder()
+			.setLevel(this.getLevel())
+			.setExp(this.getExp())
+			.setPromoteLevel(this.getPromoteLevel());
+
+		if (this.getAffixes() != null && this.getAffixes().size() > 0) {
+			for (int affix : this.getAffixes()) {
+				weapon.putAffixMap(affix, this.getRefinement());
+			}
+		}
+
+		return weapon.build();
+	}
+
+	public Reliquary toReliquaryProto() {
+		Reliquary.Builder relic = Reliquary.newBuilder()
+			.setLevel(this.getLevel())
+			.setExp(this.getExp())
+			.setPromoteLevel(this.getPromoteLevel())
+			.setMainPropId(this.getMainPropId())
+			.addAllAppendPropIdList(this.getAppendPropIdList());
+
+		return relic.build();
+	}
+
 	public Item toProto() {
 		Item.Builder proto = Item.newBuilder()
 				.setGuid(this.getGuid())
@@ -382,27 +408,11 @@ public class GameItem {
 				
 		switch (getItemType()) {
 			case ITEM_WEAPON:
-				Weapon.Builder weapon = Weapon.newBuilder()
-					.setLevel(this.getLevel())
-					.setExp(this.getExp())
-					.setPromoteLevel(this.getPromoteLevel());
-				
-				if (this.getAffixes() != null && this.getAffixes().size() > 0) {
-					for (int affix : this.getAffixes()) {
-						weapon.putAffixMap(affix, this.getRefinement());
-					}
-				}
-					
+				Weapon weapon = this.toWeaponProto();
 				proto.setEquip(Equip.newBuilder().setWeapon(weapon).setIsLocked(this.isLocked()).build());
 				break;
 			case ITEM_RELIQUARY:
-				Reliquary relic = Reliquary.newBuilder()
-					.setLevel(this.getLevel())
-					.setExp(this.getExp())
-					.setPromoteLevel(this.getPromoteLevel())
-					.setMainPropId(this.getMainPropId())
-					.addAllAppendPropIdList(this.getAppendPropIdList())
-					.build();
+				Reliquary relic = this.toReliquaryProto();
 				proto.setEquip(Equip.newBuilder().setReliquary(relic).setIsLocked(this.isLocked()).build());
 				break;
 			case ITEM_MATERIAL:

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -21,7 +21,6 @@ import emu.grasscutter.game.inventory.Inventory;
 import emu.grasscutter.game.mail.Mail;
 import emu.grasscutter.game.props.ActionReason;
 import emu.grasscutter.game.props.PlayerProperty;
-import emu.grasscutter.game.shop.ShopInfo;
 import emu.grasscutter.game.shop.ShopLimit;
 import emu.grasscutter.game.world.Scene;
 import emu.grasscutter.game.world.World;
@@ -34,6 +33,7 @@ import emu.grasscutter.net.proto.OnlinePlayerInfoOuterClass.OnlinePlayerInfo;
 import emu.grasscutter.net.proto.PlayerApplyEnterMpResultNotifyOuterClass;
 import emu.grasscutter.net.proto.PlayerLocationInfoOuterClass.PlayerLocationInfo;
 import emu.grasscutter.net.proto.PlayerWorldLocationInfoOuterClass;
+import emu.grasscutter.net.proto.ShowAvatarInfoOuterClass;
 import emu.grasscutter.net.proto.ProfilePictureOuterClass.ProfilePicture;
 import emu.grasscutter.net.proto.SocialDetailOuterClass.SocialDetail;
 import emu.grasscutter.net.proto.SocialShowAvatarInfoOuterClass;
@@ -897,6 +897,35 @@ public class Player {
 				.addAllShowAvatarInfoList(socialShowAvatarInfoList)
 				.setFinishAchievementNum(0);
 		return social;
+	}
+
+	public List<ShowAvatarInfoOuterClass.ShowAvatarInfo> getShowAvatarInfoList() {
+		List<ShowAvatarInfoOuterClass.ShowAvatarInfo> showAvatarInfoList = new ArrayList<>();
+
+		Player player;
+		boolean shouldRecalc;
+		if (this.isOnline()) {
+			player = this;
+			shouldRecalc = false;
+		} else {
+			player = DatabaseHelper.getPlayerById(id);
+			player.getAvatars().loadFromDatabase();
+			player.getInventory().loadFromDatabase();
+			shouldRecalc = true;
+		}
+
+		List<Integer> showAvatarList = player.getShowAvatarList();
+		AvatarStorage avatars = player.getAvatars();
+		if (showAvatarList != null) {
+			for (int avatarId : showAvatarList) {
+				Avatar avatar = avatars.getAvatarById(avatarId);
+				if (shouldRecalc) {
+					avatar.recalcStats();
+				}
+				showAvatarInfoList.add(avatar.toShowAvatarInfoProto());
+			}
+		}
+		return showAvatarInfoList;
 	}
 	
 	public PlayerWorldLocationInfoOuterClass.PlayerWorldLocationInfo getWorldPlayerLocationInfo() {

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetFriendShowAvatarInfoReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetFriendShowAvatarInfoReq.java
@@ -1,0 +1,26 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.GetFriendShowAvatarInfoReqOuterClass.GetFriendShowAvatarInfoReq;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketGetFriendShowAvatarInfoRsp;
+
+@Opcodes(PacketOpcodes.GetFriendShowAvatarInfoReq)
+public class HandlerGetFriendShowAvatarInfoReq extends PacketHandler {
+
+	@Override
+	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+		GetFriendShowAvatarInfoReq req = GetFriendShowAvatarInfoReq.parseFrom(payload);
+
+		int targetUid = req.getUid();
+		Player targetPlayer = session.getServer().getPlayerByUid(targetUid, true);
+
+		if (targetPlayer.isShowAvatars()) {
+			session.send(new PacketGetFriendShowAvatarInfoRsp(targetUid, targetPlayer.getShowAvatarInfoList()));
+		}
+	}
+
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketGetFriendShowAvatarInfoRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketGetFriendShowAvatarInfoRsp.java
@@ -1,0 +1,24 @@
+package emu.grasscutter.server.packet.send;
+
+import java.util.List;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.GetFriendShowAvatarInfoRspOuterClass.GetFriendShowAvatarInfoRsp;
+import emu.grasscutter.net.proto.ShowAvatarInfoOuterClass.ShowAvatarInfo;
+
+@Opcodes(PacketOpcodes.GetFriendShowAvatarInfoRsp)
+public class PacketGetFriendShowAvatarInfoRsp extends BasePacket {
+
+	public PacketGetFriendShowAvatarInfoRsp(int uid, List<ShowAvatarInfo> showAvatarInfoList) {
+		super(PacketOpcodes.GetFriendShowAvatarInfoRsp);
+
+		GetFriendShowAvatarInfoRsp.Builder p = GetFriendShowAvatarInfoRsp.newBuilder()
+				.setUid(uid)
+				.addAllShowAvatarInfoList(showAvatarInfoList);
+
+		this.setData(p.build());
+	}
+
+}


### PR DESCRIPTION
This PR implements the ability to view character details in the character showcase.

What works:
- [X] opening the character showcase menu
- [X] view level and stats ("Details" button)
- [X] view weapon and artifacts
- [X] view talent and constellation levels

The `ShowAvatarInfo` proto used by the character showcase differs from the `AvatarInfo` proto used everywhere else so I've added a new method to `Avatar`, `toShowAvatarInfoProto()`, for creating it.

A screenshot:
![mikoshowcase](https://user-images.githubusercontent.com/40713629/166115377-cd037068-22ec-4e40-b592-468a8d18b1a8.png)
