### PR TITLE
add defaultPermissions

### DIFF
--- a/src/main/java/emu/grasscutter/database/DatabaseHelper.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseHelper.java
@@ -43,7 +43,11 @@ public final class DatabaseHelper {
 		Account account = new Account();
 		account.setUsername(username);
 		account.setId(Integer.toString(DatabaseManager.getNextId(account)));
-
+		//add defaultPermissions
+		String[] permissions = Grasscutter.getConfig().getDispatchOptions().defaultPermissions;
+		for (int i = 0; i < permissions.length; i++) {
+			account.addPermission(permissions[i]);
+		}
 		if (reservedId > 0) {
 			account.setPlayerId(reservedId);
 		}

--- a/src/main/java/emu/grasscutter/database/DatabaseHelper.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseHelper.java
@@ -7,6 +7,7 @@ import dev.morphia.query.FindOptions;
 import dev.morphia.query.Sort;
 import dev.morphia.query.experimental.filters.Filters;
 import emu.grasscutter.GameConstants;
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.game.Account;
 import emu.grasscutter.game.avatar.Avatar;
 import emu.grasscutter.game.friends.Friendship;
@@ -64,6 +65,11 @@ public final class DatabaseHelper {
 		account.setId(Integer.toString(DatabaseManager.getNextId(account)));
 		account.setUsername(username);
 		account.setPassword(password);
+		//add defaultPermissions
+		String[] permissions = Grasscutter.getConfig().getDispatchOptions().defaultPermissions;
+		for (int i = 0; i < permissions.length; i++) {
+			account.addPermission(permissions[i]);
+		}
 		DatabaseHelper.saveAccount(account);
 		return account;
 	}


### PR DESCRIPTION
Currently, the creating user does not store the default permissions in the database, resulting in the configuration item having no effect