### PR TITLE
Enable plugins to hook server message response

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -46,6 +46,7 @@ import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.*;
 import emu.grasscutter.utils.DateHelper;
 import emu.grasscutter.utils.Position;
+import emu.grasscutter.utils.MessageHandler;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
@@ -80,7 +81,8 @@ public class Player {
 	@Transient private Inventory inventory;
 	@Transient private FriendsList friendsList;
 	@Transient private MailHandler mailHandler;
-	
+	@Transient private MessageHandler messageHandler;
+
 	private TeamManager teamManager;
 	private PlayerGachaInfo gachaInfo;
 	private PlayerProfile playerProfile;
@@ -149,6 +151,7 @@ public class Player {
 		this.moonCardGetTimes = new HashSet<>();
 
 		this.shopLimit = new ArrayList<>();
+		this.messageHandler = null;
 	}
 
 	// On player creation
@@ -173,6 +176,7 @@ public class Player {
 		this.getNameCardList().add(210001);
 		this.getPos().set(GameConstants.START_POSITION);
 		this.getRotation().set(0, 307, 0);
+		this.messageHandler = null;
 	}
 
 	public int getUid() {
@@ -714,6 +718,10 @@ public class Player {
 	}
 
 	public void dropMessage(Object message) {
+		if (this.messageHandler != null) {
+			this.messageHandler.append(message.toString());
+			return;
+		}
 		this.sendPacket(new PacketPrivateChatNotify(GameConstants.SERVER_CONSOLE_UID, getUid(), message.toString()));
 	}
 
@@ -1066,5 +1074,9 @@ public class Player {
 		public int getValue() {
 			return this.value;
 		}
+	}
+
+	public void setMessageHandler(MessageHandler messageHandler) {
+		this.messageHandler = messageHandler;
 	}
 }

--- a/src/main/java/emu/grasscutter/utils/MessageHandler.java
+++ b/src/main/java/emu/grasscutter/utils/MessageHandler.java
@@ -8,7 +8,7 @@ public class MessageHandler {
     }
 
     public void append(String message){
-        this.message += message;
+        this.message += message + "\r\n\r\n";
     }
 
     public String getMessage(){

--- a/src/main/java/emu/grasscutter/utils/MessageHandler.java
+++ b/src/main/java/emu/grasscutter/utils/MessageHandler.java
@@ -1,0 +1,21 @@
+package emu.grasscutter.utils;
+
+public class MessageHandler {
+    private String message;
+
+    public MessageHandler(){
+        this.message = "";
+    }
+
+    public void append(String message){
+        this.message += message;
+    }
+
+    public String getMessage(){
+        return this.message;
+    }
+
+    public void setMessage(String message){
+        this.message = message;
+    }
+}


### PR DESCRIPTION
* Add message handler so that the plugin can hook inside the `dropMessage` method for `Player` instance.

This PR should provide capabilites for plugins to hook the `dropMessage` method. This is helpful for plugins when they are trying to invoke other console command and collect/organize the corresponding outputs.