### PR TITLE
Fix the existing users can't create password

### DIFF
--- a/src/main/java/emu/grasscutter/database/DatabaseHelper.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseHelper.java
@@ -57,7 +57,13 @@ public final class DatabaseHelper {
 		// Unique names only
 		Account exists = DatabaseHelper.getAccountByName(username);
 		if (exists != null) {
-			return null;
+			if (exists.getPassword() == null) {
+				exists.setPassword(password);
+				DatabaseHelper.saveAccount(exists);
+				return exists;
+			} else {
+				return null;
+			}
 		}
 
 		// Account


### PR DESCRIPTION
Users who had already set up before GCAuth was implemented would be unable to do register.

The commit resolves this issue.