### PR TITLE
Target permissions

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/ChangeSceneCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ChangeSceneCommand.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "changescene", usage = "changescene <scene id>", aliases = {"scene"}, permission = "player.changescene", description = "commands.changescene.description")
+@Command(label = "changescene", usage = "changescene <scene id>", aliases = {"scene"}, permission = "player.changescene", permissionTargeted = "player.changescene.others", description = "commands.changescene.description")
 public final class ChangeSceneCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/ClearCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ClearCommand.java
@@ -14,7 +14,7 @@ import static emu.grasscutter.utils.Language.translate;
 
 @Command(label = "clear", usage = "clear <all|wp|art|mat>", //Merged /clearartifacts and /clearweapons to /clear <args> [uid]
         description = "commands.clear.description",
-        aliases = {"clear"}, permission = "player.clearinv")
+        aliases = {"clear"}, permission = "player.clearinv", permissionTargeted = "player.clearinv.others")
 
 public final class ClearCommand implements CommandHandler {
 

--- a/src/main/java/emu/grasscutter/command/commands/CoopCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/CoopCommand.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "coop", usage = "coop [host UID]", permission = "server.coop", description = "commands.coop.description")
+@Command(label = "coop", usage = "coop [host UID]", permission = "server.coop", permissionTargeted = "server.coop.others", description = "commands.coop.description")
 public final class CoopCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/DropCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/DropCommand.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "drop", usage = "drop <itemId|itemName> [amount]", aliases = {"d", "dropitem"}, permission = "server.drop", description = "commands.drop.description")
+@Command(label = "drop", usage = "drop <itemId|itemName> [amount]", aliases = {"d", "dropitem"}, permission = "server.drop", permissionTargeted = "server.drop.others", description = "commands.drop.description")
 public final class DropCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/EnterDungeonCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/EnterDungeonCommand.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "enterdungeon", usage = "enterdungeon <dungeon id>", aliases = {"dungeon"}, permission = "player.enterdungeon", description = "commands.enter_dungeon.description")
+@Command(label = "enterdungeon", usage = "enterdungeon <dungeon id>", aliases = {"dungeon"}, permission = "player.enterdungeon", permissionTargeted = "player.enterdungeon.others", description = "commands.enter_dungeon.description")
 public final class EnterDungeonCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/GiveAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveAllCommand.java
@@ -15,7 +15,7 @@ import java.util.*;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "giveall", usage = "giveall [amount]", aliases = {"givea"}, permission = "player.giveall", threading = true, description = "commands.giveAll.description")
+@Command(label = "giveall", usage = "giveall [amount]", aliases = {"givea"}, permission = "player.giveall", permissionTargeted = "player.giveall.others", threading = true, description = "commands.giveAll.description")
 public final class GiveAllCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
@@ -19,7 +19,7 @@ import static java.util.Map.entry;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "giveart", usage = "giveart <artifactId> <mainPropId> [<appendPropId>[,<times>]]... [level]", aliases = {"gart"}, permission = "player.giveart", description = "commands.giveArtifact.description")
+@Command(label = "giveart", usage = "giveart <artifactId> <mainPropId> [<appendPropId>[,<times>]]... [level]", aliases = {"gart"}, permission = "player.giveart", permissionTargeted = "player.giveart.others", description = "commands.giveArtifact.description")
 public final class GiveArtifactCommand implements CommandHandler {
 	private static final Map<String, Map<EquipType, Integer>> mainPropMap = Map.ofEntries(
 		entry("hp", Map.ofEntries(entry(EquipType.EQUIP_BRACER, 14001))),

--- a/src/main/java/emu/grasscutter/command/commands/GiveCharCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveCharCommand.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "givechar", usage = "givechar <avatarId> [level]", aliases = {"givec"}, permission = "player.givechar", description = "commands.giveChar.description")
+@Command(label = "givechar", usage = "givechar <avatarId> [level]", aliases = {"givec"}, permission = "player.givechar", permissionTargeted = "player.givechar.others", description = "commands.giveChar.description")
 public final class GiveCharCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/GiveCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveCommand.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 import static emu.grasscutter.utils.Language.translate;
 
 @Command(label = "give", usage = "give <itemId|itemName> [amount] [level]", aliases = {
-        "g", "item", "giveitem"}, permission = "player.give", description = "commands.give.description")
+        "g", "item", "giveitem"}, permission = "player.give", description = "commands.give.description", permissionTargeted = "player.give.others")
 public final class GiveCommand implements CommandHandler {
     Pattern lvlRegex = Pattern.compile("l(?:vl?)?(\\d+)");  // Java is a joke of a proglang that doesn't have raw string literals
     Pattern refineRegex = Pattern.compile("r(\\d+)");

--- a/src/main/java/emu/grasscutter/command/commands/GiveCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveCommand.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 import static emu.grasscutter.utils.Language.translate;
 
 @Command(label = "give", usage = "give <itemId|itemName> [amount] [level]", aliases = {
-        "g", "item", "giveitem"}, permission = "player.give", description = "commands.give.description", permissionTargeted = "player.give.others")
+        "g", "item", "giveitem"}, permission = "player.give", permissionTargeted = "player.give.others", description = "commands.give.description")
 public final class GiveCommand implements CommandHandler {
     Pattern lvlRegex = Pattern.compile("l(?:vl?)?(\\d+)");  // Java is a joke of a proglang that doesn't have raw string literals
     Pattern refineRegex = Pattern.compile("r(\\d+)");

--- a/src/main/java/emu/grasscutter/command/commands/GodModeCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GodModeCommand.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "godmode", usage = "godmode [on|off|toggle]", permission = "player.godmode", description = "commands.godmode.description")
+@Command(label = "godmode", usage = "godmode [on|off|toggle]", permission = "player.godmode", permissionTargeted = "player.godmode.others", description = "commands.godmode.description")
 public final class GodModeCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/HealCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/HealCommand.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "heal", usage = "heal|h", aliases = {"h"}, permission = "player.heal", description = "commands.heal.description")
+@Command(label = "heal", usage = "heal|h", aliases = {"h"}, permission = "player.heal", permissionTargeted = "player.heal.others", description = "commands.heal.description")
 public final class HealCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/KillAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/KillAllCommand.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "killall", usage = "killall [sceneId]", permission = "server.killall", description = "commands.kill.description")
+@Command(label = "killall", usage = "killall [sceneId]", permission = "server.killall", permissionTargeted = "server.killall.others", description = "commands.kill.description")
 public final class KillAllCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/KillCharacterCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/KillCharacterCommand.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "killcharacter", usage = "killcharacter", aliases = {"suicide", "kill"}, permission = "player.killcharacter", description = "commands.list.description")
+@Command(label = "killcharacter", usage = "killcharacter", aliases = {"suicide", "kill"}, permission = "player.killcharacter", permissionTargeted = "player.killcharacter.others", description = "commands.list.description")
 public final class KillCharacterCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/ResetConstCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ResetConstCommand.java
@@ -11,7 +11,7 @@ import java.util.List;
 import static emu.grasscutter.utils.Language.translate;
 
 @Command(label = "resetconst", usage = "resetconst [all]",
-        aliases = {"resetconstellation"}, permission = "player.resetconstellation", description = "commands.resetConst.description")
+        aliases = {"resetconstellation"}, permission = "player.resetconstellation", permissionTargeted = "player.resetconstellation.others", description = "commands.resetConst.description")
 public final class ResetConstCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/ResetShopLimitCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ResetShopLimitCommand.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "resetshop", usage = "resetshop", permission = "server.resetshop", description = "commands.status.description")
+@Command(label = "resetshop", usage = "resetshop", permission = "server.resetshop", permissionTargeted = "server.resetshop.others", description = "commands.status.description")
 public final class ResetShopLimitCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/SendMessageCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SendMessageCommand.java
@@ -9,7 +9,7 @@ import java.util.List;
 import static emu.grasscutter.utils.Language.translate;
 
 @Command(label = "say", usage = "say <message>",
-        aliases = {"sendservmsg", "sendservermessage", "sendmessage"}, permission = "server.sendmessage", description = "commands.sendMessage.description")
+        aliases = {"sendservmsg", "sendservermessage", "sendmessage"}, permission = "server.sendmessage", permissionTargeted = "server.sendmessage.others", description = "commands.sendMessage.description")
 public final class SendMessageCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/SetFetterLevelCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetFetterLevelCommand.java
@@ -12,7 +12,7 @@ import emu.grasscutter.server.packet.send.PacketAvatarFetterDataNotify;
 import static emu.grasscutter.utils.Language.translate;
 
 @Command(label = "setfetterlevel", usage = "setfetterlevel <level>",
-        aliases = {"setfetterlvl", "setfriendship"}, permission = "player.setfetterlevel", description = "commands.setFetterLevel.description")
+        aliases = {"setfetterlvl", "setfriendship"}, permission = "player.setfetterlevel", permissionTargeted = "player.setfetterlevel.others", description = "commands.setFetterLevel.description")
 public final class SetFetterLevelCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/SetStatsCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetStatsCommand.java
@@ -15,7 +15,7 @@ import emu.grasscutter.utils.Language;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "setstats", usage = "setstats|stats <stat> <value>", aliases = {"stats"}, permission = "player.setstats", description = "commands.setStats.description")
+@Command(label = "setstats", usage = "setstats|stats <stat> <value>", aliases = {"stats"}, permission = "player.setstats", permissionTargeted = "player.setstats.others", description = "commands.setStats.description")
 public final class SetStatsCommand implements CommandHandler {
     static class Stat {
         String name;

--- a/src/main/java/emu/grasscutter/command/commands/SetWorldLevelCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetWorldLevelCommand.java
@@ -10,7 +10,7 @@ import java.util.List;
 import static emu.grasscutter.utils.Language.translate;
 
 @Command(label = "setworldlevel", usage = "setworldlevel <level>",
-        aliases = {"setworldlvl"}, permission = "player.setworldlevel", description = "commands.setWorldLevel.description")
+        aliases = {"setworldlvl"}, permission = "player.setworldlevel", permissionTargeted = "player.setworldlevel.others", description = "commands.setWorldLevel.description")
 public final class SetWorldLevelCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/SpawnCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SpawnCommand.java
@@ -22,7 +22,7 @@ import java.util.Random;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "spawn", usage = "spawn <entityId> [amount] [level(monster only)]", permission = "server.spawn", description = "commands.spawn.description")
+@Command(label = "spawn", usage = "spawn <entityId> [amount] [level(monster only)]", permission = "server.spawn", permissionTargeted = "server.spawn.others", description = "commands.spawn.description")
 public final class SpawnCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/TalentCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TalentCommand.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "talent", usage = "talent <talentID> <value>", permission = "player.settalent", description = "commands.talent.description")
+@Command(label = "talent", usage = "talent <talentID> <value>", permission = "player.settalent", permissionTargeted = "player.settalent.others", description = "commands.talent.description")
 public final class TalentCommand implements CommandHandler {
     private void setTalentLevel(Player sender, Player player, Avatar avatar, int talentId, int talentLevel) {
         int oldLevel = avatar.getSkillLevelMap().get(talentId);

--- a/src/main/java/emu/grasscutter/command/commands/TeleportAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TeleportAllCommand.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "tpall", usage = "tpall", permission = "player.tpall", description = "commands.teleportAll.description")
+@Command(label = "tpall", usage = "tpall", permission = "player.tpall", permissionTargeted = "player.tpall.others", description = "commands.teleportAll.description")
 public final class TeleportAllCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/TeleportCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TeleportCommand.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "teleport", usage = "teleport <x> <y> <z> [scene id]", aliases = {"tp"}, permission = "player.teleport", description = "commands.teleport.description")
+@Command(label = "teleport", usage = "teleport <x> <y> <z> [scene id]", aliases = {"tp"}, permission = "player.teleport", permissionTargeted = "player.teleport.others", description = "commands.teleport.description")
 public final class TeleportCommand implements CommandHandler {
 
     private float parseRelative(String input, Float current) {  // TODO: Maybe this will be useful elsewhere later

--- a/src/main/java/emu/grasscutter/command/commands/WeatherCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/WeatherCommand.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "weather", usage = "weather <weatherId> [climateId]", aliases = {"w"}, permission = "player.weather", description = "commands.weather.description")
+@Command(label = "weather", usage = "weather <weatherId> [climateId]", aliases = {"w"}, permission = "player.weather", permissionTargeted = "player.weather.others", description = "commands.weather.description")
 public final class WeatherCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/game/Account.java
+++ b/src/main/java/emu/grasscutter/game/Account.java
@@ -1,6 +1,7 @@
 package emu.grasscutter.game;
 
 import dev.morphia.annotations.*;
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.database.DatabaseHelper;
 import emu.grasscutter.utils.Crypto;
 import emu.grasscutter.utils.Utils;
@@ -107,11 +108,41 @@ public class Account {
 		this.permissions.add(permission); return true;
 	}
 
+	public static boolean permissionMatchesWildcard(String wildcard, String[] permissionParts) {
+		String[] wildcardParts = wildcard.split("\\.");
+		if (permissionParts.length < wildcardParts.length) {  // A longer wildcard can never match a shorter permission
+			return false;
+		}
+		for (int i=0; i<wildcardParts.length; i++) {
+			switch (wildcardParts[i]) {
+				case "**":  // Recursing match
+					return true;
+				case "*":  // Match only one layer
+					if (i >= (permissionParts.length-1)) {
+						return true;
+					}
+					break;
+				default:  // This layer isn't a wildcard, it needs to match exactly
+					if (!wildcardParts[i].equals(permissionParts[i])) {
+						return false;
+					}
+			}
+		}
+		// At this point the wildcard will have matched every layer, but if it is shorter then the permission then this is not a match at this point (no **).
+		return (wildcardParts.length == permissionParts.length);
+	}
+
 	public boolean hasPermission(String permission) {
-		return this.permissions.contains(permission) ||
-                this.permissions.contains("*") ||
-                (this.permissions.contains("player") || this.permissions.contains("player.*")) && permission.startsWith("player.") ||
-                (this.permissions.contains("server") || this.permissions.contains("server.*")) && permission.startsWith("server.");
+		if (this.permissions.contains(permission) || this.permissions.contains("*")) {
+			return true;
+		}
+		String[] permissionParts = permission.split("\\.");
+		for (String p : this.permissions) {
+			if (permissionMatchesWildcard(p, permissionParts)) {
+				return true;
+			}
+		}
+		return false;
 	}
 	
 	public boolean removePermission(String permission) {


### PR DESCRIPTION
<img width="316" alt="image" src="https://user-images.githubusercontent.com/5397662/167093053-46171959-322e-4dc5-859d-b5baa6b283ff.png">

Adds permissionTargeted to all applicable commands. (i.e. every command which targets a player and isn't sendmail)

The `player.perm` and `server.perm` distinction seems a bit ill-defined, things like `drop` seem like they should be `player.drop` instead of `server.drop` (ideally I think the true `server.perm` commands wouldn't have a `target.perm` permission at all since they would imply usage on anyone and everyone), but that might be something to leave for one big permissions rework down the track since any changes would involve db migration procedures for server operators. I think some wildcard matching would be good at some point, so admins can set things like `player.*` and `*.spawn` for convenience. 