### PR TITLE
Stop WindSeedClientNotify and PlayerLuaShellNotify from being sent

### DIFF
--- a/src/main/java/emu/grasscutter/net/packet/PacketOpcodes.java
+++ b/src/main/java/emu/grasscutter/net/packet/PacketOpcodes.java
@@ -1,5 +1,8 @@
 package emu.grasscutter.net.packet;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class PacketOpcodes {
     // Empty
     public static final int NONE = 0;
@@ -1566,4 +1569,6 @@ public class PacketOpcodes {
     public static final int UNKNOWN_43 = 8877;
     public static final int UNKNOWN_44 = 8983;
     public static final int UNKNOWN_45 = 943;
+
+    public static final List<Integer> BANNED_PACKETS = Arrays.asList(PacketOpcodes.WindSeedClientNotify, PacketOpcodes.PlayerLuaShellNotify);
 }

--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -160,7 +160,7 @@ public class GameSession extends KcpChannel {
 
 		// DO NOT REMOVE (unless we find a way to validate code before sending to client which I don't think we can)
 		// Stop WindSeedClientNotify from being sent for security purposes.
-		if(packet.getOpcode() == PacketOpcodes.WindSeedClientNotify) {
+		if(PacketOpcodes.BANNED_PACKETS.contains(packet.getOpcode())) {
 			return;
 		}
     	

--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -157,6 +157,12 @@ public class GameSession extends KcpChannel {
     		Grasscutter.getLogger().warn("Tried to send packet with missing cmd id!");
     		return;
     	}
+
+		// DO NOT REMOVE (unless we find a way to validate code before sending to client which I don't think we can)
+		// Stop WindSeedClientNotify from being sent for security purposes.
+		if(packet.getOpcode() == PacketOpcodes.WindSeedClientNotify) {
+			return;
+		}
     	
     	// Header
     	if (packet.shouldBuildHeader()) {


### PR DESCRIPTION
Since ``WindSeedClientNotify`` allows remote code execution, I think our best bet is to stop it from being sent to clients at all.
I know this is very easy to remove but I don't think there is much else we can currently do unless we find a way of validating code before sending to client... 
