### PR TITLE
Cleaned up dispatch iOS fixes

### DIFF
--- a/src/main/java/emu/grasscutter/game/Account.java
+++ b/src/main/java/emu/grasscutter/game/Account.java
@@ -74,7 +74,11 @@ public class Account {
 	}
 	
 	public String getEmail() {
-		return email;
+		if(email != null && !email.isEmpty()) {
+			return email;
+		} else {
+			return "";
+		}
 	}
 
 	public void setEmail(String email) {

--- a/src/main/java/emu/grasscutter/server/dispatch/DispatchHttpJsonHandler.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/DispatchHttpJsonHandler.java
@@ -35,7 +35,7 @@ public final class DispatchHttpJsonHandler implements HttpContextHandler {
 	public void handle(Request req, Response res) throws IOException {
 		// Checking for ALL here isn't required as when ALL is enabled enableDevLogging() gets enabled
 		if(Grasscutter.getConfig().DebugMode.equalsIgnoreCase("MISSING") && Arrays.stream(missingRoutes).anyMatch(x -> x == req.baseUrl())) {
-			Grasscutter.getLogger().info(String.format("[Dispatch] Client %s %s request: ", req.ip(), req.method(), req.baseUrl()) + (Grasscutter.getConfig().DebugMode.equalsIgnoreCase("MISSING") ? "(MISSING)" : ""));
+			Grasscutter.getLogger().info(String.format("[Dispatch] Client %s %s request: %s", req.ip(), req.method(), req.baseUrl()) + (Grasscutter.getConfig().DebugMode.equalsIgnoreCase("MISSING") ? "(MISSING)" : ""));
 		}
 		res.send(response);
 	}

--- a/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
@@ -319,9 +319,6 @@ public final class DispatchServer {
 						responseData.data.account.uid = account.getId();
 						responseData.data.account.token = account.generateSessionKey();
 						responseData.data.account.email = account.getEmail();
-						if (responseData.data.account.email == null) {
-							responseData.data.account.email = "";
-						}
 
 						Grasscutter.getLogger()
 								.info(String.format("[Dispatch] Client %s failed to log in: Account %s created",
@@ -346,9 +343,6 @@ public final class DispatchServer {
 				responseData.data.account.uid = account.getId();
 				responseData.data.account.token = account.generateSessionKey();
 				responseData.data.account.email = account.getEmail();
-				if (responseData.data.account.email == null) {
-					responseData.data.account.email = "";
-				}
 
 				Grasscutter.getLogger().info(String.format("[Dispatch] Client %s logged in as %s", req.ip(),
 						responseData.data.account.uid));
@@ -389,9 +383,6 @@ public final class DispatchServer {
 				responseData.data.account.uid = requestData.uid;
 				responseData.data.account.token = requestData.token;
 				responseData.data.account.email = account.getEmail();
-				if (responseData.data.account.email == null) { // null will trigger crash in some client
-					responseData.data.account.email = "";
-				}
 
 				Grasscutter.getLogger().info(String.format("[Dispatch] Client %s logged in via token as %s",
 						req.ip(), responseData.data.account.uid));

--- a/src/main/java/emu/grasscutter/server/dispatch/json/LoginResultJson.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/json/LoginResultJson.java
@@ -16,7 +16,7 @@ public class LoginResultJson {
 	public static class VerifyAccountData {
 		public String uid;
 		public String name = "";
-		public String email;
+		public String email = "";
 		public String mobile = "";
 		public String is_email_verify = "0";
 		public String realname = "";


### PR DESCRIPTION
While #392 and #394 fixed the issues iOS devices were having with logging in, it left if statements everywhere and if there comes a time when another login route needs to get created in the future this issue may arise again.
This PR clean up the if statements by moving them into the `getEmail()` which now if a player's email is not set or is empty, `getEmail()` should always return "".

Thanks @mingjun97 for helping to test