### PR TITLE
Fix crash when login

### DIFF
--- a/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
@@ -381,6 +381,9 @@ public final class DispatchServer {
 				responseData.data.account.uid = requestData.uid;
 				responseData.data.account.token = requestData.token;
 				responseData.data.account.email = account.getEmail();
+				if (responseData.data.account.email == null) { // null will trigger crash in some client
+					responseData.data.account.email = "";
+				}
 
 				Grasscutter.getLogger().info(String.format("[Dispatch] Client %s logged in via token as %s",
 						req.ip(), responseData.data.account.uid));
@@ -437,7 +440,7 @@ public final class DispatchServer {
 		// hk4e-sdk-os.hoyoverse.com
 		httpServer.get("/hk4e_global/mdk/agreement/api/getAgreementInfos", new DispatchHttpJsonHandler("{\"retcode\":0,\"message\":\"OK\",\"data\":{\"marketing_agreements\":[]}}"));
 		// hk4e-sdk-os.hoyoverse.com
-		httpServer.post("/hk4e_global/combo/granter/api/compareProtocolVersion", new DispatchHttpJsonHandler("{\"retcode\":0,\"message\":\"OK\",\"data\":{\"modified\":true,\"protocol\":{\"id\":0,\"app_id\":4,\"language\":\"en\",\"user_proto\":\"\",\"priv_proto\":\"\",\"major\":7,\"minimum\":0,\"create_time\":\"0\",\"teenager_proto\":\"\",\"third_proto\":\"\"}}}"));
+		httpServer.get("/hk4e_global/combo/granter/api/compareProtocolVersion", new DispatchHttpJsonHandler("{\"retcode\":0,\"message\":\"OK\",\"data\":{\"modified\":true,\"protocol\":{\"id\":0,\"app_id\":4,\"language\":\"en\",\"user_proto\":\"\",\"priv_proto\":\"\",\"major\":7,\"minimum\":0,\"create_time\":\"0\",\"teenager_proto\":\"\",\"third_proto\":\"\"}}}"));
 
 		// Game data
 		// hk4e-api-os.hoyoverse.com
@@ -469,7 +472,7 @@ public final class DispatchServer {
 		// log-upload-os.mihoyo.com
 		httpServer.all("/log/sdk/upload", new DispatchHttpJsonHandler("{\"code\":0}"));
 		httpServer.all("/sdk/upload", new DispatchHttpJsonHandler("{\"code\":0}"));
-		httpServer.post("/sdk/dataUpload", new DispatchHttpJsonHandler("{\"code\":0}"));
+		httpServer.post("/sdk/dataUpload", (req, res) -> res.send("Hello"));
 		// /perf/config/verify?device_id=xxx&platform=x&name=xxx
 		httpServer.all("/perf/config/verify", new DispatchHttpJsonHandler("{\"code\":0}"));
 
@@ -478,6 +481,9 @@ public final class DispatchServer {
 		httpServer.all("/log", new ClientLogHandler());
 		// log-upload-os.mihoyo.com
 		httpServer.all("/crash/dataUpload", new ClientLogHandler());
+
+		// webstatic-sea.hoyoverse.com
+		httpServer.get("/admin/mi18n/plat_oversea/m202003048/m202003048-version.json", new DispatchHttpJsonHandler("{\"version\":51}"));
 
 		httpServer.get("/gacha", (req, res) -> res.send("<!doctype html><html lang=\"en\"><head><title>Gacha</title></head><body></body></html>"));
 

--- a/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
@@ -472,7 +472,7 @@ public final class DispatchServer {
 		// log-upload-os.mihoyo.com
 		httpServer.all("/log/sdk/upload", new DispatchHttpJsonHandler("{\"code\":0}"));
 		httpServer.all("/sdk/upload", new DispatchHttpJsonHandler("{\"code\":0}"));
-		httpServer.post("/sdk/dataUpload", (req, res) -> res.send("Hello"));
+		httpServer.post("/sdk/dataUpload", new DispatchHttpJsonHandler("{\"code\":0}"));
 		// /perf/config/verify?device_id=xxx&platform=x&name=xxx
 		httpServer.all("/perf/config/verify", new DispatchHttpJsonHandler("{\"code\":0}"));
 


### PR DESCRIPTION
Dispatch server route `POST /hk4e_global/mdk/shield/api/verify` may return `"email": null,` in its response, which will trigger crash in some client.

Add a guard to replace `null` with empty string will prevent such kind of crash.