### PR TITLE
Dungeon challenge success/fail notify should only be triggered once

### DIFF
--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonChallenge.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonChallenge.java
@@ -140,7 +140,7 @@ public class DungeonChallenge {
 		
 		getScene().broadcastPacket(new PacketChallengeDataNotify(this, 1, getScore()));
 		
-		if (getScore() >= getObjective()) {
+		if (getScore() >= getObjective() && this.progress) {
 			this.setSuccess(true);
 			finish();
 		}


### PR DESCRIPTION
when server spawned mob more than score (such as Domain of Blessing: Dance of Steel I)