### PR TITLE
GiveCommand: fix edge case with unspaced multiple args

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/GiveCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveCommand.java
@@ -20,7 +20,7 @@ import java.util.regex.Matcher;
 public final class GiveCommand implements CommandHandler {
     Pattern lvlRegex = Pattern.compile("l(?:vl?)?(\\d+)");  // Java is a joke of a proglang that doesn't have raw string literals
     Pattern refineRegex = Pattern.compile("r(\\d+)");
-    Pattern amountRegex = Pattern.compile("((?<=x)\\d+|\\d+(?=x))");
+    Pattern amountRegex = Pattern.compile("((?<=x)\\d+|\\d+(?=x)(?!x\\d))");
 
     private int matchIntOrNeg(Pattern pattern, String arg) {
         Matcher match = pattern.matcher(arg);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5397662/166878194-ea586e9d-80a4-4357-a7c9-b4debcdc0ae1.png)

Also noticed r0 is default which seems weird but doesn't seem to matter for real weapons so I didn't change that.
![image](https://user-images.githubusercontent.com/5397662/166878274-7a486447-e11c-4c31-a7c9-dee60bdbaace.png)
