### PR TITLE
[Breaking] Command Targeting overhaul

### DIFF
--- a/src/main/java/emu/grasscutter/Grasscutter.java
+++ b/src/main/java/emu/grasscutter/Grasscutter.java
@@ -213,7 +213,7 @@ public final class Grasscutter {
 
 			isLastInterrupted = false;
 			try {
-				CommandMap.getInstance().invoke(null, input);
+				CommandMap.getInstance().invoke(null, null, input);
 			} catch (Exception e) {
 				Grasscutter.getLogger().error(language.Command_error, e);
 			}

--- a/src/main/java/emu/grasscutter/command/Command.java
+++ b/src/main/java/emu/grasscutter/command/Command.java
@@ -14,6 +14,8 @@ public @interface Command {
     String[] aliases() default {};
 
     String permission() default "";
+    
+    String permissionTargeted() default "";
 
     boolean threading() default false;
 }

--- a/src/main/java/emu/grasscutter/command/CommandHandler.java
+++ b/src/main/java/emu/grasscutter/command/CommandHandler.java
@@ -25,6 +25,6 @@ public interface CommandHandler {
      * @param sender The player/console that invoked the command.
      * @param args The arguments to the command.
      */
-    default void execute(Player sender, List<String> args) {
+    default void execute(Player sender, Player targetPlayer, List<String> args) {
     }
 }

--- a/src/main/java/emu/grasscutter/command/CommandMap.java
+++ b/src/main/java/emu/grasscutter/command/CommandMap.java
@@ -12,6 +12,8 @@ import java.util.*;
 public final class CommandMap {
     private final Map<String, CommandHandler> commands = new HashMap<>();
     private final Map<String, Command> annotations = new HashMap<>();
+    private final Map<String, Player> targetPlayers = new HashMap<>();
+    private static final String consoleId = "console";
     public CommandMap() {
         this(false);
     }
@@ -104,7 +106,7 @@ public final class CommandMap {
      * @param player     The player invoking the command or null for the server console.
      * @param rawMessage The messaged used to invoke the command.
      */
-    public void invoke(Player player, String rawMessage) {
+    public void invoke(Player player, Player targetPlayer, String rawMessage) {
         rawMessage = rawMessage.trim();
         if (rawMessage.length() == 0) {
             CommandHandler.sendMessage(player, Grasscutter.getLanguage().No_command_specified);
@@ -119,6 +121,29 @@ public final class CommandMap {
         String[] split = rawMessage.split(" ");
         List<String> args = new LinkedList<>(Arrays.asList(split));
         String label = args.remove(0);
+        // Check for special case
+        String playerId = (player == null) ? consoleId : player.getAccount().getId();
+        if (label == "target") {  // Sets or clears default targetPlayer
+            if (args.size() < 1) {
+                targetPlayers.remove(playerId);
+                CommandHandler.sendMessage(player, Grasscutter.getLanguage().Target_cleared);
+            } else {
+                try {
+                    String sUid = args.get(0);
+                    int uid = Integer.parseInt(sUid);
+                    targetPlayer = Grasscutter.getGameServer().getPlayerByUid(uid);
+                    if (targetPlayer == null) {
+                        CommandHandler.sendMessage(player, Grasscutter.getLanguage().Player_not_found_or_offline);
+                    } else {
+                        targetPlayers.put(playerId, targetPlayer);
+                        CommandHandler.sendMessage(player, Grasscutter.getLanguage().Target_set.replace("{uid}", sUid));
+                    }
+                } catch (NumberFormatException e) {
+                    CommandHandler.sendMessage(player, Grasscutter.getLanguage().Invalid_UID);
+                }
+            }
+            return;
+        } 
         // Get command handler.
         CommandHandler handler = this.commands.get(label);
         if (handler == null) {
@@ -126,10 +151,43 @@ public final class CommandMap {
             return;
         }
 
+        // If any @UID argument is present, override targetPlayer with it
+        for (int i = 0; i < args.size(); i++) {
+            String arg = args.get(i);
+            if (!arg.startsWith("@")) {
+                continue;
+            } else {
+                arg = args.remove(i).substring(1);
+                try {
+                    int uid = Integer.parseInt(arg);
+                    targetPlayer = Grasscutter.getGameServer().getPlayerByUid(uid);
+                    if (targetPlayer == null) {
+                        CommandHandler.sendMessage(player, Grasscutter.getLanguage().Player_not_found_or_offline);
+                        return;
+                    }
+                    break;
+                } catch (NumberFormatException e) {
+                    CommandHandler.sendMessage(player, Grasscutter.getLanguage().Invalid_UID);
+                    return;
+                }
+            }
+        }
+        // If there's still no targetPlayer at this point, use previously-set target
+        if (targetPlayer == null) {
+            targetPlayer = targetPlayers.getOrDefault(playerId, null);
+        }
+
         // Check for permission.
         if (player != null) {
             String permissionNode = this.annotations.get(label).permission();
+            String permissionNodeTargeted = this.annotations.get(label).permissionTargeted();
             Account account = player.getAccount();
+            if (player != targetPlayer) {  // Additional permission required for targeting another player
+                if (!permissionNodeTargeted.isEmpty() && !account.hasPermission(permissionNodeTargeted)) {
+                    CommandHandler.sendMessage(player, Grasscutter.getLanguage().You_not_permission_run_command);
+                    return;
+                }
+            }
             if (!permissionNode.isEmpty() && !account.hasPermission(permissionNode)) {
                 CommandHandler.sendMessage(player, Grasscutter.getLanguage().You_not_permission_run_command);
                 return;
@@ -138,7 +196,8 @@ public final class CommandMap {
 
         // Invoke execute method for handler.
         boolean threading  = this.annotations.get(label).threading();
-        Runnable runnable = () -> handler.execute(player, args);
+        final Player targetPlayerF = targetPlayer;  // Is there a better way to do this?
+        Runnable runnable = () -> handler.execute(player, targetPlayerF, args);
         if(threading) {
             Thread command = new Thread(runnable);
             command.start();

--- a/src/main/java/emu/grasscutter/command/CommandMap.java
+++ b/src/main/java/emu/grasscutter/command/CommandMap.java
@@ -117,29 +117,37 @@ public final class CommandMap {
         String[] split = rawMessage.split(" ");
         List<String> args = new LinkedList<>(Arrays.asList(split));
         String label = args.remove(0);
-        // Check for special case
         String playerId = (player == null) ? consoleId : player.getAccount().getId();
-        if (label == "target") {  // Sets or clears default targetPlayer
-            if (args.size() < 1) {
-                targetPlayers.remove(playerId);
-                CommandHandler.sendMessage(player, Grasscutter.getLanguage().Target_cleared);
-            } else {
-                try {
-                    String sUid = args.get(0);
-                    int uid = Integer.parseInt(sUid);
-                    targetPlayer = Grasscutter.getGameServer().getPlayerByUid(uid);
-                    if (targetPlayer == null) {
-                        CommandHandler.sendMessage(player, Grasscutter.getLanguage().Player_not_found_or_offline);
-                    } else {
-                        targetPlayers.put(playerId, targetPlayer);
-                        CommandHandler.sendMessage(player, Grasscutter.getLanguage().Target_set.replace("{uid}", sUid));
-                    }
-                } catch (NumberFormatException e) {
-                    CommandHandler.sendMessage(player, Grasscutter.getLanguage().Invalid_UID);
+        // Check for special cases - currently only target command
+        String targetUidStr = null;
+        if (label.startsWith("@")) {  // @[UID]
+            targetUidStr = label.substring(1);
+        } else if (label == "target") {  // target [[@]UID]
+            targetUidStr = args.get(0);
+            if (targetUidStr.startsWith("@")) {
+                targetUidStr = targetUidStr.substring(1);
+            }
+        }
+        if (targetUidStr == "") {  // Clears default targetPlayer
+            targetPlayers.remove(playerId);
+            CommandHandler.sendMessage(player, Grasscutter.getLanguage().Target_cleared);
+            return;
+        } else if (targetUidStr != null) {  // Sets default targetPlayer to the UID given
+            try {
+                int uid = Integer.parseInt(targetUidStr);
+                targetPlayer = Grasscutter.getGameServer().getPlayerByUid(uid);
+                if (targetPlayer == null) {
+                    CommandHandler.sendMessage(player, Grasscutter.getLanguage().Player_not_found_or_offline);
+                } else {
+                    targetPlayers.put(playerId, targetPlayer);
+                    CommandHandler.sendMessage(player, Grasscutter.getLanguage().Target_set.replace("{uid}", targetUidStr));
                 }
+            } catch (NumberFormatException e) {
+                CommandHandler.sendMessage(player, Grasscutter.getLanguage().Invalid_UID);
             }
             return;
         } 
+
         // Get command handler.
         CommandHandler handler = this.commands.get(label);
         if (handler == null) {

--- a/src/main/java/emu/grasscutter/command/CommandMap.java
+++ b/src/main/java/emu/grasscutter/command/CommandMap.java
@@ -113,10 +113,6 @@ public final class CommandMap {
             return;
         }
 
-        // Remove prefix if present.
-        if (!Character.isLetter(rawMessage.charAt(0)))
-            rawMessage = rawMessage.substring(1);
-
         // Parse message.
         String[] split = rawMessage.split(" ");
         List<String> args = new LinkedList<>(Arrays.asList(split));

--- a/src/main/java/emu/grasscutter/command/commands/AccountCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/AccountCommand.java
@@ -12,7 +12,7 @@ import java.util.List;
 public final class AccountCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (sender != null) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().This_command_can_only_run_from_console);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/BroadcastCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/BroadcastCommand.java
@@ -12,7 +12,7 @@ import java.util.List;
 public final class BroadcastCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (args.size() < 1) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Broadcast_command_usage);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/ChangeSceneCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ChangeSceneCommand.java
@@ -12,7 +12,7 @@ import java.util.List;
         description = "Changes your scene", aliases = {"scene"}, permission = "player.changescene")
 public final class ChangeSceneCommand implements CommandHandler {
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (sender == null) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/ChangeSceneCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ChangeSceneCommand.java
@@ -3,7 +3,6 @@ package emu.grasscutter.command.commands;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.command.Command;
 import emu.grasscutter.command.CommandHandler;
-import emu.grasscutter.game.gacha.GachaRecord;
 import emu.grasscutter.game.player.Player;
 
 import java.util.List;
@@ -13,12 +12,12 @@ import java.util.List;
 public final class ChangeSceneCommand implements CommandHandler {
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (sender == null) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
 
-        if (args.size() < 1) {
+        if (args.size() != 1) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Change_screen_usage);
             return;
         }
@@ -26,19 +25,19 @@ public final class ChangeSceneCommand implements CommandHandler {
         try {
             int sceneId = Integer.parseInt(args.get(0));
             
-            if (sceneId == sender.getSceneId()) {
+            if (sceneId == targetPlayer.getSceneId()) {
             	CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Change_screen_you_in_that_screen);
             	return;
             }
             
-            boolean result = sender.getWorld().transferPlayerToScene(sender, sceneId, sender.getPos());
+            boolean result = targetPlayer.getWorld().transferPlayerToScene(targetPlayer, sceneId, targetPlayer.getPos());
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Change_screen + sceneId);
             
             if (!result) {
                 CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Change_screen_not_exist);
             }
         } catch (Exception e) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Change_screen_usage);
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_arguments);
         }
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/ClearCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ClearCommand.java
@@ -16,7 +16,7 @@ import java.util.List;
 public final class ClearCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         int target;
         String cmdSwitch = "";
         if (sender == null) {
@@ -32,7 +32,6 @@ public final class ClearCommand implements CommandHandler {
                 cmdSwitch = args.get(1);
                 target = Integer.parseInt(args.get(0));
             }
-            Player targetPlayer = Grasscutter.getGameServer().getPlayerByUid(target);
             switch (cmdSwitch) {
                 case "wp" -> {
                     playerInventory.getItems().values().stream()
@@ -99,7 +98,6 @@ public final class ClearCommand implements CommandHandler {
             return;
         }
 
-        Player targetPlayer = Grasscutter.getGameServer().getPlayerByUid(target);
         if (targetPlayer == null) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/ClearCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ClearCommand.java
@@ -32,7 +32,7 @@ public final class ClearCommand implements CommandHandler {
                         .filter(item -> item.getItemType() == ItemType.ITEM_WEAPON)
                         .filter(item -> !item.isLocked() && !item.isEquipped())
                         .forEach(item -> playerInventory.removeItem(item, item.getCount()));
-                sender.dropMessage(Grasscutter.getLanguage().Clear_weapons.replace("{name}", targetPlayer.getNickname()));
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Clear_weapons.replace("{name}", targetPlayer.getNickname()));
             }
             case "art" -> {
                 playerInventory.getItems().values().stream()
@@ -40,7 +40,7 @@ public final class ClearCommand implements CommandHandler {
                         .filter(item -> item.getLevel() == 1 && item.getExp() == 0)
                         .filter(item -> !item.isLocked() && !item.isEquipped())
                         .forEach(item -> playerInventory.removeItem(item, item.getCount()));
-                sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
             }
             case "mat" -> {
                 playerInventory.getItems().values().stream()
@@ -48,7 +48,7 @@ public final class ClearCommand implements CommandHandler {
                         .filter(item -> item.getLevel() == 1 && item.getExp() == 0)
                         .filter(item -> !item.isLocked() && !item.isEquipped())
                         .forEach(item -> playerInventory.removeItem(item, item.getCount()));
-                sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
             }
             case "all" -> {
                 playerInventory.getItems().values().stream()
@@ -56,34 +56,34 @@ public final class ClearCommand implements CommandHandler {
                         .filter(item1 -> item1.getLevel() == 1 && item1.getExp() == 0)
                         .filter(item1 -> !item1.isLocked() && !item1.isEquipped())
                         .forEach(item1 -> playerInventory.removeItem(item1, item1.getCount()));
-                sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
                 playerInventory.getItems().values().stream()
                         .filter(item2 -> item2.getItemType() == ItemType.ITEM_MATERIAL)
                         .filter(item2 -> !item2.isLocked() && !item2.isEquipped())
                         .forEach(item2 -> playerInventory.removeItem(item2, item2.getCount()));
-                sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
                 playerInventory.getItems().values().stream()
                         .filter(item3 -> item3.getItemType() == ItemType.ITEM_WEAPON)
                         .filter(item3 -> item3.getLevel() == 1 && item3.getExp() == 0)
                         .filter(item3 -> !item3.isLocked() && !item3.isEquipped())
                         .forEach(item3 -> playerInventory.removeItem(item3, item3.getCount()));
-                sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
                 playerInventory.getItems().values().stream()
                         .filter(item4 -> item4.getItemType() == ItemType.ITEM_FURNITURE)
                         .filter(item4 -> !item4.isLocked() && !item4.isEquipped())
                         .forEach(item4 -> playerInventory.removeItem(item4, item4.getCount()));
-                sender.dropMessage(Grasscutter.getLanguage().Clear_furniture.replace("{name}", targetPlayer.getNickname()));
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Clear_furniture.replace("{name}", targetPlayer.getNickname()));
                 playerInventory.getItems().values().stream()
                         .filter(item5 -> item5.getItemType() == ItemType.ITEM_DISPLAY)
                         .filter(item5 -> !item5.isLocked() && !item5.isEquipped())
                         .forEach(item5 -> playerInventory.removeItem(item5, item5.getCount()));
-                sender.dropMessage(Grasscutter.getLanguage().Clear_displays.replace("{name}", targetPlayer.getNickname()));
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Clear_displays.replace("{name}", targetPlayer.getNickname()));
                 playerInventory.getItems().values().stream()
                         .filter(item6 -> item6.getItemType() == ItemType.ITEM_VIRTUAL)
                         .filter(item6 -> !item6.isLocked() && !item6.isEquipped())
                         .forEach(item6 -> playerInventory.removeItem(item6, item6.getCount()));
-                sender.dropMessage(Grasscutter.getLanguage().Clear_virtuals.replace("{name}", targetPlayer.getNickname()));
-                sender.dropMessage(Grasscutter.getLanguage().Clear_everything.replace("{name}", targetPlayer.getNickname()));
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Clear_virtuals.replace("{name}", targetPlayer.getNickname()));
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Clear_everything.replace("{name}", targetPlayer.getNickname()));
             }
         }
     }

--- a/src/main/java/emu/grasscutter/command/commands/ClearCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ClearCommand.java
@@ -17,90 +17,74 @@ public final class ClearCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        int target;
-        String cmdSwitch = "";
-        if (sender == null) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
-            return;
-        }
-        Inventory playerInventory = sender.getInventory();
-        try {
-            if (args.size() == 1) {
-                cmdSwitch = args.get(0);
-                target = sender.getUid();
-            }else {
-                cmdSwitch = args.get(1);
-                target = Integer.parseInt(args.get(0));
-            }
-            switch (cmdSwitch) {
-                case "wp" -> {
-                    playerInventory.getItems().values().stream()
-                            .filter(item -> item.getItemType() == ItemType.ITEM_WEAPON)
-                            .filter(item -> !item.isLocked() && !item.isEquipped())
-                            .forEach(item -> playerInventory.removeItem(item, item.getCount()));
-                    sender.dropMessage(Grasscutter.getLanguage().Clear_weapons.replace("{name}", targetPlayer.getNickname()));
-                }
-                case "art" -> {
-                    playerInventory.getItems().values().stream()
-                            .filter(item -> item.getItemType() == ItemType.ITEM_RELIQUARY)
-                            .filter(item -> item.getLevel() == 1 && item.getExp() == 0)
-                            .filter(item -> !item.isLocked() && !item.isEquipped())
-                            .forEach(item -> playerInventory.removeItem(item, item.getCount()));
-                    sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
-                }
-                case "mat" -> {
-                    playerInventory.getItems().values().stream()
-                            .filter(item -> item.getItemType() == ItemType.ITEM_MATERIAL)
-                            .filter(item -> item.getLevel() == 1 && item.getExp() == 0)
-                            .filter(item -> !item.isLocked() && !item.isEquipped())
-                            .forEach(item -> playerInventory.removeItem(item, item.getCount()));
-                    sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
-                }
-                case "all" -> {
-                    playerInventory.getItems().values().stream()
-                            .filter(item1 -> item1.getItemType() == ItemType.ITEM_RELIQUARY)
-                            .filter(item1 -> item1.getLevel() == 1 && item1.getExp() == 0)
-                            .filter(item1 -> !item1.isLocked() && !item1.isEquipped())
-                            .forEach(item1 -> playerInventory.removeItem(item1, item1.getCount()));
-                    sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
-                    playerInventory.getItems().values().stream()
-                            .filter(item2 -> item2.getItemType() == ItemType.ITEM_MATERIAL)
-                            .filter(item2 -> !item2.isLocked() && !item2.isEquipped())
-                            .forEach(item2 -> playerInventory.removeItem(item2, item2.getCount()));
-                    sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
-                    playerInventory.getItems().values().stream()
-                            .filter(item3 -> item3.getItemType() == ItemType.ITEM_WEAPON)
-                            .filter(item3 -> item3.getLevel() == 1 && item3.getExp() == 0)
-                            .filter(item3 -> !item3.isLocked() && !item3.isEquipped())
-                            .forEach(item3 -> playerInventory.removeItem(item3, item3.getCount()));
-                    sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
-                    playerInventory.getItems().values().stream()
-                            .filter(item4 -> item4.getItemType() == ItemType.ITEM_FURNITURE)
-                            .filter(item4 -> !item4.isLocked() && !item4.isEquipped())
-                            .forEach(item4 -> playerInventory.removeItem(item4, item4.getCount()));
-                    sender.dropMessage(Grasscutter.getLanguage().Clear_furniture.replace("{name}", targetPlayer.getNickname()));
-                    playerInventory.getItems().values().stream()
-                            .filter(item5 -> item5.getItemType() == ItemType.ITEM_DISPLAY)
-                            .filter(item5 -> !item5.isLocked() && !item5.isEquipped())
-                            .forEach(item5 -> playerInventory.removeItem(item5, item5.getCount()));
-                    sender.dropMessage(Grasscutter.getLanguage().Clear_displays.replace("{name}", targetPlayer.getNickname()));
-                    playerInventory.getItems().values().stream()
-                            .filter(item6 -> item6.getItemType() == ItemType.ITEM_VIRTUAL)
-                            .filter(item6 -> !item6.isLocked() && !item6.isEquipped())
-                            .forEach(item6 -> playerInventory.removeItem(item6, item6.getCount()));
-                    sender.dropMessage(Grasscutter.getLanguage().Clear_virtuals.replace("{name}", targetPlayer.getNickname()));
-                    sender.dropMessage(Grasscutter.getLanguage().Clear_everything.replace("{name}", targetPlayer.getNickname()));
-                }
-            }
-        } catch (NumberFormatException ignored) {
-            // TODO: Parse from item name using GM Handbook.
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_playerId);
-            return;
-        }
-
         if (targetPlayer == null) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
+        }
+        if (args.size() < 1) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Clear_usage);
+            return;
+        }
+        Inventory playerInventory = targetPlayer.getInventory();
+        switch (args.get(0)) {
+            case "wp" -> {
+                playerInventory.getItems().values().stream()
+                        .filter(item -> item.getItemType() == ItemType.ITEM_WEAPON)
+                        .filter(item -> !item.isLocked() && !item.isEquipped())
+                        .forEach(item -> playerInventory.removeItem(item, item.getCount()));
+                sender.dropMessage(Grasscutter.getLanguage().Clear_weapons.replace("{name}", targetPlayer.getNickname()));
+            }
+            case "art" -> {
+                playerInventory.getItems().values().stream()
+                        .filter(item -> item.getItemType() == ItemType.ITEM_RELIQUARY)
+                        .filter(item -> item.getLevel() == 1 && item.getExp() == 0)
+                        .filter(item -> !item.isLocked() && !item.isEquipped())
+                        .forEach(item -> playerInventory.removeItem(item, item.getCount()));
+                sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
+            }
+            case "mat" -> {
+                playerInventory.getItems().values().stream()
+                        .filter(item -> item.getItemType() == ItemType.ITEM_MATERIAL)
+                        .filter(item -> item.getLevel() == 1 && item.getExp() == 0)
+                        .filter(item -> !item.isLocked() && !item.isEquipped())
+                        .forEach(item -> playerInventory.removeItem(item, item.getCount()));
+                sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
+            }
+            case "all" -> {
+                playerInventory.getItems().values().stream()
+                        .filter(item1 -> item1.getItemType() == ItemType.ITEM_RELIQUARY)
+                        .filter(item1 -> item1.getLevel() == 1 && item1.getExp() == 0)
+                        .filter(item1 -> !item1.isLocked() && !item1.isEquipped())
+                        .forEach(item1 -> playerInventory.removeItem(item1, item1.getCount()));
+                sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
+                playerInventory.getItems().values().stream()
+                        .filter(item2 -> item2.getItemType() == ItemType.ITEM_MATERIAL)
+                        .filter(item2 -> !item2.isLocked() && !item2.isEquipped())
+                        .forEach(item2 -> playerInventory.removeItem(item2, item2.getCount()));
+                sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
+                playerInventory.getItems().values().stream()
+                        .filter(item3 -> item3.getItemType() == ItemType.ITEM_WEAPON)
+                        .filter(item3 -> item3.getLevel() == 1 && item3.getExp() == 0)
+                        .filter(item3 -> !item3.isLocked() && !item3.isEquipped())
+                        .forEach(item3 -> playerInventory.removeItem(item3, item3.getCount()));
+                sender.dropMessage(Grasscutter.getLanguage().Clear_artifacts.replace("{name}", targetPlayer.getNickname()));
+                playerInventory.getItems().values().stream()
+                        .filter(item4 -> item4.getItemType() == ItemType.ITEM_FURNITURE)
+                        .filter(item4 -> !item4.isLocked() && !item4.isEquipped())
+                        .forEach(item4 -> playerInventory.removeItem(item4, item4.getCount()));
+                sender.dropMessage(Grasscutter.getLanguage().Clear_furniture.replace("{name}", targetPlayer.getNickname()));
+                playerInventory.getItems().values().stream()
+                        .filter(item5 -> item5.getItemType() == ItemType.ITEM_DISPLAY)
+                        .filter(item5 -> !item5.isLocked() && !item5.isEquipped())
+                        .forEach(item5 -> playerInventory.removeItem(item5, item5.getCount()));
+                sender.dropMessage(Grasscutter.getLanguage().Clear_displays.replace("{name}", targetPlayer.getNickname()));
+                playerInventory.getItems().values().stream()
+                        .filter(item6 -> item6.getItemType() == ItemType.ITEM_VIRTUAL)
+                        .filter(item6 -> !item6.isLocked() && !item6.isEquipped())
+                        .forEach(item6 -> playerInventory.removeItem(item6, item6.getCount()));
+                sender.dropMessage(Grasscutter.getLanguage().Clear_virtuals.replace("{name}", targetPlayer.getNickname()));
+                sender.dropMessage(Grasscutter.getLanguage().Clear_everything.replace("{name}", targetPlayer.getNickname()));
+            }
         }
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/CoopCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/CoopCommand.java
@@ -20,17 +20,21 @@ public final class CoopCommand implements CommandHandler {
         Player host = sender;
         switch (args.size()) {
             case 0:  // Summon target to self
+                if (sender == null) {  // Console doesn't have a self to summon to
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Coop_usage);
+                    return;
+                }
                 break;
             case 1:  // Summon target to argument
                 try {
-                    int hostId = Integer.parseInt(args.get(1));
-                    host = sender.getServer().getPlayerByUid(hostId);
+                    int hostId = Integer.parseInt(args.get(0));
+                    host = Grasscutter.getGameServer().getPlayerByUid(hostId);
                     if (host == null) {
                         CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_is_offline);
                         return;
                     }
                     break;
-                } catch (Exception e) {
+                } catch (NumberFormatException ignored) {
                     CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_playerId);
                     return;
                 }
@@ -39,12 +43,12 @@ public final class CoopCommand implements CommandHandler {
                 return;
         }
         
-        
+        // There's no target==host check but this just places them in multiplayer in their own world which seems fine.
         if (targetPlayer.isInMultiplayer()) {
-            sender.getServer().getMultiplayerManager().leaveCoop(targetPlayer);
+            targetPlayer.getServer().getMultiplayerManager().leaveCoop(targetPlayer);
         }
-        sender.getServer().getMultiplayerManager().applyEnterMp(targetPlayer, host.getUid());
-        sender.getServer().getMultiplayerManager().applyEnterMpReply(host, targetPlayer.getUid(), true);
+        host.getServer().getMultiplayerManager().applyEnterMp(targetPlayer, host.getUid());
+        targetPlayer.getServer().getMultiplayerManager().applyEnterMpReply(host, targetPlayer.getUid(), true);
         CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Coop_success.replace("{host}", host.getNickname()).replace("{target}", targetPlayer.getNickname()));
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/CoopCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/CoopCommand.java
@@ -7,32 +7,44 @@ import emu.grasscutter.game.player.Player;
 
 import java.util.List;
 
-@Command(label = "coop", usage = "coop",
+@Command(label = "coop", usage = "coop [host UID]",
         description = "Forces someone to join the world of others", permission = "server.coop")
 public final class CoopCommand implements CommandHandler {
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (args.size() < 2) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Coop_usage);
-            return;
+		if (targetPlayer == null) {
+			CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
+			return;
+		}
+
+        Player host = sender;
+        switch (args.size()) {
+            case 0:  // Summon target to self
+                break;
+            case 1:  // Summon target to argument
+                try {
+                    int hostId = Integer.parseInt(args.get(1));
+                    host = sender.getServer().getPlayerByUid(hostId);
+                    if (host == null) {
+                        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_is_offline);
+                        return;
+                    }
+                    break;
+                } catch (Exception e) {
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_playerId);
+                    return;
+                }
+            default:
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Coop_usage);
+                return;
         }
         
-        try {
-            int tid = Integer.parseInt(args.get(0));
-            int hostId = Integer.parseInt(args.get(1));
-            Player host = sender.getServer().getPlayerByUid(hostId);
-            Player want = sender.getServer().getPlayerByUid(tid);
-            if (host == null || want == null) {
-                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_is_offline);
-                return;
-            }
-            if (want.isInMultiplayer()) {
-                sender.getServer().getMultiplayerManager().leaveCoop(want);
-            }
-            sender.getServer().getMultiplayerManager().applyEnterMp(want, hostId);
-            sender.getServer().getMultiplayerManager().applyEnterMpReply(host, tid, true);
-        } catch (Exception e) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_playerId);
+        
+        if (targetPlayer.isInMultiplayer()) {
+            sender.getServer().getMultiplayerManager().leaveCoop(targetPlayer);
         }
+        sender.getServer().getMultiplayerManager().applyEnterMp(targetPlayer, host.getUid());
+        sender.getServer().getMultiplayerManager().applyEnterMpReply(host, targetPlayer.getUid(), true);
+        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Coop_success.replace("{host}", host.getNickname()).replace("{target}", targetPlayer.getNickname()));
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/CoopCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/CoopCommand.java
@@ -11,7 +11,7 @@ import java.util.List;
         description = "Forces someone to join the world of others", permission = "server.coop")
 public final class CoopCommand implements CommandHandler {
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (args.size() < 2) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Coop_usage);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/DropCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/DropCommand.java
@@ -17,41 +17,51 @@ public final class DropCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (sender == null) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Target_needed);
             return;
         }
+        
+        int item = 0;
+        int amount = 1;
 
-        if (args.size() < 1) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Drop_usage);
-            return;
-        }
-
-        try {
-            int item = Integer.parseInt(args.get(0));
-            int amount = 1;
-            if (args.size() > 1) amount = Integer.parseInt(args.get(1));
-
-            ItemData itemData = GameData.getItemDataMap().get(item);
-            if (itemData == null) {
-                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_id);
-                return;
-            }
-
-            if (itemData.isEquip()) {
-                float range = (5f + (.1f * amount));
-                for (int i = 0; i < amount; i++) {
-                    Position pos = sender.getPos().clone().addX((float) (Math.random() * range) - (range / 2)).addY(3f).addZ((float) (Math.random() * range) - (range / 2));
-                    EntityItem entity = new EntityItem(sender.getScene(), sender, itemData, pos, 1);
-                    sender.getScene().addEntity(entity);
+        switch (args.size()) {
+            case 2:
+                try {
+                    amount = Integer.parseInt(args.get(1));
+                } catch (NumberFormatException ignored) {
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_amount);
+                    return;
+                }  // Slightly cheeky here: no break so it falls through to initialize the first argument too
+            case 1:
+                try {
+                    item = Integer.parseInt(args.get(0));
+                } catch (NumberFormatException ignored) {
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_id);
+                    return;
                 }
-            } else {
-                EntityItem entity = new EntityItem(sender.getScene(), sender, itemData, sender.getPos().clone().addY(3f), amount);
-                sender.getScene().addEntity(entity);
-            }
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Drop_dropped_of.replace("{amount}", Integer.toString(amount)).replace("{item}", Integer.toString(item)));
-        } catch (NumberFormatException ignored) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_or_player_id);
+                break;
+            default:
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Drop_usage);
+                return;
         }
+
+        ItemData itemData = GameData.getItemDataMap().get(item);
+        if (itemData == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_id);
+            return;
+        }
+        if (itemData.isEquip()) {
+            float range = (5f + (.1f * amount));
+            for (int i = 0; i < amount; i++) {
+                Position pos = targetPlayer.getPos().clone().addX((float) (Math.random() * range) - (range / 2)).addY(3f).addZ((float) (Math.random() * range) - (range / 2));
+                EntityItem entity = new EntityItem(targetPlayer.getScene(), targetPlayer, itemData, pos, 1);
+                targetPlayer.getScene().addEntity(entity);
+            }
+        } else {
+            EntityItem entity = new EntityItem(targetPlayer.getScene(), targetPlayer, itemData, targetPlayer.getPos().clone().addY(3f), amount);
+            targetPlayer.getScene().addEntity(entity);
+        }
+        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Drop_dropped_of.replace("{amount}", Integer.toString(amount)).replace("{item}", Integer.toString(item)));
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/DropCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/DropCommand.java
@@ -16,7 +16,7 @@ import java.util.List;
 public final class DropCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (sender == null) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/EnterDungeonCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/EnterDungeonCommand.java
@@ -11,7 +11,7 @@ import java.util.List;
         description = "Enter a dungeon", aliases = {"dungeon"}, permission = "player.enterdungeon")
 public final class EnterDungeonCommand implements CommandHandler {
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (sender == null) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/EnterDungeonCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/EnterDungeonCommand.java
@@ -12,8 +12,8 @@ import java.util.List;
 public final class EnterDungeonCommand implements CommandHandler {
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (sender == null) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Target_needed);
             return;
         }
 
@@ -25,12 +25,12 @@ public final class EnterDungeonCommand implements CommandHandler {
         try {
             int dungeonId = Integer.parseInt(args.get(0));
             
-            if (dungeonId == sender.getSceneId()) {
+            if (dungeonId == targetPlayer.getSceneId()) {
             	CommandHandler.sendMessage(sender, Grasscutter.getLanguage().EnterDungeon_you_in_that_dungeon);
             	return;
             }
             
-            boolean result = sender.getServer().getDungeonManager().enterDungeon(sender.getSession().getPlayer(), 0, dungeonId);
+            boolean result = targetPlayer.getServer().getDungeonManager().enterDungeon(targetPlayer.getSession().getPlayer(), 0, dungeonId);
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().EnterDungeon_changed_to_dungeon + dungeonId);
 
             if (!result) {

--- a/src/main/java/emu/grasscutter/command/commands/GiveAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveAllCommand.java
@@ -37,7 +37,7 @@ public final class GiveAllCommand implements CommandHandler {
                 }
                 break;
             default: // invalid
-                CommandHandler.sendMessage(null, Grasscutter.getLanguage().GiveAll_usage);
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().GiveAll_usage);
                 return;
         }
 

--- a/src/main/java/emu/grasscutter/command/commands/GiveAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveAllCommand.java
@@ -18,7 +18,7 @@ import java.util.*;
 public final class GiveAllCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         int target, amount = 99999;
 
         switch (args.size()) {
@@ -63,7 +63,6 @@ public final class GiveAllCommand implements CommandHandler {
                 return;
         }
 
-        Player targetPlayer = Grasscutter.getGameServer().getPlayerByUid(target);
         if (targetPlayer == null) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/GiveAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveAllCommand.java
@@ -13,59 +13,32 @@ import emu.grasscutter.game.player.Player;
 
 import java.util.*;
 
-@Command(label = "giveall", usage = "giveall [player] [amount]",
+@Command(label = "giveall", usage = "giveall [amount]",
         description = "Gives all items", aliases = {"givea"}, permission = "player.giveall", threading = true)
 public final class GiveAllCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        int target, amount = 99999;
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
+            return;
+        }
+        int amount = 99999;
 
         switch (args.size()) {
-            case 0: // *no args*
-                if (sender == null) {
-                    CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
-                    return;
-                }
-                target = sender.getUid();
+            case 0:
                 break;
-
-            case 1: // [player]
+            case 1: // [amount]
                 try {
-                    target = Integer.parseInt(args.get(0));
-                    if (Grasscutter.getGameServer().getPlayerByUid(target) == null) {
-                        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_playerId);
-                        return;
-                    }
-                }catch (NumberFormatException ignored){
-                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_playerId);
-                    return;
-                }
-                break;
-
-            case 2: // [player] [amount]
-                try {
-                    target = Integer.parseInt(args.get(0));
-                    if (Grasscutter.getGameServer().getPlayerByUid(target) == null) {
-                        target = sender.getUid();
-                        amount = Integer.parseInt(args.get(0));
-                    } else {
-                        amount = Integer.parseInt(args.get(1));
-                    }
+                    amount = Integer.parseInt(args.get(0));
                 } catch (NumberFormatException ignored) {
-                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().GiveAll_invalid_amount_or_playerId);
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_amount);
                     return;
                 }
                 break;
-
             default: // invalid
                 CommandHandler.sendMessage(null, Grasscutter.getLanguage().GiveAll_usage);
                 return;
-        }
-
-        if (targetPlayer == null) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
-            return;
         }
 
         this.giveAllItems(targetPlayer, amount);

--- a/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Command(label = "giveart", usage = "giveart [player] <artifactId> <mainPropId> [<appendPropId>[,<times>]]... [level]", description = "Gives the player a specified artifact", aliases = {"gart"}, permission = "player.giveart")
 public final class GiveArtifactCommand implements CommandHandler {
 	@Override
-	public void execute(Player sender, List<String> args) {
+	public void execute(Player sender, Player targetPlayer, List<String> args) {
 		int size = args.size(), target, itemId, mainPropId, level = 1;
 		ArrayList<Integer> appendPropIdList = new ArrayList<>();
 		String msg = Grasscutter.getLanguage().GiveArtifact_usage;
@@ -71,7 +71,6 @@ public final class GiveArtifactCommand implements CommandHandler {
 			return;
 		}
 
-		Player targetPlayer = Grasscutter.getGameServer().getPlayerByUid(target);
 		if (targetPlayer == null) {
 			CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
 			return;

--- a/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
@@ -52,7 +52,7 @@ public final class GiveArtifactCommand implements CommandHandler {
 		int level = 1;
 		try {
 			int last = Integer.parseInt(args.get(args.size()-1));
-			if (last > 0 && last < 21) {  // Luckily appendPropIds aren't in the range of [1,20] 
+			if (last > 0 && last < 22) {  // Luckily appendPropIds aren't in the range of [1,21] 
 				level = last;
 				args.remove(args.size()-1);
 			}

--- a/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
@@ -14,72 +14,67 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-@Command(label = "giveart", usage = "giveart [player] <artifactId> <mainPropId> [<appendPropId>[,<times>]]... [level]", description = "Gives the player a specified artifact", aliases = {"gart"}, permission = "player.giveart")
+@Command(label = "giveart", usage = "giveart <artifactId> <mainPropId> [<appendPropId>[,<times>]]... [level]", description = "Gives the player a specified artifact", aliases = {"gart"}, permission = "player.giveart")
 public final class GiveArtifactCommand implements CommandHandler {
 	@Override
 	public void execute(Player sender, Player targetPlayer, List<String> args) {
-		int size = args.size(), target, itemId, mainPropId, level = 1;
-		ArrayList<Integer> appendPropIdList = new ArrayList<>();
-		String msg = Grasscutter.getLanguage().GiveArtifact_usage;
-
-		if (sender == null && size < 2) {
-			CommandHandler.sendMessage(null, msg);
-			return;
-		}
-
-		if (size >= 2) {
-			try {
-				try {
-					int last = Integer.parseInt(args.get(size - 1));
-					if (last >= 1 && last <= 21) {
-						level = last;
-						size--;
-					}
-				} catch (NumberFormatException ignored) {
-				}
-				target = Integer.parseInt(args.get(0));
-				int fromIdx;
-				if (Grasscutter.getGameServer().getPlayerByUid(target) == null && sender != null) {
-					target = sender.getUid();
-					itemId = Integer.parseInt(args.get(0));
-					mainPropId = Integer.parseInt(args.get(1));
-					fromIdx = 2;
-				} else {
-					target = Integer.parseInt(args.get(0));
-					itemId = Integer.parseInt(args.get(1));
-					mainPropId = Integer.parseInt(args.get(2));
-					fromIdx = 3;
-				}
-				args.subList(fromIdx, size).forEach(it -> {
-					String[] arr;
-					int n = 1;
-					if ((arr = it.split(",")).length == 2) {
-						it = arr[0];
-						n = Integer.parseInt(arr[1]);
-						if (n > 200) {
-							n = 200;
-						}
-					}
-					appendPropIdList.addAll(Collections.nCopies(n, Integer.parseInt(it)));
-				});
-			} catch (Exception ignored) {
-				CommandHandler.sendMessage(sender, msg);
-				return;
-			}
-		} else {
-			CommandHandler.sendMessage(sender, msg);
-			return;
-		}
-
 		if (targetPlayer == null) {
-			CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
+			CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
 			return;
 		}
 
-		ItemData itemData = GameData.getItemDataMap().get(itemId);
+		if (args.size() < 2) {
+			CommandHandler.sendMessage(sender, Grasscutter.getLanguage().GiveArtifact_usage);
+			return;
+		}
 
+		int itemId;
+		try {
+			itemId = Integer.parseInt(args.remove(0));
+		} catch (NumberFormatException ignored) {
+			CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_artifact_id);
+			return;
+		}
+		ItemData itemData = GameData.getItemDataMap().get(itemId);
 		if (itemData.getItemType() != ItemType.ITEM_RELIQUARY) {
-			CommandHandler.sendMessage(sender, Grasscutter.getLanguage().GiveArtifact_invalid_artifact_id);
+			CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_artifact_id);
+			return;
+		}
+
+		int mainPropId;
+		try {
+			mainPropId = Integer.parseInt(args.remove(0));
+		} catch (NumberFormatException ignored) {
+			CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_arguments);
+			return;
+		}
+
+		int level = 1;
+		try {
+			int last = Integer.parseInt(args.get(args.size()-1));
+			if (last > 0 && last < 21) {  // Luckily appendPropIds aren't in the range of [1,20] 
+				level = last;
+				args.remove(args.size()-1);
+			}
+		} catch (NumberFormatException ignored) {  // Could be a stat,times string so no need to panic
+		}
+
+		ArrayList<Integer> appendPropIdList = new ArrayList<>();
+		try {
+			args.forEach(it -> {
+				String[] arr;
+				int n = 1;
+				if ((arr = it.split(",")).length == 2) {
+					it = arr[0];
+					n = Integer.parseInt(arr[1]);
+					if (n > 200) {
+						n = 200;
+					}
+				}
+				appendPropIdList.addAll(Collections.nCopies(n, Integer.parseInt(it)));
+			});
+		} catch (Exception ignored) {
+			CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_arguments);
 			return;
 		}
 
@@ -90,7 +85,7 @@ public final class GiveArtifactCommand implements CommandHandler {
 		item.getAppendPropIdList().addAll(appendPropIdList);
 		targetPlayer.getInventory().addItem(item, ActionReason.SubfieldDrop);
 
-		CommandHandler.sendMessage(sender, Grasscutter.getLanguage().GiveArtifact_given.replace("{itemId}", Integer.toString(itemId)).replace("target", Integer.toString(target)));
+		CommandHandler.sendMessage(sender, Grasscutter.getLanguage().GiveArtifact_given.replace("{itemId}", Integer.toString(itemId)).replace("target", Integer.toString(targetPlayer.getUid())));
 	}
 }
 

--- a/src/main/java/emu/grasscutter/command/commands/GiveCharCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveCharCommand.java
@@ -15,7 +15,7 @@ import java.util.List;
 public final class GiveCharCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         int target, avatarId, level = 1, ascension;
 
         if (sender == null && args.size() < 2) {
@@ -61,7 +61,6 @@ public final class GiveCharCommand implements CommandHandler {
                 break;
         }
 
-        Player targetPlayer = Grasscutter.getGameServer().getPlayerByUid(target);
         if (targetPlayer == null) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/GiveCharCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveCharCommand.java
@@ -10,75 +10,57 @@ import emu.grasscutter.game.player.Player;
 
 import java.util.List;
 
-@Command(label = "givechar", usage = "givechar <playerId> <avatarId> [level]",
+@Command(label = "givechar", usage = "givechar <avatarId> [level]",
         description = "Gives the player a specified character", aliases = {"givec"}, permission = "player.givechar")
 public final class GiveCharCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        int target, avatarId, level = 1, ascension;
-
-        if (sender == null && args.size() < 2) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().GiveChar_usage);
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
 
+        int avatarId;
+        int level = 1;
+
         switch (args.size()) {
+            case 2:
+                try {
+                    level = Integer.parseInt(args.get(1));
+                } catch (NumberFormatException ignored) {
+                    // TODO: Parse from avatar name using GM Handbook.
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_avatar_level);
+                    return;
+                }  // Cheeky fall-through to parse first argument too
+            case 1:
+                try {
+                    avatarId = Integer.parseInt(args.get(0));
+                } catch (NumberFormatException ignored) {
+                    // TODO: Parse from avatar name using GM Handbook.
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_avatar_id);
+                    return;
+                }
+                break;
             default:
                 CommandHandler.sendMessage(sender, Grasscutter.getLanguage().GiveChar_usage);
                 return;
-            case 2:
-                try {
-                    target = Integer.parseInt(args.get(0));
-                    if (Grasscutter.getGameServer().getPlayerByUid(target) == null && sender != null) {
-                        target = sender.getUid();
-                        level = Integer.parseInt(args.get(1));
-                        avatarId = Integer.parseInt(args.get(0));
-                    } else {
-                        avatarId = Integer.parseInt(args.get(1));
-                    }
-                } catch (NumberFormatException ignored) {
-                    // TODO: Parse from avatar name using GM Handbook.
-                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().GiveChar_invalid_avatar_or_player_id);
-                    return;
-                }
-                break;
-            case 3:
-                try {
-                    target = Integer.parseInt(args.get(0));
-                    if (Grasscutter.getGameServer().getPlayerByUid(target) == null) {
-                        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_playerId);
-                        return;
-                    }
-
-                    avatarId = Integer.parseInt(args.get(1));
-                    level = Integer.parseInt(args.get(2));
-                } catch (NumberFormatException ignored) {
-                    // TODO: Parse from avatar name using GM Handbook.
-                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().GiveChar_invalid_avatar_or_player_id);
-                    return;
-                }
-                break;
-        }
-
-        if (targetPlayer == null) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
-            return;
         }
 
         AvatarData avatarData = GameData.getAvatarDataMap().get(avatarId);
         if (avatarData == null) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().GiveChar_invalid_avatar_id);
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_avatar_id);
             return;
         }
 
         // Check level.
         if (level > 90) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().GiveChar_invalid_avatar_level);
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_avatar_level);
             return;
         }
 
         // Calculate ascension level.
+        int ascension;
         if (level <= 40) {
             ascension = (int) Math.ceil(level / 20f);
         } else {
@@ -93,6 +75,6 @@ public final class GiveCharCommand implements CommandHandler {
         avatar.recalcStats();
 
         targetPlayer.addAvatar(avatar);
-        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().GiveChar_given.replace("{avatarId}", Integer.toString(avatarId)).replace("{level}", Integer.toString(level)).replace("{target}", Integer.toString(target)));
+        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().GiveChar_given.replace("{avatarId}", Integer.toString(avatarId)).replace("{level}", Integer.toString(level)).replace("{target}", Integer.toString(targetPlayer.getUid())));
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/GiveCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveCommand.java
@@ -13,119 +13,58 @@ import emu.grasscutter.game.props.ActionReason;
 import java.util.LinkedList;
 import java.util.List;
 
-@Command(label = "give", usage = "give [player] <itemId|itemName> [amount] [level]", description = "Gives an item to you or the specified player", aliases = {
+@Command(label = "give", usage = "give <itemId|itemName> [amount] [level]", description = "Gives an item to you or the specified player", aliases = {
         "g", "item", "giveitem"}, permission = "player.give")
 public final class GiveCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        int target, item, lvl, amount = 1, refinement = 0;
-        if (sender == null && args.size() < 2) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Give_usage);
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
+        int item;
+        int lvl = 1;
+        int amount = 1;
+        int refinement = 0;
 
         switch (args.size()) {
-            default: // *No args*
-                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Give_usage);
-                return;
+            case 4: // <itemId|itemName> [amount] [level] [refinement]
+                try {
+                    refinement = Integer.parseInt(args.get(3));
+                } catch (NumberFormatException ignored) {
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_refinement);
+                    return;
+                }  // Fallthrough
+            case 3: // <itemId|itemName> [amount] [level]
+                try {
+                    lvl = Integer.parseInt(args.get(2));
+                } catch (NumberFormatException ignored) {
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_level);
+                    return;
+                }  // Fallthrough
+            case 2: // <itemId|itemName> [amount]
+                try {
+                    amount = Integer.parseInt(args.get(1));
+                } catch (NumberFormatException ignored) {
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_amount);
+                    return;
+                }  // Fallthrough
             case 1: // <itemId|itemName>
                 try {
                     item = Integer.parseInt(args.get(0));
-                    target = sender.getUid();
-                    lvl = 1;
                 } catch (NumberFormatException ignored) {
                     // TODO: Parse from item name using GM Handbook.
                     CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_id);
                     return;
                 }
                 break;
-            case 2: // <itemId|itemName> [amount] | [player] <itemId|itemName>
-                try {
-                    target = Integer.parseInt(args.get(0));
-                    lvl = 1;
-
-                    if (Grasscutter.getGameServer().getPlayerByUid(target) == null && sender != null) {
-                        target = sender.getUid();
-                        item = Integer.parseInt(args.get(0));
-                        amount = Integer.parseInt(args.get(1));
-                    } else {
-                        item = Integer.parseInt(args.get(1));
-                    }
-                } catch (NumberFormatException ignored) {
-                    // TODO: Parse from item name using GM Handbook.
-                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_or_player_id);
-                    return;
-                }
-                break;
-            case 3: // [player] <itemId|itemName> [amount] | <itemId|itemName> [amount] [level]
-                try {
-                    target = Integer.parseInt(args.get(0));
-
-                    if (Grasscutter.getGameServer().getPlayerByUid(target) == null && sender != null) {
-                        target = sender.getUid();
-                        item = Integer.parseInt(args.get(0));
-                        amount = Integer.parseInt(args.get(1));
-                        lvl = Integer.parseInt(args.get(2));
-                    } else {
-                        item = Integer.parseInt(args.get(1));
-                        amount = Integer.parseInt(args.get(2));
-                        lvl = 1;
-                    }
-
-                } catch (NumberFormatException ignored) {
-                    // TODO: Parse from item name using GM Handbook.
-                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_or_player_id);
-                    return;
-                }
-                break;
-            case 4: // [player] <itemId|itemName> [amount] [level] | <itemId|itemName> [amount] [level] [refinement]
-                try {
-                    target = Integer.parseInt(args.get(0));
-
-                    if (Grasscutter.getGameServer().getPlayerByUid(target) == null && sender != null) {
-                        target = sender.getUid();
-                        item = Integer.parseInt(args.get(0));
-                        amount = Integer.parseInt(args.get(1));
-                        lvl = Integer.parseInt(args.get(2));
-                        refinement = Integer.parseInt(args.get(3));
-                    } else {
-                        item = Integer.parseInt(args.get(1));
-                        amount = Integer.parseInt(args.get(2));
-                        lvl = Integer.parseInt(args.get(3));
-                    }
-                } catch (NumberFormatException ignored) {
-                    // TODO: Parse from item name using GM Handbook.
-                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_or_player_id);
-                    return;
-                }
-                break;
-            case 5: // [player] <itemId|itemName> [amount] [level] [refinement]
-                try {
-                    target = Integer.parseInt(args.get(0));
-
-                    if (Grasscutter.getGameServer().getPlayerByUid(target) == null) {
-                        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_playerId);
-                        return;
-                    } else {
-                        item = Integer.parseInt(args.get(1));
-                        amount = Integer.parseInt(args.get(2));
-                        lvl = Integer.parseInt(args.get(3));
-                        refinement = Integer.parseInt(args.get(4));
-                    }
-                } catch (NumberFormatException ignored) {
-                    // TODO: Parse from item name using GM Handbook.
-                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_or_player_id);
-                    return;
-                }
-                break;
+            default: // *No args*
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Give_usage);
+                return;
         }
 
 
-        if (targetPlayer == null) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
-            return;
-        }
 
         ItemData itemData = GameData.getItemDataMap().get(item);
         if (itemData == null) {
@@ -147,9 +86,9 @@ public final class GiveCommand implements CommandHandler {
         this.item(targetPlayer, itemData, amount, lvl, refinement);
 
         if (!itemData.isEquip()) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Give_given.replace("{amount}", Integer.toString(amount)).replace("{item}", Integer.toString(item)).replace("{target}", Integer.toString(target)));
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Give_given.replace("{amount}", Integer.toString(amount)).replace("{item}", Integer.toString(item)).replace("{target}", Integer.toString(targetPlayer.getUid())));
         } else if (itemData.getItemType() == ItemType.ITEM_WEAPON) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Give_given_with_level_and_refinement.replace("{item}", Integer.toString(item)).replace("{lvl}", Integer.toString(lvl)).replace("{refinement}", Integer.toString(refinement)).replace("{amount}", Integer.toString(amount)).replace("{target}", Integer.toString(target)));
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Give_given_with_level_and_refinement.replace("{item}", Integer.toString(item)).replace("{lvl}", Integer.toString(lvl)).replace("{refinement}", Integer.toString(refinement)).replace("{amount}", Integer.toString(amount)).replace("{target}", Integer.toString(targetPlayer.getUid())));
         } else {
             CommandHandler.sendMessage(sender,Grasscutter.getLanguage().Give_given_level.replace("{item}", Integer.toString(item)).replace("{lvl}", Integer.toString(lvl)).replace("{amount}", Integer.toString(amount)));
         }

--- a/src/main/java/emu/grasscutter/command/commands/GiveCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveCommand.java
@@ -18,7 +18,7 @@ import java.util.List;
 public final class GiveCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         int target, item, lvl, amount = 1, refinement = 0;
         if (sender == null && args.size() < 2) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().Give_usage);
@@ -121,7 +121,6 @@ public final class GiveCommand implements CommandHandler {
                 break;
         }
 
-        Player targetPlayer = Grasscutter.getGameServer().getPlayerByUid(target);
 
         if (targetPlayer == null) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);

--- a/src/main/java/emu/grasscutter/command/commands/GodModeCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GodModeCommand.java
@@ -35,6 +35,6 @@ public final class GodModeCommand implements CommandHandler {
         }
 
         targetPlayer.setGodmode(enabled);
-        sender.dropMessage(Grasscutter.getLanguage().Godmode_status.replace("{status}", (enabled ? Grasscutter.getLanguage().Enabled : Grasscutter.getLanguage().Disabled)).replace("{name}", targetPlayer.getNickname()));
+        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Godmode_status.replace("{status}", (enabled ? Grasscutter.getLanguage().Enabled : Grasscutter.getLanguage().Disabled)).replace("{name}", targetPlayer.getNickname()));
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/GodModeCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GodModeCommand.java
@@ -12,7 +12,7 @@ import java.util.List;
 public final class GodModeCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (sender == null) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
             return; // TODO: toggle player's godmode statue from console or other players
@@ -32,7 +32,6 @@ public final class GodModeCommand implements CommandHandler {
         } else {
             target = sender.getUid();
         }
-        Player targetPlayer = Grasscutter.getGameServer().getPlayerByUid(target);
         if (targetPlayer == null) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/GodModeCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GodModeCommand.java
@@ -7,37 +7,34 @@ import emu.grasscutter.game.player.Player;
 
 import java.util.List;
 
-@Command(label = "godmode", usage = "godmode [playerId]",
-        description = "Prevents you from taking damage", permission = "player.godmode")
+@Command(label = "godmode", usage = "godmode [on|off|toggle]",
+        description = "Prevents you from taking damage. Defaults to toggle.", permission = "player.godmode")
 public final class GodModeCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (sender == null) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
-            return; // TODO: toggle player's godmode statue from console or other players
-        }
-
-        int target;
-        if (args.size() == 1) {
-            try {
-                target = Integer.parseInt(args.get(0));
-                if (Grasscutter.getGameServer().getPlayerByUid(target) == null) {
-                    target = sender.getUid();
-                }
-            } catch (NumberFormatException e) {
-                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_playerId);
-                return;
-            }
-        } else {
-            target = sender.getUid();
-        }
         if (targetPlayer == null) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
 
-        targetPlayer.setGodmode(!targetPlayer.inGodmode());
-        sender.dropMessage(Grasscutter.getLanguage().Godmode_status.replace("{status}", (targetPlayer.inGodmode() ? Grasscutter.getLanguage().Enabled : Grasscutter.getLanguage().Disabled)).replace("{name}", targetPlayer.getNickname()));
+        boolean enabled = !targetPlayer.inGodmode();
+        if (args.size() == 1) {
+            switch (args.get(0).toLowerCase()) {
+                case "on":
+                    enabled = true;
+                    break;
+                case "off":
+                    enabled = false;
+                    break;
+                case "toggle":
+                    break;  // Already toggled
+                default:
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Godmode_status);
+            }
+        }
+
+        targetPlayer.setGodmode(enabled);
+        sender.dropMessage(Grasscutter.getLanguage().Godmode_status.replace("{status}", (enabled ? Grasscutter.getLanguage().Enabled : Grasscutter.getLanguage().Disabled)).replace("{name}", targetPlayer.getNickname()));
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/HealCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/HealCommand.java
@@ -15,12 +15,12 @@ import java.util.List;
 public final class HealCommand implements CommandHandler {
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (sender == null) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
         
-        sender.getTeamManager().getActiveTeam().forEach(entity -> {
+        targetPlayer.getTeamManager().getActiveTeam().forEach(entity -> {
             boolean isAlive = entity.isAlive();
             entity.setFightProperty(
                     FightProperty.FIGHT_PROP_CUR_HP,

--- a/src/main/java/emu/grasscutter/command/commands/HealCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/HealCommand.java
@@ -14,7 +14,7 @@ import java.util.List;
         description = "Heal all characters in your current team.", permission = "player.heal")
 public final class HealCommand implements CommandHandler {
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (sender == null) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/HelpCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/HelpCommand.java
@@ -13,7 +13,7 @@ import java.util.*;
 public final class HelpCommand implements CommandHandler {
 
     @Override
-    public void execute(Player player, List<String> args) {
+    public void execute(Player player, Player targetPlayer, List<String> args) {
         if (args.size() < 1) {
             HashMap<String, CommandHandler> handlers = CommandMap.getInstance().getHandlers();
             List<Command> annotations = new ArrayList<>();

--- a/src/main/java/emu/grasscutter/command/commands/KickCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/KickCommand.java
@@ -7,23 +7,21 @@ import emu.grasscutter.game.player.Player;
 
 import java.util.List;
 
-@Command(label = "kick", usage = "kick <player>",
+@Command(label = "kick", usage = "kick",
         description = "Kicks the specified player from the server (WIP)", permission = "server.kick")
 public final class KickCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        int target = Integer.parseInt(args.get(0));
-
         if (targetPlayer == null) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
 
         if (sender != null) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Kick_player_kick_player.replace("{sendUid}", Integer.toString(sender.getAccount().getPlayerUid())).replace("{sendName}", sender.getAccount().getUsername()).replace("kickUid", Integer.toString(target)).replace("{kickName}", targetPlayer.getAccount().getUsername()));
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Kick_player_kick_player.replace("{sendUid}", Integer.toString(sender.getAccount().getPlayerUid())).replace("{sendName}", sender.getAccount().getUsername()).replace("kickUid", Integer.toString(targetPlayer.getUid())).replace("{kickName}", targetPlayer.getAccount().getUsername()));
         } else {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Kick_server_player.replace("{kickUid}", Integer.toString(target)).replace("{kickName}", targetPlayer.getAccount().getUsername()));
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Kick_server_player.replace("{kickUid}", Integer.toString(targetPlayer.getUid())).replace("{kickName}", targetPlayer.getAccount().getUsername()));
         }
 
         targetPlayer.getSession().close();

--- a/src/main/java/emu/grasscutter/command/commands/KickCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/KickCommand.java
@@ -12,10 +12,9 @@ import java.util.List;
 public final class KickCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         int target = Integer.parseInt(args.get(0));
 
-        Player targetPlayer = Grasscutter.getGameServer().getPlayerByUid(target);
         if (targetPlayer == null) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/KillAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/KillAllCommand.java
@@ -10,57 +10,43 @@ import emu.grasscutter.game.world.Scene;
 
 import java.util.List;
 
-@Command(label = "killall", usage = "killall [playerUid] [sceneId]",
+@Command(label = "killall", usage = "killall [sceneId]",
         description = "Kill all entities", permission = "server.killall")
 public final class KillAllCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        Scene mainScene;
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
+            return;
+        }
 
+        Scene scene = targetPlayer.getScene();
         try {
             switch (args.size()) {
                 case 0: // *No args*
-                    if (sender == null) {
-                        CommandHandler.sendMessage(null, Grasscutter.getLanguage().Kill_usage);
-                        return;
-                    }
-                    mainScene = sender.getScene();
                     break;
-                case 1: // [playerUid]
-                    targetPlayer = Grasscutter.getGameServer().getPlayerByUid(Integer.parseInt(args.get(0)));
-                    if (targetPlayer == null) {
-                        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found_or_offline);
-                        return;
-                    }
-                    mainScene = targetPlayer.getScene();
-                    break;
-                case 2: // [playerUid] [sceneId]
-                    targetPlayer = Grasscutter.getGameServer().getPlayerByUid(Integer.parseInt(args.get(0)));
-                    if (targetPlayer == null) {
-                        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found_or_offline);
-                        return;
-                    }
-                    Scene scene = sender.getWorld().getSceneById(Integer.parseInt(args.get(1)));
-                    if (scene == null) {
-                        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Kill_scene_not_found_in_player_world);
-                        return;
-                    }
-                    mainScene = scene;
+                case 1: // [sceneId]
+                    scene = targetPlayer.getWorld().getSceneById(Integer.parseInt(args.get(0)));
                     break;
                 default:
                     CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Kill_usage);
                     return;
             }
-
-            // Separate into list to avoid concurrency issue
-            List<GameEntity> toKill = mainScene.getEntities().values().stream()
-                    .filter(entity -> entity instanceof EntityMonster)
-                    .toList();
-            toKill.stream().forEach(entity -> mainScene.killEntity(entity, 0));
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Kill_kill_monsters_in_scene.replace("{size}", Integer.toString(toKill.size())).replace("{id}", Integer.toString(mainScene.getId())));
         } catch (NumberFormatException ignored) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_arguments);
         }
+        if (scene == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Kill_scene_not_found_in_player_world);
+            return;
+        }
+
+        // Separate into list to avoid concurrency issue
+        final Scene sceneF = scene;
+        List<GameEntity> toKill = sceneF.getEntities().values().stream()
+                .filter(entity -> entity instanceof EntityMonster)
+                .toList();
+        toKill.stream().forEach(entity -> sceneF.killEntity(entity, 0));
+        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Kill_kill_monsters_in_scene.replace("{size}", Integer.toString(toKill.size())).replace("{id}", Integer.toString(scene.getId())));
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/KillAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/KillAllCommand.java
@@ -15,9 +15,8 @@ import java.util.List;
 public final class KillAllCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         Scene mainScene;
-        Player targetPlayer;
 
         try {
             switch (args.size()) {

--- a/src/main/java/emu/grasscutter/command/commands/KillCharacterCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/KillCharacterCommand.java
@@ -12,44 +12,14 @@ import emu.grasscutter.server.packet.send.PacketLifeStateChangeNotify;
 
 import java.util.List;
 
-@Command(label = "killcharacter", usage = "killcharacter [playerId]", aliases = {"suicide", "kill"},
+@Command(label = "killcharacter", usage = "killcharacter", aliases = {"suicide", "kill"},
         description = "Kills the players current character", permission = "player.killcharacter")
 public final class KillCharacterCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        int target;
-        if (sender == null) {
-            // from console
-            if (args.size() == 1) {
-                try {
-                    target = Integer.parseInt(args.get(0));
-                } catch (NumberFormatException e) {
-                    CommandHandler.sendMessage(null, Grasscutter.getLanguage().Invalid_playerId);
-                    return;
-                }
-            } else {
-                CommandHandler.sendMessage(null, Grasscutter.getLanguage().KillCharacter_usage);
-                return;
-            }
-        } else {
-            if (args.size() == 1) {
-                try {
-                    target = Integer.parseInt(args.get(0));
-                    if (Grasscutter.getGameServer().getPlayerByUid(target) == null) {
-                        target = sender.getUid();
-                    }
-                } catch (NumberFormatException e) {
-                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_playerId);
-                    return;
-                }
-            } else {
-                target = sender.getUid();
-            }
-        }
-
         if (targetPlayer == null) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found_or_offline);
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
 

--- a/src/main/java/emu/grasscutter/command/commands/KillCharacterCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/KillCharacterCommand.java
@@ -17,7 +17,7 @@ import java.util.List;
 public final class KillCharacterCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         int target;
         if (sender == null) {
             // from console
@@ -48,7 +48,6 @@ public final class KillCharacterCommand implements CommandHandler {
             }
         }
 
-        Player targetPlayer = Grasscutter.getGameServer().getPlayerByUid(target);
         if (targetPlayer == null) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found_or_offline);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/ListCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ListCommand.java
@@ -13,7 +13,7 @@ import java.util.Map;
 public final class ListCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         Map<Integer, Player> playersMap = Grasscutter.getGameServer().getPlayers();
         boolean needUID = false;
 

--- a/src/main/java/emu/grasscutter/command/commands/PermissionCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/PermissionCommand.java
@@ -8,22 +8,26 @@ import emu.grasscutter.game.player.Player;
 
 import java.util.List;
 
-@Command(label = "permission", usage = "permission <add|remove> <username> <permission>",
+@Command(label = "permission", usage = "permission <add|remove> <permission>",
         description = "Grants or removes a permission for a user", permission = "*")
 public final class PermissionCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (args.size() < 3) {
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
+            return;
+        }
+        
+        if (args.size() != 2) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Permission_usage);
             return;
         }
 
         String action = args.get(0);
-        String username = args.get(1);
-        String permission = args.get(2);
+        String permission = args.get(1);
 
-        Account account = Grasscutter.getGameServer().getAccountByName(username);
+        Account account = targetPlayer.getAccount();
         if (account == null) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Account_not_find);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/PermissionCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/PermissionCommand.java
@@ -13,7 +13,7 @@ import java.util.List;
 public final class PermissionCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (args.size() < 3) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Permission_usage);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/PositionCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/PositionCommand.java
@@ -20,6 +20,6 @@ public final class PositionCommand implements CommandHandler {
         }
 
         Position pos = targetPlayer.getPos();
-        sender.dropMessage(Grasscutter.getLanguage().Position_message.replace("{x}", Float.toString(pos.getX())).replace("{y}", Float.toString(pos.getY())).replace("{z}", Float.toString(pos.getZ())).replace("{id}", Integer.toString(sender.getSceneId())));
+        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Position_message.replace("{x}", Float.toString(pos.getX())).replace("{y}", Float.toString(pos.getY())).replace("{z}", Float.toString(pos.getZ())).replace("{id}", Integer.toString(targetPlayer.getSceneId())));
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/PositionCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/PositionCommand.java
@@ -12,7 +12,7 @@ import java.util.List;
 public final class PositionCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (sender == null) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/PositionCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/PositionCommand.java
@@ -4,6 +4,7 @@ import emu.grasscutter.Grasscutter;
 import emu.grasscutter.command.Command;
 import emu.grasscutter.command.CommandHandler;
 import emu.grasscutter.game.player.Player;
+import emu.grasscutter.utils.Position;
 
 import java.util.List;
 
@@ -13,11 +14,12 @@ public final class PositionCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (sender == null) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
 
-        sender.dropMessage(Grasscutter.getLanguage().Position_message.replace("{x}", Float.toString(sender.getPos().getX())).replace("{y}", Float.toString(sender.getPos().getY())).replace("{z}", Float.toString(sender.getPos().getZ())).replace("{id}", Integer.toString(sender.getSceneId())));
+        Position pos = targetPlayer.getPos();
+        sender.dropMessage(Grasscutter.getLanguage().Position_message.replace("{x}", Float.toString(pos.getX())).replace("{y}", Float.toString(pos.getY())).replace("{z}", Float.toString(pos.getZ())).replace("{id}", Integer.toString(sender.getSceneId())));
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/ReloadCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ReloadCommand.java
@@ -12,7 +12,7 @@ import java.util.List;
 public final class ReloadCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Reload_reload_start);
         Grasscutter.loadConfig();
         Grasscutter.loadLanguage();

--- a/src/main/java/emu/grasscutter/command/commands/ResetConstCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ResetConstCommand.java
@@ -15,7 +15,7 @@ import java.util.List;
 public final class ResetConstCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (sender == null) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/ResetConstCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ResetConstCommand.java
@@ -23,7 +23,7 @@ public final class ResetConstCommand implements CommandHandler {
 
         if (args.size() > 0 && args.get(0).equalsIgnoreCase("all")) {
             targetPlayer.getAvatars().forEach(this::resetConstellation);
-            targetPlayer.dropMessage(Grasscutter.getLanguage().ResetConst_reset_all);
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().ResetConst_reset_all);
         } else {
             EntityAvatar entity = targetPlayer.getTeamManager().getCurrentAvatarEntity();
             if (entity == null) {
@@ -33,7 +33,7 @@ public final class ResetConstCommand implements CommandHandler {
             Avatar avatar = entity.getAvatar();
             this.resetConstellation(avatar);
 
-            sender.dropMessage(Grasscutter.getLanguage().ResetConst_reset_all_done.replace("{name}", avatar.getAvatarData().getName()));
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().ResetConst_reset_all_done.replace("{name}", avatar.getAvatarData().getName()));
         }
     }
 

--- a/src/main/java/emu/grasscutter/command/commands/ResetConstCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ResetConstCommand.java
@@ -16,16 +16,16 @@ public final class ResetConstCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (sender == null) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
 
         if (args.size() > 0 && args.get(0).equalsIgnoreCase("all")) {
-            sender.getAvatars().forEach(this::resetConstellation);
-            sender.dropMessage(Grasscutter.getLanguage().ResetConst_reset_all);
+            targetPlayer.getAvatars().forEach(this::resetConstellation);
+            targetPlayer.dropMessage(Grasscutter.getLanguage().ResetConst_reset_all);
         } else {
-            EntityAvatar entity = sender.getTeamManager().getCurrentAvatarEntity();
+            EntityAvatar entity = targetPlayer.getTeamManager().getCurrentAvatarEntity();
             if (entity == null) {
                 return;
             }

--- a/src/main/java/emu/grasscutter/command/commands/ResetShopLimitCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ResetShopLimitCommand.java
@@ -11,14 +11,13 @@ import java.util.List;
         description = "Reset target player's shop refresh time.", permission = "server.resetshop")
 public final class ResetShopLimitCommand implements CommandHandler {
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (args.size() < 1) {
             CommandHandler.sendMessage(sender,Grasscutter.getLanguage().ResetShopLimit_usage);
             return;
         }
 
         int target = Integer.parseInt(args.get(0));
-        Player targetPlayer = Grasscutter.getGameServer().getPlayerByUid(target);
         if (targetPlayer == null) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/ResetShopLimitCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ResetShopLimitCommand.java
@@ -12,14 +12,8 @@ import java.util.List;
 public final class ResetShopLimitCommand implements CommandHandler {
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (args.size() < 1) {
-            CommandHandler.sendMessage(sender,Grasscutter.getLanguage().ResetShopLimit_usage);
-            return;
-        }
-
-        int target = Integer.parseInt(args.get(0));
         if (targetPlayer == null) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
 

--- a/src/main/java/emu/grasscutter/command/commands/RestartCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/RestartCommand.java
@@ -10,7 +10,7 @@ import java.util.List;
 public final class RestartCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         sender.getSession().close();
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/RestartCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/RestartCommand.java
@@ -11,6 +11,9 @@ public final class RestartCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
+		if (sender == null) {
+			return;
+		}
         sender.getSession().close();
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/SendMailCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SendMailCommand.java
@@ -23,7 +23,7 @@ public final class SendMailCommand implements CommandHandler {
 
     // Yes this is awful and I hate it.
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         int senderId;
         if(sender != null) {
             senderId = sender.getUid();

--- a/src/main/java/emu/grasscutter/command/commands/SendMailCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SendMailCommand.java
@@ -108,40 +108,44 @@ public final class SendMailCommand implements CommandHandler {
                                 mailBuilder.constructionStage++;
                             }
                             case 3 -> {
-                                // Literally just copy-pasted from the give command lol.
-                                int item, lvl, amount = 1;
+                                int item;
+                                int lvl = 1;
+                                int amount = 1;
+                                int refinement = 0;
                                 switch (args.size()) {
-                                    default -> { // *No args*
-                                        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().SendMail_usage);
-                                        return;
-                                    }
-                                    case 1 -> { // <itemId|itemName>
+                                    case 4: // <itemId|itemName> [amount] [level] [refinement] // TODO: this requires Mail support but there's no harm leaving it here for now
+                                        try {
+                                            refinement = Integer.parseInt(args.get(3));
+                                        } catch (NumberFormatException ignored) {
+                                            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_refinement);
+                                            return;
+                                        }  // Fallthrough
+                                    case 3: // <itemId|itemName> [amount] [level]
+                                        try {
+                                            lvl = Integer.parseInt(args.get(2));
+                                        } catch (NumberFormatException ignored) {
+                                            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_level);
+                                            return;
+                                        }  // Fallthrough
+                                    case 2: // <itemId|itemName> [amount]
+                                        try {
+                                            amount = Integer.parseInt(args.get(1));
+                                        } catch (NumberFormatException ignored) {
+                                            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_amount);
+                                            return;
+                                        }  // Fallthrough
+                                    case 1: // <itemId|itemName>
                                         try {
                                             item = Integer.parseInt(args.get(0));
-                                            lvl = 1;
                                         } catch (NumberFormatException ignored) {
                                             // TODO: Parse from item name using GM Handbook.
                                             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_id);
                                             return;
                                         }
-                                    }
-                                    case 2 -> { // <itemId|itemName> [amount]
-                                        lvl = 1;
-                                        item = Integer.parseInt(args.get(0));
-                                        amount = Integer.parseInt(args.get(1));
-                                    }
-                                    case 3 -> { // <itemId|itemName> [amount] [level]
-                                        try {
-                                            item = Integer.parseInt(args.get(0));
-                                            amount = Integer.parseInt(args.get(1));
-                                            lvl = Integer.parseInt(args.get(2));
-
-                                        } catch (NumberFormatException ignored) {
-                                            // TODO: Parse from item name using GM Handbook.
-                                            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_item_or_player_id);
-                                            return;
-                                        }
-                                    }
+                                        break;
+                                    default: // *No args*
+                                        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Give_usage);
+                                        return;
                                 }
                                 mailBuilder.mail.itemList.add(new Mail.MailItem(item, amount, lvl));
                                 CommandHandler.sendMessage(sender, Grasscutter.getLanguage().SendMail_send.replace("{amount}", Integer.toString(amount)).replace("{item}", Integer.toString(item)).replace("{lvl}", Integer.toString(lvl)));

--- a/src/main/java/emu/grasscutter/command/commands/SendMessageCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SendMessageCommand.java
@@ -7,30 +7,23 @@ import emu.grasscutter.game.player.Player;
 
 import java.util.List;
 
-@Command(label = "say", usage = "say <player> <message>", description = "Sends a message to a player as the server",
+@Command(label = "say", usage = "say <message>", description = "Sends a message to a player as the server",
         aliases = {"sendservmsg", "sendservermessage", "sendmessage"}, permission = "server.sendmessage")
 public final class SendMessageCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (args.size() < 2) {
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
+            return;
+        }
+        if (args.size() == 0) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().SendMessage_usage);
             return;
         }
 
-        try {
-            int target = Integer.parseInt(args.get(0));
-            String message = String.join(" ", args.subList(1, args.size()));
-
-            if (targetPlayer == null) {
-                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
-                return;
-            }
-
-            CommandHandler.sendMessage(targetPlayer, message);
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().SenaMessage_message_sent);
-        } catch (NumberFormatException ignored) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_playerId);
-        }
+        String message = String.join(" ", args);
+        CommandHandler.sendMessage(targetPlayer, message);
+        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().SenaMessage_message_sent);
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/SendMessageCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SendMessageCommand.java
@@ -12,7 +12,7 @@ import java.util.List;
 public final class SendMessageCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (args.size() < 2) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().SendMessage_usage);
             return;
@@ -22,7 +22,6 @@ public final class SendMessageCommand implements CommandHandler {
             int target = Integer.parseInt(args.get(0));
             String message = String.join(" ", args.subList(1, args.size()));
 
-            Player targetPlayer = Grasscutter.getGameServer().getPlayerByUid(target);
             if (targetPlayer == null) {
                 CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found);
                 return;

--- a/src/main/java/emu/grasscutter/command/commands/SetFetterLevelCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetFetterLevelCommand.java
@@ -16,7 +16,7 @@ import emu.grasscutter.server.packet.send.PacketAvatarFetterDataNotify;
 public final class SetFetterLevelCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (sender == null) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/SetFetterLevelCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetFetterLevelCommand.java
@@ -17,12 +17,12 @@ public final class SetFetterLevelCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (sender == null) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
 
-        if (args.size() < 1) {
+        if (args.size() != 1) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().SetFetterLevel_usage);
             return;
         }
@@ -33,7 +33,7 @@ public final class SetFetterLevelCommand implements CommandHandler {
                 CommandHandler.sendMessage(sender, Grasscutter.getLanguage().SetFetterLevel_fetter_level_must_between_0_and_10);
                 return;
             }
-            Avatar avatar = sender.getTeamManager().getCurrentAvatarEntity().getAvatar();
+            Avatar avatar = targetPlayer.getTeamManager().getCurrentAvatarEntity().getAvatar();
 
             avatar.setFetterLevel(fetterLevel);
             if (fetterLevel != 10) {
@@ -41,7 +41,7 @@ public final class SetFetterLevelCommand implements CommandHandler {
             }
 		    avatar.save();
 		
-		    sender.sendPacket(new PacketAvatarFetterDataNotify(avatar));
+		    targetPlayer.sendPacket(new PacketAvatarFetterDataNotify(avatar));
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().SetFetterLevel_fetter_set_level.replace("{level}", Integer.toString(fetterLevel)));
         } catch (NumberFormatException ignored) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().SetFetterLevel_invalid_fetter_level);

--- a/src/main/java/emu/grasscutter/command/commands/SetStatsCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetStatsCommand.java
@@ -174,49 +174,25 @@ public final class SetStatsCommand implements CommandHandler {
     }
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         Language lang = Grasscutter.getLanguage();
         String syntax = sender == null ? lang.SetStats_usage_console : lang.SetStats_usage_console;
         String usage = syntax + lang.SetStats_help_message;
-        Player targetPlayer = sender;
-        String uidStr = "";
         String statStr;
         String valueStr;
+
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, usage);
+            return;
+        }
 
         switch (args.size()) {
             default:
                 CommandHandler.sendMessage(sender, usage);
                 return;
             case 2:
-                if (sender == null) {
-                    // When run by the server, first parameter is not optional
-                    CommandHandler.sendMessage(sender, usage);
-                    return;
-                }
                 statStr = args.get(0).toLowerCase();
                 valueStr = args.get(1);
-                break;
-            case 3:
-                uidStr = args.get(0);
-                if (uidStr.startsWith("@")) {
-                    uidStr = uidStr.substring(1);
-                } else {
-                    CommandHandler.sendMessage(sender, usage);
-                    return;
-                }
-                try {
-                    int uid = Integer.parseInt(uidStr);
-                    targetPlayer = Grasscutter.getGameServer().getPlayerByUid(uid);
-                    if (targetPlayer == null) {
-                        CommandHandler.sendMessage(sender, lang.SetStats_player_error);
-                        return;
-                    }
-                } catch (NumberFormatException e) {
-                    CommandHandler.sendMessage(sender, lang.SetStats_uid_error);
-                    return;
-                }
-                statStr = args.get(1).toLowerCase();
-                valueStr = args.get(2);
                 break;
         };
 
@@ -248,6 +224,7 @@ public final class SetStatsCommand implements CommandHandler {
             if (targetPlayer == sender) {
                 CommandHandler.sendMessage(sender, lang.SetStats_set_self.replace("{name}", stat.name).replace("{value}", valueStr));
             } else {
+                String uidStr = targetPlayer.getAccount().getId();
                 CommandHandler.sendMessage(sender, lang.SetStats_set_for_uid.replace("{name}", stat.name).replace("{uid}", uidStr).replace("{value}", valueStr));
             }
             return;

--- a/src/main/java/emu/grasscutter/command/commands/SetStatsCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetStatsCommand.java
@@ -13,7 +13,7 @@ import emu.grasscutter.game.props.FightProperty;
 import emu.grasscutter.languages.Language;
 import emu.grasscutter.server.packet.send.PacketEntityFightPropUpdateNotify;
 
-@Command(label = "setstats", usage = "setstats|stats [@UID] <stat> <value>",
+@Command(label = "setstats", usage = "setstats|stats <stat> <value>",
         description = "Set fight property for your current active character", aliases = {"stats"}, permission = "player.setstats")
 public final class SetStatsCommand implements CommandHandler {
     class Stat {
@@ -182,7 +182,7 @@ public final class SetStatsCommand implements CommandHandler {
         String valueStr;
 
         if (targetPlayer == null) {
-            CommandHandler.sendMessage(sender, usage);
+            CommandHandler.sendMessage(sender, lang.Target_needed);
             return;
         }
 
@@ -209,8 +209,6 @@ public final class SetStatsCommand implements CommandHandler {
             CommandHandler.sendMessage(sender, lang.SetStats_value_error);
             return;
         }
-        
-
 
         if (stats.containsKey(statStr)) {
             Stat stat = stats.get(statStr);

--- a/src/main/java/emu/grasscutter/command/commands/SetWorldLevelCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetWorldLevelCommand.java
@@ -13,7 +13,7 @@ import java.util.List;
 public final class SetWorldLevelCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (sender == null) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
             return; // TODO: set player's world level from console or other players

--- a/src/main/java/emu/grasscutter/command/commands/SetWorldLevelCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetWorldLevelCommand.java
@@ -27,7 +27,7 @@ public final class SetWorldLevelCommand implements CommandHandler {
         try {
             int level = Integer.parseInt(args.get(0));
             if (level > 8 || level < 0) {
-                sender.dropMessage(Grasscutter.getLanguage().SetWorldLevel_world_level_must_between_0_and_8);
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().SetWorldLevel_world_level_must_between_0_and_8);
                 return;
             }
 
@@ -35,7 +35,7 @@ public final class SetWorldLevelCommand implements CommandHandler {
             targetPlayer.getWorld().setWorldLevel(level);
             targetPlayer.setWorldLevel(level);
 
-            sender.dropMessage(Grasscutter.getLanguage().SetWorldLevel_set_world_level.replace("{level}", Integer.toString(level)));
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().SetWorldLevel_set_world_level.replace("{level}", Integer.toString(level)));
         } catch (NumberFormatException ignored) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().SetWorldLevel_invalid_world_level);
         }

--- a/src/main/java/emu/grasscutter/command/commands/SetWorldLevelCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetWorldLevelCommand.java
@@ -14,9 +14,9 @@ public final class SetWorldLevelCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (sender == null) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
-            return; // TODO: set player's world level from console or other players
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
+            return;
         }
 
         if (args.size() < 1) {
@@ -32,8 +32,8 @@ public final class SetWorldLevelCommand implements CommandHandler {
             }
 
             // Set in both world and player props
-            sender.getWorld().setWorldLevel(level);
-            sender.setWorldLevel(level);
+            targetPlayer.getWorld().setWorldLevel(level);
+            targetPlayer.setWorldLevel(level);
 
             sender.dropMessage(Grasscutter.getLanguage().SetWorldLevel_set_world_level.replace("{level}", Integer.toString(level)));
         } catch (NumberFormatException ignored) {

--- a/src/main/java/emu/grasscutter/command/commands/SpawnCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SpawnCommand.java
@@ -24,7 +24,7 @@ import java.util.Random;
 public final class SpawnCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (sender == null) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/SpawnCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SpawnCommand.java
@@ -14,6 +14,7 @@ import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.EntityType;
 import emu.grasscutter.game.props.FightProperty;
 import emu.grasscutter.utils.Position;
+import emu.grasscutter.game.world.Scene;
 
 import javax.swing.text.html.parser.Entity;
 import java.util.List;
@@ -25,64 +26,80 @@ public final class SpawnCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (sender == null) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
 
-        if (args.size() < 1) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Spawn_usage);
-            return;
-        }
-
-        try {
-            int id = Integer.parseInt(args.get(0));
-            int amount = args.size() > 1 ? Integer.parseInt(args.get(1)) : 1;
-            int level = args.size() > 2 ? Integer.parseInt(args.get(2)) : 1;
-
-            MonsterData monsterData = GameData.getMonsterDataMap().get(id);
-            GadgetData gadgetData = GameData.getGadgetDataMap().get(id);
-            ItemData itemData = GameData.getItemDataMap().get(id);
-            if (monsterData == null && gadgetData == null && itemData == null) {
-                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_entity_id);
+        int id = 0;  // This is just to shut up the linter, it's not a real default
+        int amount = 1;
+        int level = 1;
+        switch (args.size()) {
+            case 3:
+                try {
+                    level = Integer.parseInt(args.get(2));
+                } catch (NumberFormatException ignored) {
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_arguments);
+                }  // Fallthrough
+            case 2:
+                try {
+                    amount = Integer.parseInt(args.get(1));
+                } catch (NumberFormatException ignored) {
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_amount);
+                }  // Fallthrough
+            case 1:
+                try {
+                    id = Integer.parseInt(args.get(0));
+                } catch (NumberFormatException ignored) {
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_entity_id);
+                }
+                break;
+            default:
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Spawn_usage);
                 return;
-            }
-
-            double maxRadius = Math.sqrt(amount * 0.2 / Math.PI);
-            for (int i = 0; i < amount; i++) {
-                Position pos = GetRandomPositionInCircle(sender.getPos(), maxRadius).addY(3);
-                GameEntity entity = null;
-                if (itemData != null) {
-                    entity = new EntityItem(sender.getScene(), null, itemData, pos, 1, true);
-                }
-                if (gadgetData != null) {
-                    entity = new EntityVehicle(sender.getScene(), sender.getSession().getPlayer(), gadgetData.getId(), 0, pos, sender.getRotation());
-                    int gadgetId = gadgetData.getId();
-                    switch (gadgetId) {
-                        // TODO: Not hardcode this. Waverider (skiff)
-                        case 45001001, 45001002 -> {
-                            entity.addFightProperty(FightProperty.FIGHT_PROP_BASE_HP, 10000);
-                            entity.addFightProperty(FightProperty.FIGHT_PROP_BASE_ATTACK, 100);
-                            entity.addFightProperty(FightProperty.FIGHT_PROP_CUR_ATTACK, 100);
-                            entity.addFightProperty(FightProperty.FIGHT_PROP_CUR_HP, 10000);
-                            entity.addFightProperty(FightProperty.FIGHT_PROP_CUR_DEFENSE, 0);
-                            entity.addFightProperty(FightProperty.FIGHT_PROP_CUR_SPEED, 0);
-                            entity.addFightProperty(FightProperty.FIGHT_PROP_CHARGE_EFFICIENCY, 0);
-                            entity.addFightProperty(FightProperty.FIGHT_PROP_MAX_HP, 10000);
-                        }
-                        default -> {}
-                    }
-                }
-                if (monsterData != null) {
-                    entity = new EntityMonster(sender.getScene(), monsterData, pos, level);
-                }
-
-                sender.getScene().addEntity(entity);
-            }
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Spawn_message.replace("{amount}", Integer.toString(amount)).replace("{id}", Integer.toString(id)));
-        } catch (NumberFormatException ignored) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_entity_id);
         }
+
+        MonsterData monsterData = GameData.getMonsterDataMap().get(id);
+        GadgetData gadgetData = GameData.getGadgetDataMap().get(id);
+        ItemData itemData = GameData.getItemDataMap().get(id);
+        if (monsterData == null && gadgetData == null && itemData == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_entity_id);
+            return;
+        }
+        Scene scene = targetPlayer.getScene();
+
+        double maxRadius = Math.sqrt(amount * 0.2 / Math.PI);
+        for (int i = 0; i < amount; i++) {
+            Position pos = GetRandomPositionInCircle(targetPlayer.getPos(), maxRadius).addY(3);
+            GameEntity entity = null;
+            if (itemData != null) {
+                entity = new EntityItem(scene, null, itemData, pos, 1, true);
+            }
+            if (gadgetData != null) {
+                entity = new EntityVehicle(scene, targetPlayer.getSession().getPlayer(), gadgetData.getId(), 0, pos, targetPlayer.getRotation());  // TODO: does targetPlayer.getSession().getPlayer() have some meaning?
+                int gadgetId = gadgetData.getId();
+                switch (gadgetId) {
+                    // TODO: Not hardcode this. Waverider (skiff)
+                    case 45001001, 45001002 -> {
+                        entity.addFightProperty(FightProperty.FIGHT_PROP_BASE_HP, 10000);
+                        entity.addFightProperty(FightProperty.FIGHT_PROP_BASE_ATTACK, 100);
+                        entity.addFightProperty(FightProperty.FIGHT_PROP_CUR_ATTACK, 100);
+                        entity.addFightProperty(FightProperty.FIGHT_PROP_CUR_HP, 10000);
+                        entity.addFightProperty(FightProperty.FIGHT_PROP_CUR_DEFENSE, 0);
+                        entity.addFightProperty(FightProperty.FIGHT_PROP_CUR_SPEED, 0);
+                        entity.addFightProperty(FightProperty.FIGHT_PROP_CHARGE_EFFICIENCY, 0);
+                        entity.addFightProperty(FightProperty.FIGHT_PROP_MAX_HP, 10000);
+                    }
+                    default -> {}
+                }
+            }
+            if (monsterData != null) {
+                entity = new EntityMonster(scene, monsterData, pos, level);
+            }
+
+            scene.addEntity(entity);
+        }
+        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Spawn_message.replace("{amount}", Integer.toString(amount)).replace("{id}", Integer.toString(id)));
     }
 
     private Position GetRandomPositionInCircle(Position origin, double radius){

--- a/src/main/java/emu/grasscutter/command/commands/StopCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/StopCommand.java
@@ -12,7 +12,7 @@ import java.util.List;
 public final class StopCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         CommandHandler.sendMessage(null, Grasscutter.getLanguage().Stop_message);
         for (Player p : Grasscutter.getGameServer().getPlayers().values()) {
             CommandHandler.sendMessage(p, Grasscutter.getLanguage().Stop_message);

--- a/src/main/java/emu/grasscutter/command/commands/TalentCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TalentCommand.java
@@ -15,11 +15,37 @@ import java.util.List;
 @Command(label = "talent", usage = "talent <talentID> <value>",
         description = "Set talent level for your current active character", permission = "player.settalent")
 public final class TalentCommand implements CommandHandler {
+    private void setTalentLevel(Player sender, Player player, Avatar avatar, int talentId, int talentLevel) {
+        int oldLevel = avatar.getSkillLevelMap().get(talentId);
+        if (talentLevel < 0 || talentLevel > 15) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_lower_16);
+            return;
+        }
+
+        // Upgrade skill
+        avatar.getSkillLevelMap().put(talentLevel, talentLevel);
+        avatar.save();
+
+        // Packet
+        player.sendPacket(new PacketAvatarSkillChangeNotify(avatar, talentId, oldLevel, talentLevel));
+        player.sendPacket(new PacketAvatarSkillUpgradeRsp(avatar, talentId, oldLevel, talentLevel));
+
+        String successMessage = Grasscutter.getLanguage().Talent_set_id.replace("{id}", Integer.toString(talentId));
+        AvatarSkillDepotData depot = avatar.getData().getSkillDepot();
+        if (talentId == depot.getSkills().get(0)) {
+            successMessage = Grasscutter.getLanguage().Talent_set_atk;
+        } else if (talentId == depot.getSkills().get(1)) {
+            successMessage = Grasscutter.getLanguage().Talent_set_e;
+        } else if (talentId == depot.getEnergySkill()) {
+            successMessage = Grasscutter.getLanguage().Talent_set_q;
+        }
+        CommandHandler.sendMessage(sender, successMessage.replace("{level}", Integer.toString(talentLevel)));
+    }
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (sender == null) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
 
@@ -30,6 +56,8 @@ public final class TalentCommand implements CommandHandler {
             return;
         }
 
+        EntityAvatar entity = sender.getTeamManager().getCurrentAvatarEntity();
+        Avatar avatar = entity.getAvatar(); 
         String cmdSwitch = args.get(0);
         switch (cmdSwitch) {
             default:
@@ -38,112 +66,59 @@ public final class TalentCommand implements CommandHandler {
                 CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_usage_3);
             return;
             case "set":
-                    try {
-                        int skillId = Integer.parseInt(args.get(1));
-                        int nextLevel = Integer.parseInt(args.get(2));
-                        EntityAvatar entity = sender.getTeamManager().getCurrentAvatarEntity();
-                        Avatar avatar = entity.getAvatar(); 
-                        int skillIdNorAtk = avatar.getData().getSkillDepot().getSkills().get(0);
-                        int skillIdE = avatar.getData().getSkillDepot().getSkills().get(1);
-                        int skillIdQ = avatar.getData().getSkillDepot().getEnergySkill();
-                        int currentLevelNorAtk = avatar.getSkillLevelMap().get(skillIdNorAtk);
-                        int currentLevelE = avatar.getSkillLevelMap().get(skillIdE);
-                        int currentLevelQ = avatar.getSkillLevelMap().get(skillIdQ);
-                        if (args.size() < 2){
-                            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_usage_1);
-                            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_usage_3);
-                            return;
-                        }
-                        if (nextLevel >= 16){ 
-                            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_lower_16);
-                            return;
-                        }
-                            if (skillId == skillIdNorAtk){ 
-                            // Upgrade skill
-                            avatar.getSkillLevelMap().put(skillIdNorAtk, nextLevel);
-                            avatar.save();
-                
-                            // Packet
-                            sender.sendPacket(new PacketAvatarSkillChangeNotify(avatar, skillIdNorAtk, currentLevelNorAtk, nextLevel));
-                            sender.sendPacket(new PacketAvatarSkillUpgradeRsp(avatar, skillIdNorAtk, currentLevelNorAtk, nextLevel));
-                            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_set_atk.replace("{level}", Integer.toString(nextLevel)));
-                        }    
-                        if (skillId == skillIdE){ 
-                            // Upgrade skill
-                            avatar.getSkillLevelMap().put(skillIdE, nextLevel);
-                            avatar.save();
-                
-                            // Packet
-                            sender.sendPacket(new PacketAvatarSkillChangeNotify(avatar, skillIdE, currentLevelE, nextLevel));
-                            sender.sendPacket(new PacketAvatarSkillUpgradeRsp(avatar, skillIdE, currentLevelE, nextLevel));
-                            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_set_e.replace("{level}", Integer.toString(nextLevel)));
-                        }
-                        if (skillId == skillIdQ){ 
-                            // Upgrade skill
-                            avatar.getSkillLevelMap().put(skillIdQ, nextLevel);
-                            avatar.save();
-                
-                            // Packet
-                            sender.sendPacket(new PacketAvatarSkillChangeNotify(avatar, skillIdQ, currentLevelQ, nextLevel));
-                            sender.sendPacket(new PacketAvatarSkillUpgradeRsp(avatar, skillIdQ, currentLevelQ, nextLevel));
-                            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_set_q.replace("{level}", Integer.toString(nextLevel)));
-                        }       
-                                
-                    } catch (NumberFormatException ignored) {
-                        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_invalid_skill_id);
-                        return;
-                    }
-                
-                break;
-            case "n": case "e": case "q":
+                if (args.size() < 3){
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_usage_1);
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_usage_3);
+                    return;
+                }
+
                 try {
-                    EntityAvatar entity = sender.getTeamManager().getCurrentAvatarEntity();
-                    Avatar avatar = entity.getAvatar();
-                    AvatarSkillDepotData SkillDepot = avatar.getData().getSkillDepot();
-                    int skillId;
-                    switch (cmdSwitch) {
-                        default:
-                            skillId = SkillDepot.getSkills().get(0);
-                            break;
-                        case "e":
-                            skillId = SkillDepot.getSkills().get(1);
-                            break;
-                        case "q":
-                            skillId = SkillDepot.getEnergySkill();
-                            break;
-                    }
-                    int nextLevel = Integer.parseInt(args.get(1));
-                    int currentLevel = avatar.getSkillLevelMap().get(skillId);
-                    if (args.size() < 1){
-                        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_usage_2);
-                        return;
-                    }
-                    if (nextLevel >= 16){
-                        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_lower_16);
-                        return;
-                    }
-                    // Upgrade skill
-                    avatar.getSkillLevelMap().put(skillId, nextLevel);
-                    avatar.save();
-                    // Packet
-                    sender.sendPacket(new PacketAvatarSkillChangeNotify(avatar, skillId, currentLevel, nextLevel));
-                    sender.sendPacket(new PacketAvatarSkillUpgradeRsp(avatar, skillId, currentLevel, nextLevel));
-                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_set_this.replace("{level}", Integer.toString(nextLevel)));
+                    int skillId = Integer.parseInt(args.get(1));
+                    int newLevel = Integer.parseInt(args.get(2));
+                    setTalentLevel(sender, targetPlayer, avatar, skillId, newLevel);
+                } catch (NumberFormatException ignored) {
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_invalid_skill_id);
+                    return;
+                }
+                break;
+            case "n":
+            case "e":
+            case "q":
+                if (args.size() < 2){
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_usage_2);
+                    return;
+                }
+
+                AvatarSkillDepotData SkillDepot = avatar.getData().getSkillDepot();
+                int skillId;
+                switch (cmdSwitch) {
+                    default:
+                        skillId = SkillDepot.getSkills().get(0);
+                        break;
+                    case "e":
+                        skillId = SkillDepot.getSkills().get(1);
+                        break;
+                    case "q":
+                        skillId = SkillDepot.getEnergySkill();
+                        break;
+                }
+
+                try {
+                    int newLevel = Integer.parseInt(args.get(1));
+                    setTalentLevel(sender, targetPlayer, avatar, skillId, newLevel);
                 } catch (NumberFormatException ignored) {
                     CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_invalid_talent_level);
                     return;
                 }
                 break;
-            case "getid":           
-                    EntityAvatar entity = sender.getTeamManager().getCurrentAvatarEntity();
-                    Avatar avatar = entity.getAvatar(); 
-                    int skillIdNorAtk = avatar.getData().getSkillDepot().getSkills().get(0);
-                    int skillIdE = avatar.getData().getSkillDepot().getSkills().get(1);
-                    int skillIdQ = avatar.getData().getSkillDepot().getEnergySkill();
+            case "getid":
+                int skillIdNorAtk = avatar.getData().getSkillDepot().getSkills().get(0);
+                int skillIdE = avatar.getData().getSkillDepot().getSkills().get(1);
+                int skillIdQ = avatar.getData().getSkillDepot().getEnergySkill();
 
-                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_normal_attack_id.replace("{id}", Integer.toString(skillIdNorAtk)));
-                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_e_skill_id.replace("{id}", Integer.toString(skillIdE)));
-                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_q_skill_id.replace("{id}", Integer.toString(skillIdQ)));
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_normal_attack_id.replace("{id}", Integer.toString(skillIdNorAtk)));
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_e_skill_id.replace("{id}", Integer.toString(skillIdE)));
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Talent_q_skill_id.replace("{id}", Integer.toString(skillIdQ)));
                 break;
         }
     }

--- a/src/main/java/emu/grasscutter/command/commands/TalentCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TalentCommand.java
@@ -56,7 +56,7 @@ public final class TalentCommand implements CommandHandler {
             return;
         }
 
-        EntityAvatar entity = sender.getTeamManager().getCurrentAvatarEntity();
+        EntityAvatar entity = targetPlayer.getTeamManager().getCurrentAvatarEntity();
         Avatar avatar = entity.getAvatar(); 
         String cmdSwitch = args.get(0);
         switch (cmdSwitch) {

--- a/src/main/java/emu/grasscutter/command/commands/TalentCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TalentCommand.java
@@ -17,7 +17,7 @@ import java.util.List;
 public final class TalentCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (sender == null) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/TeleportAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TeleportAllCommand.java
@@ -12,7 +12,7 @@ import java.util.List;
         description = "Teleports all players in your world to your position", permission = "player.tpall")
 public final class TeleportAllCommand implements CommandHandler {
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (sender == null) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/TeleportAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TeleportAllCommand.java
@@ -13,22 +13,22 @@ import java.util.List;
 public final class TeleportAllCommand implements CommandHandler {
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (sender == null) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
         
-        if (!sender.getWorld().isMultiplayer()) {
+        if (!targetPlayer.getWorld().isMultiplayer()) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().TeleportAll_message);
             return;
         }
         
-        for (Player player : sender.getWorld().getPlayers()) {
-            if (player.equals(sender))
+        for (Player player : targetPlayer.getWorld().getPlayers()) {
+            if (player.equals(targetPlayer))
                 continue;
-            Position pos = sender.getPos();
+            Position pos = targetPlayer.getPos();
 
-            player.getWorld().transferPlayerToScene(player, sender.getSceneId(), pos);
+            player.getWorld().transferPlayerToScene(player, targetPlayer.getSceneId(), pos);
         }
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/TeleportCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TeleportCommand.java
@@ -8,83 +8,62 @@ import emu.grasscutter.utils.Position;
 
 import java.util.List;
 
-@Command(label = "teleport", usage = "teleport [@player id] <x> <y> <z> [scene id]", aliases = {"tp"},
+@Command(label = "teleport", usage = "teleport <x> <y> <z> [scene id]", aliases = {"tp"},
         description = "Change the player's position.", permission = "player.teleport")
 public final class TeleportCommand implements CommandHandler {
 
+    private float parseRelative(String input, Float current) {  // TODO: Maybe this will be useful elsewhere later
+        if (input.contains("~")) {  // Relative
+            if (!input.equals("~")) {  // Relative with offset
+                current += Float.parseFloat(input.replace("~", ""));
+            }  // Else no offset, no modification
+        } else {  // Absolute
+            current = Float.parseFloat(input);
+        }
+        return current;
+    }
+
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        int target;
-        if (args.size() < (sender == null ? 4 : 3)) {
-            CommandHandler.sendMessage(sender, sender == null ? Grasscutter.getLanguage().Teleport_usage_server :
-                    Grasscutter.getLanguage().Teleport_usage);
-            return;
-        }
-        if (args.get(0).startsWith("@")) {
-            try {
-                target = Integer.parseInt(args.get(0).substring(1));
-            } catch (NumberFormatException e) {
-                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_playerId);
-                return;
-            }
-        } else {
-            if (sender == null) {
-                CommandHandler.sendMessage(null, Grasscutter.getLanguage().Teleport_specify_player_id);
-                return;
-            }
-            target = sender.getUid();
-        }
-
         if (targetPlayer == null) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found_or_offline);
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
-        args = args.subList(args.get(0).startsWith("@") ? 1 : 0, args.size());
 
-        try {
-            float x = 0f;
-            float y = 0f;
-            float z = 0f;
-            if (args.get(0).contains("~")) {
-                if (args.get(0).equals("~")) {
-                    x = targetPlayer.getPos().getX();
-                } else {
-                    x = Float.parseFloat(args.get(0).replace("~", "")) + targetPlayer.getPos().getX();
+        Position pos = targetPlayer.getPos();
+        float x = pos.getX();
+        float y = pos.getY();
+        float z = pos.getZ();
+        int sceneId = targetPlayer.getSceneId();
+
+        switch (args.size()) {
+            case 4:
+                try {
+                    sceneId = Integer.parseInt(args.get(3));
+                }catch (NumberFormatException ignored) {
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Invalid_arguments);
+                }  // Fallthrough
+            case 3:
+                try {
+                    x = parseRelative(args.get(0), x);
+                    y = parseRelative(args.get(0), y);
+                    z = parseRelative(args.get(0), z);
+                } catch (NumberFormatException ignored) {
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Teleport_invalid_position);
                 }
-            } else {
-                x = Float.parseFloat(args.get(0));
-            }
-            if (args.get(1).contains("~")) {
-                if (args.get(1).equals("~")) {
-                    y = targetPlayer.getPos().getY();
-                } else {
-                    y = Float.parseFloat(args.get(1).replace("~", "")) + targetPlayer.getPos().getY();
-                }
-            } else {
-                y = Float.parseFloat(args.get(1));
-            }
-            if (args.get(2).contains("~")) {
-                if (args.get(2).equals("~")) {
-                    z = targetPlayer.getPos().getZ();
-                } else {
-                    z = Float.parseFloat(args.get(2).replace("~", "")) + targetPlayer.getPos().getZ();
-                }
-            } else {
-                z = Float.parseFloat(args.get(2));
-            }
-            int sceneId = targetPlayer.getSceneId();
-            if (args.size() == 4){
-                sceneId = Integer.parseInt(args.get(3));
-            }
-            Position target_pos = new Position(x, y, z);
-            boolean result = targetPlayer.getWorld().transferPlayerToScene(targetPlayer, sceneId, target_pos);
-            if (!result) {
-                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Teleport_invalid_position);
-            } else {
-                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Teleport_message.replace("{name}", targetPlayer.getNickname()).replace("{x}", Float.toString(x)).replace("{y}", Float.toString(y)).replace("{z}", Float.toString(z)).replace("{id}", Integer.toString(sceneId)));
-            }
-        } catch (NumberFormatException ignored) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Teleport_invalid_position);
+                break;
+            default:
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Teleport_usage);
+                return;
         }
+
+        Position target_pos = new Position(x, y, z);
+        boolean result = targetPlayer.getWorld().transferPlayerToScene(targetPlayer, sceneId, target_pos);
+        if (!result) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Teleport_invalid_position);
+        } else {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Teleport_message.replace("{name}", targetPlayer.getNickname()).replace("{x}", Float.toString(x)).replace("{y}", Float.toString(y)).replace("{z}", Float.toString(z)).replace("{id}", Integer.toString(sceneId)));
+        }
+
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/TeleportCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TeleportCommand.java
@@ -46,8 +46,8 @@ public final class TeleportCommand implements CommandHandler {
             case 3:
                 try {
                     x = parseRelative(args.get(0), x);
-                    y = parseRelative(args.get(0), y);
-                    z = parseRelative(args.get(0), z);
+                    y = parseRelative(args.get(1), y);
+                    z = parseRelative(args.get(2), z);
                 } catch (NumberFormatException ignored) {
                     CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Teleport_invalid_position);
                 }

--- a/src/main/java/emu/grasscutter/command/commands/TeleportCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TeleportCommand.java
@@ -13,7 +13,7 @@ import java.util.List;
 public final class TeleportCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         int target;
         if (args.size() < (sender == null ? 4 : 3)) {
             CommandHandler.sendMessage(sender, sender == null ? Grasscutter.getLanguage().Teleport_usage_server :
@@ -35,7 +35,6 @@ public final class TeleportCommand implements CommandHandler {
             target = sender.getUid();
         }
 
-        Player targetPlayer = Grasscutter.getGameServer().getPlayerByUid(target);
         if (targetPlayer == null) {
             CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Player_not_found_or_offline);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/WeatherCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/WeatherCommand.java
@@ -43,9 +43,9 @@ public final class WeatherCommand implements CommandHandler {
 
         ClimateType climate = ClimateType.getTypeByValue(climateId);
 
-        sender.getScene().setWeather(weatherId);
-        sender.getScene().setClimate(climate);
-        sender.getScene().broadcastPacket(new PacketSceneAreaWeatherNotify(sender));
+        targetPlayer.getScene().setWeather(weatherId);
+        targetPlayer.getScene().setClimate(climate);
+        targetPlayer.getScene().broadcastPacket(new PacketSceneAreaWeatherNotify(targetPlayer));
         CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Weather_message.replace("{weatherId}", Integer.toString(weatherId)).replace("{climateId}", Integer.toString(climateId)));
 
     }

--- a/src/main/java/emu/grasscutter/command/commands/WeatherCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/WeatherCommand.java
@@ -15,28 +15,38 @@ public final class WeatherCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (sender == null) {
-            CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Target_needed);
             return;
         }
 
-        if (args.size() < 1) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Weather_usage);
-            return;
+        int weatherId = 0;
+        int climateId = 1;
+        switch (args.size()) {
+            case 2:
+                try {
+                    climateId = Integer.parseInt(args.get(1));
+                } catch (NumberFormatException ignored) {
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Weather_invalid_id);
+                }
+            case 1:
+                try {
+                    weatherId = Integer.parseInt(args.get(0));
+                } catch (NumberFormatException ignored) {
+                    CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Weather_invalid_id);
+                }
+                break;
+            default:
+                CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Weather_usage);
+                return;
         }
 
-        try {
-            int weatherId = Integer.parseInt(args.get(0));
-            int climateId = args.size() > 1 ? Integer.parseInt(args.get(1)) : 1;
+        ClimateType climate = ClimateType.getTypeByValue(climateId);
 
-            ClimateType climate = ClimateType.getTypeByValue(climateId);
+        sender.getScene().setWeather(weatherId);
+        sender.getScene().setClimate(climate);
+        sender.getScene().broadcastPacket(new PacketSceneAreaWeatherNotify(sender));
+        CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Weather_message.replace("{weatherId}", Integer.toString(weatherId)).replace("{climateId}", Integer.toString(climateId)));
 
-            sender.getScene().setWeather(weatherId);
-            sender.getScene().setClimate(climate);
-            sender.getScene().broadcastPacket(new PacketSceneAreaWeatherNotify(sender));
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Weather_message.replace("{weatherId}", Integer.toString(weatherId)).replace("{climateId}", Integer.toString(climateId)));
-        } catch (NumberFormatException ignored) {
-            CommandHandler.sendMessage(sender, Grasscutter.getLanguage().Weather_invalid_id);
-        }
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/WeatherCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/WeatherCommand.java
@@ -14,7 +14,7 @@ import java.util.List;
 public final class WeatherCommand implements CommandHandler {
 
     @Override
-    public void execute(Player sender, List<String> args) {
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (sender == null) {
             CommandHandler.sendMessage(null, Grasscutter.getLanguage().Run_this_command_in_game);
             return;

--- a/src/main/java/emu/grasscutter/game/managers/ChatManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/ChatManager.java
@@ -34,7 +34,7 @@ public class ChatManager {
 				
 		// Check if command
 		if (PREFIXES.contains(message.charAt(0))) {
-			CommandMap.getInstance().invoke(player, target, message);
+			CommandMap.getInstance().invoke(player, target, message.substring(1));
 			return;
 		}
 		

--- a/src/main/java/emu/grasscutter/game/managers/ChatManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/ChatManager.java
@@ -28,15 +28,15 @@ public class ChatManager {
 		if (message == null || message.length() == 0) {
 			return;
 		}
-				
-		// Check if command
-		if (PREFIXES.contains(message.charAt(0))) {
-			CommandMap.getInstance().invoke(player, message);
-			return;
-		}
 		
 		// Get target
 		Player target = getServer().getPlayerByUid(targetUid);
+				
+		// Check if command
+		if (PREFIXES.contains(message.charAt(0))) {
+			CommandMap.getInstance().invoke(player, target, message);
+			return;
+		}
 		
 		if (target == null) {
 			return;
@@ -72,7 +72,7 @@ public class ChatManager {
 				
 		// Check if command
 		if (PREFIXES.contains(message.charAt(0))) {
-			CommandMap.getInstance().invoke(player, message);
+			CommandMap.getInstance().invoke(player, null, message);
 			return;
 		}
 

--- a/src/main/java/emu/grasscutter/languages/Language.java
+++ b/src/main/java/emu/grasscutter/languages/Language.java
@@ -58,6 +58,8 @@ public final class Language {
     public String Invalid_arguments = "Invalid arguments.";
     public String Success = "Success";
     public String Invalid_entity_id = "Invalid entity id.";
+    public String Target_cleared = "Target cleared.";
+    public String Target_set = "Subsequent commands will target @{uid} by default.";
 
     // Help
     public String Help_usage = "   Usage: ";
@@ -215,8 +217,6 @@ public final class Language {
         \t(cont.) Elemental RES: respyro | rescryo | reshydro | resgeo | resdendro | reselectro | resphys
         """;
     public String SetStats_value_error = "Invalid stat value.";
-    public String SetStats_uid_error = "Invalid UID.";
-    public String SetStats_player_error = "Player not found or offline.";
     public String SetStats_set_self = "{name} set to {value}.";
     public String SetStats_set_for_uid = "{name} for {uid} set to {value}.";
     public String Stats_FIGHT_PROP_MAX_HP = "Max HP";

--- a/src/main/java/emu/grasscutter/languages/Language.java
+++ b/src/main/java/emu/grasscutter/languages/Language.java
@@ -45,21 +45,28 @@ public final class Language {
     public String You_not_permission_run_command = "You do not have permission to run this command.";
     public String This_command_can_only_run_from_console = "This command can only be run from the console.";
     public String Run_this_command_in_game = "Run this command in-game.";
+    public String Invalid_amount = "Invalid amount.";
+    public String Invalid_arguments = "Invalid arguments.";
+    public String Invalid_artifact_id = "Invalid artifact ID.";
+    public String Invalid_avatar_id = "Invalid avatar id.";
+    public String Invalid_avatar_level = "Invalid avatar level.";
+    public String Invalid_entity_id = "Invalid entity id.";
+    public String Invalid_item_id = "Invalid item id.";
+    public String Invalid_item_level = "Invalid item level.";
+    public String Invalid_item_refinement = "Invalid item refinement level.";
     public String Invalid_playerId = "Invalid playerId.";
+    public String Invalid_UID = "Invalid UID.";
     public String Player_not_found = "Player not found.";
     public String Player_is_offline = "Player is offline.";
-    public String Invalid_item_id = "Invalid item id.";
-    public String Invalid_item_or_player_id = "Invalid item or player ID.";
     public String Enabled = "enabled";
     public String Disabled = "disabled";
     public String No_command_found = "No command found.";
     public String Help = "Help";
     public String Player_not_found_or_offline = "Player not found or offline.";
-    public String Invalid_arguments = "Invalid arguments.";
     public String Success = "Success";
-    public String Invalid_entity_id = "Invalid entity id.";
     public String Target_cleared = "Target cleared.";
     public String Target_set = "Subsequent commands will target @{uid} by default.";
+    public String Target_needed = "This command requires a target UID. Add a <@UID> argument or set a persistent target with /target @UID.";
 
     // Help
     public String Help_usage = "   Usage: ";
@@ -68,7 +75,6 @@ public final class Language {
 
     // Account
     public String Modify_user_account = "Modify user accounts";
-    public String Invalid_UID = "Invalid UID.";
     public String Account_exists = "Account already exists.";
     public String Account_create_UID = "Account created with UID {uid}.";
     public String Account_delete = "Account deleted.";
@@ -86,6 +92,7 @@ public final class Language {
     public String Change_screen_not_exist = "Scene does not exist";
 
     // Clear
+    public String Clear_usage = "Usage: clear <all|wp|art|mat>";
     public String Clear_weapons = "Cleared weapons for {name} .";
     public String Clear_artifacts = "Cleared artifacts for {name} .";
     public String Clear_materials = "Cleared materials for {name} .";
@@ -95,7 +102,8 @@ public final class Language {
     public String Clear_everything = "Cleared everything for {name} .";
 
     // Coop
-    public String Coop_usage = "Usage: coop <playerId> <target playerId>";
+    public String Coop_usage = "Usage: coop <host UID>";
+    public String Coop_success = "Summoned {target} to {host}'s world.";
 
     // Drop
     public String Drop_usage = "Usage: drop <itemId|itemName> [amount]";
@@ -108,22 +116,17 @@ public final class Language {
     public String EnterDungeon_you_in_that_dungeon = "You are already in that dungeon";
 
     // GiveAll
-    public String GiveAll_usage = "Usage: giveall [player] [amount]";
+    public String GiveAll_usage = "Usage: giveall [amount]";
     public String GiveAll_item = "Giving all items...";
     public String GiveAll_done = "Giving all items done";
-    public String GiveAll_invalid_amount_or_playerId = "Invalid amount or player ID.";
 
     // GiveArtifact
     public String GiveArtifact_usage = "Usage: giveart|gart [player] <artifactId> <mainPropId> [<appendPropId>[,<times>]]... [level]";
-    public String GiveArtifact_invalid_artifact_id = "Invalid artifact ID.";
     public String GiveArtifact_given = "Given {itemId} to {target}.";
 
     // GiveChar
     public String GiveChar_usage = "Usage: givechar <player> <itemId|itemName> [amount]";
     public String GiveChar_given = "Given {avatarId} with level {level} to {target}.";
-    public String GiveChar_invalid_avatar_id = "Invalid avatar id.";
-    public String GiveChar_invalid_avatar_level = "Invalid avatar level.";
-    public String GiveChar_invalid_avatar_or_player_id = "Invalid avatar or player ID.";
 
     // Give
     public String Give_usage = "Usage: give <player> <itemId|itemName> [amount] [level]";
@@ -134,7 +137,8 @@ public final class Language {
     public String Give_given_level = "Given {item} with level {lvl} {amount} times to {target}";
 
     // GodMode
-    public String Godmode_status = "Godmode is now {status} for {name} .";
+    public String Godmode_usage = "Usage: godmode [on|off|toggle]";
+    public String Godmode_status = "Godmode is now {status} for {name}.";
 
     // Heal
     public String Heal_message = "All characters have been healed.";
@@ -156,7 +160,7 @@ public final class Language {
     public String List_message = "There are {size} player(s) online:";
 
     // Permission
-    public String Permission_usage = "Usage: permission <add|remove> <username> <permission>";
+    public String Permission_usage = "Usage: permission <add|remove> <permission>";
     public String Permission_add = "Permission added.";
     public String Permission_have_permission = "They already have this permission!";
     public String Permission_remove = "Permission removed.";
@@ -270,6 +274,7 @@ public final class Language {
     public String Talent_usage_2 = "Another way to set talent level: /talent <n or e or q> <value>";
     public String Talent_usage_3 = "To get talent ID: /talent getid";
     public String Talent_lower_16 = "Invalid talent level. Level should be lower than 16";
+    public String Talent_set_id = "Set talent {id} to {level}.";
     public String Talent_set_atk = "Set talent Normal ATK to {level}.";
     public String Talent_set_e = "Set talent E to {level}.";
     public String Talent_set_q = "Set talent Q to {level}.";
@@ -284,9 +289,7 @@ public final class Language {
     public String TeleportAll_message = "You only can use this command in MP mode.";
 
     // Teleport
-    public String Teleport_usage_server = "Usage: /tp @<player id> <x> <y> <z> [scene id]";
-    public String Teleport_usage = "Usage: /tp [@<player id>] <x> <y> <z> [scene id]";
-    public String Teleport_specify_player_id = "You must specify a player id.";
+    public String Teleport_usage = "Usage: /tp <x> <y> <z> [scene id]";
     public String Teleport_invalid_position = "Invalid position.";
     public String Teleport_message = "Teleported {name} to {x},{y},{z} in scene {id}";
 


### PR DESCRIPTION
Thanks @Melledy for the previous merge :)

This is an incomplete rework of the commands system to introduce the concept of a `targetPlayer` for all commands to make use of.
If the syntax is acceptable, I'll go ahead and fix all the Commands to use it.

- Any argument starting with `@` will be treated as a target player UID, for any command. This argument will be deleted from the list and commands won't see it. This has the highest priority.
- If messaging in-game, you can direct message commands to other players with the usual prefixes and they will be the `targetPlayer`.
- Using the command `/target [UID]` will set the default `targetPlayer` for all future commands to `UID`, or delete this default if none is given.
- If none of the above give a `targetPlayer`, the sender will be used, or `null` for commands entered in the console. It is up to individual commands to complain about no `targetPlayer` being present if they cannot be run from the console without a targeted player.
- Players targeting other players in-game may require additional permissions on a per-command basis. This does not apply to the console.

Examples:
`stats @10001 hp 100`: under all circumstances, this targets player with UID `10001`.

Set a target player and do multiple commands on them from the console:
```
target 10001
stats maxhp 500
stats hp 500
stats respyro 35%
```

Do the same in-game and then something to yourself:
```
!target 10002
!stats maxhp 500
!stats hp 500
!stats respyro 35%
!target
!giveall
```

Also works with `@[UID]` instead of `target [UID]`
```
@10001
killall
teleport 0 0 0
@
```