### PR TITLE
Enable language option for `Tools`

### DIFF
--- a/src/main/java/emu/grasscutter/tools/Tools.java
+++ b/src/main/java/emu/grasscutter/tools/Tools.java
@@ -1,10 +1,12 @@
 package emu.grasscutter.tools;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.io.FilenameFilter;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -30,13 +32,73 @@ import emu.grasscutter.data.def.SceneData;
 import emu.grasscutter.utils.Utils;
 
 public final class Tools {
-	
-	@SuppressWarnings("deprecation")
 	public static void createGmHandbook() throws Exception {
+		ToolsWithLanguageOption.createGmHandbook(getLanguageOption());
+	}
+
+	public static void createGachaMapping(String location) throws Exception {
+		ToolsWithLanguageOption.createGachaMapping(location, getLanguageOption());
+	}
+
+	public static List<String> getAvailableLanguage() throws Exception {
+		File textMapFolder = new File(Grasscutter.getConfig().RESOURCE_FOLDER + "TextMap");
+		List<String> availableLangList = new ArrayList<String>();
+		for (String textMapFileName : textMapFolder.list(new FilenameFilter() {
+			@Override
+			public boolean accept(File dir, String name) {
+				if (name.startsWith("TextMap") && name.endsWith(".json")){
+					return true;
+				}
+				return false;
+			}
+		})) {
+			availableLangList.add(textMapFileName.replace("TextMap","").replace(".json","").toLowerCase());
+		}
+		return availableLangList;
+	}
+
+	public static String getLanguageOption() throws Exception {
+		List<String> availableLangList = getAvailableLanguage();
+	
+		// Use system out for better format
+		if (availableLangList.size() == 1) {
+			return availableLangList.get(0).toUpperCase();
+		}
+		System.out.println("The following languages mappings are available, please select one: [default: EN]");
+		String groupedLangList = "> ";
+		int groupedLangCount = 0;
+		String input = "";
+		for (String availableLanguage: availableLangList){
+			groupedLangCount++;
+			groupedLangList = groupedLangList + "" + availableLanguage + "\t";
+			if (groupedLangCount == 6) {
+				System.out.println(groupedLangList);
+				groupedLangCount = 0;
+				groupedLangList = "> ";
+			}
+		}
+		if (groupedLangCount > 0) {
+			System.out.println(groupedLangList);
+		}
+		System.out.print("\nYour choice:[EN]");
+
+		input = new BufferedReader(new InputStreamReader(System.in)).readLine();
+		if (availableLangList.contains(input.toLowerCase())) {
+			return input.toUpperCase();
+		}
+		Grasscutter.getLogger().info("Invalid option. Will use EN(English) as fallback");
+
+		return "EN";
+	}
+}
+
+final class ToolsWithLanguageOption {
+	@SuppressWarnings("deprecation")
+	public static void createGmHandbook(String language) throws Exception {
 		ResourceLoader.loadResources();
 		
 		Map<Long, String> map;
-		try (InputStreamReader fileReader = new InputStreamReader(new FileInputStream(Utils.toFilePath(Grasscutter.getConfig().RESOURCE_FOLDER + "TextMap/TextMapEN.json")), StandardCharsets.UTF_8)) {
+		try (InputStreamReader fileReader = new InputStreamReader(new FileInputStream(Utils.toFilePath(Grasscutter.getConfig().RESOURCE_FOLDER + "TextMap/TextMap"+language+".json")), StandardCharsets.UTF_8)) {
 			map = Grasscutter.getGsonFactory().fromJson(fileReader, new TypeToken<Map<Long, String>>() {}.getType());
 		}
 		
@@ -96,11 +158,11 @@ public final class Tools {
 	}
 
 	@SuppressWarnings("deprecation")
-	public static void createGachaMapping(String location) throws Exception {
+	public static void createGachaMapping(String location, String language) throws Exception {
 		ResourceLoader.loadResources();
 		
 		Map<Long, String> map;
-		try (InputStreamReader fileReader = new InputStreamReader(new FileInputStream(Utils.toFilePath(Grasscutter.getConfig().RESOURCE_FOLDER + "TextMap/TextMapEN.json")), StandardCharsets.UTF_8)) {
+		try (InputStreamReader fileReader = new InputStreamReader(new FileInputStream(Utils.toFilePath(Grasscutter.getConfig().RESOURCE_FOLDER + "TextMap/TextMap"+language+".json")), StandardCharsets.UTF_8)) {
 			map = Grasscutter.getGsonFactory().fromJson(fileReader, new TypeToken<Map<Long, String>>() {}.getType());
 		}
 		
@@ -113,6 +175,9 @@ public final class Tools {
 			list = new ArrayList<>(GameData.getAvatarDataMap().keySet());
 			Collections.sort(list); 
 			 
+			// if the user made choices for language, I assume it's okay to assign his/her selected language to "en-us"
+			// since it's the fallback language and there will be no difference in the gacha record page. 
+			// The enduser can still modify the `gacha_mappings.js` directly to enable multilingual for the gacha record system.
 			writer.println("mappings = {\"en-us\": {"); 
 
 			// Avatars
@@ -140,10 +205,10 @@ public final class Tools {
 					default:
 						color = "blue";
 				}
-				
+				// Got the magic number 4233146695 from manually search in the json file
 				writer.println(
 					"\"" + (avatarID % 1000 + 1000) + "\" : [\"" 
-					+ map.get(data.getNameTextMapHash()) + "(Avatar)\", \"" 
+					+ map.get(data.getNameTextMapHash()) + "(" +  map.get(4233146695L)+ ")\", \"" 
 					+ color + "\"]");
 			}
 			
@@ -173,9 +238,12 @@ public final class Tools {
 					default:
 						continue; // skip unnecessary entries
 				}
+				
+				// Got the magic number 4231343903 from manually search in the json file
+
 				writer.println(",\"" + data.getId() +
 						 "\" : [\"" + map.get(data.getNameTextMapHash()).replaceAll("\"", "")
-						 + "(Weapon)\",\""+ color + "\"]");
+						 + "("+ map.get(4231343903L)+")\",\""+ color + "\"]");
 			}
 			writer.println(",\"200\": \"Standard\", \"301\": \"Avatar Event\", \"302\": \"Weapon event\"");
 			writer.println("}\n}");

--- a/src/main/java/emu/grasscutter/tools/Tools.java
+++ b/src/main/java/emu/grasscutter/tools/Tools.java
@@ -245,7 +245,7 @@ final class ToolsWithLanguageOption {
 						 "\" : [\"" + map.get(data.getNameTextMapHash()).replaceAll("\"", "")
 						 + "("+ map.get(4231343903L)+")\",\""+ color + "\"]");
 			}
-			writer.println(",\"200\": \"Standard\", \"301\": \"Avatar Event\", \"302\": \"Weapon event\"");
+			writer.println(",\"200\": \""+map.get(332935371L)+"\", \"301\": \""+ map.get(2272170627L) + "\", \"302\": \""+map.get(2864268523L)+"\"");
 			writer.println("}\n}");
 		}
 		Grasscutter.getLogger().info("Mappings generated!");

--- a/src/main/java/emu/grasscutter/tools/Tools.java
+++ b/src/main/java/emu/grasscutter/tools/Tools.java
@@ -80,7 +80,7 @@ public final class Tools {
 		if (groupedLangCount > 0) {
 			System.out.println(groupedLangList);
 		}
-		System.out.print("\nYour choice:[EN]");
+		System.out.print("\nYour choice:[EN] ");
 
 		input = new BufferedReader(new InputStreamReader(System.in)).readLine();
 		if (availableLangList.contains(input.toLowerCase())) {


### PR DESCRIPTION
Now the following items is capable of generating based on user selected languages.

* GM Handbook
* Gacha Map

<img width="729" alt="image" src="https://user-images.githubusercontent.com/15214491/167069818-cf1fc9c0-d7b4-445f-84e8-2a22f0c71826.png">
<img width="741" alt="image" src="https://user-images.githubusercontent.com/15214491/167070156-86f2446c-f6fa-4d14-b8a5-98e969d97da9.png">

Example for GM Handbook.txt in `ru` option:
<img width="348" alt="image" src="https://user-images.githubusercontent.com/15214491/167070257-f415aedb-d1e2-4eeb-99ca-1d34bfffb633.png">
