### PR TITLE
Fixed can set avatar level more than 90 and cause game to freeze

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/GiveCharCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveCharCommand.java
@@ -73,6 +73,12 @@ public final class GiveCharCommand implements CommandHandler {
             return;
         }
 
+        // Check level.
+        if (level > 90) {
+            CommandHandler.sendMessage(sender, "Invalid avatar level.");
+            return;
+        }
+
         // Calculate ascension level.
         if (level <= 40) {
             ascension = (int) Math.ceil(level / 20f);
@@ -88,6 +94,6 @@ public final class GiveCharCommand implements CommandHandler {
         avatar.recalcStats();
 
         targetPlayer.addAvatar(avatar);
-        CommandHandler.sendMessage(sender, String.format("Given %s to %s.", avatarId, target));
+        CommandHandler.sendMessage(sender, String.format("Given %s with level %s to %s.", avatarId, level, target));
     }
 }


### PR DESCRIPTION
Limit the avatar level given by "/givechar" command.
If avatar level >90, the game will freeze if open the character interface.