### PR TITLE
GameServerPacketHandler need to be added a registration interface for plugin developers

### DIFF
--- a/src/main/java/emu/grasscutter/server/game/GameServerPacketHandler.java
+++ b/src/main/java/emu/grasscutter/server/game/GameServerPacketHandler.java
@@ -22,7 +22,11 @@ public class GameServerPacketHandler {
 		
 		this.registerHandlers(handlerClass);
 	}
-	
+
+	public void registerPacketHandler(int opcode, PacketHandler handler) {
+		this.handlers.put(opcode, handler);
+	}
+
 	public void registerHandlers(Class<? extends PacketHandler> handlerClass) {
 		Reflections reflections = new Reflections("emu.grasscutter.server.packet");
 		Set<?> handlerClasses = reflections.getSubTypesOf(handlerClass);


### PR DESCRIPTION
I want to register a PlayerLoginReq handler when i developing some plugins, but there doesn't seem to be a way to register the handler, otherwise, it is only possible using Java Reflection.
I modified it a bit, now the handler can be registered like this:
![image](https://user-images.githubusercontent.com/44562331/166146707-ce762ae7-d3e1-4631-ba8a-64eed600201e.png)
![image](https://user-images.githubusercontent.com/44562331/166146721-f38a3a05-e099-4e6a-8b63-3afcdba3bb40.png)
![image](https://user-images.githubusercontent.com/44562331/166143446-2ed44f02-8072-4ac0-8787-01ec99c53baf.png)
