### PR TITLE
Fix incorrect language tag in init

### DIFF
--- a/src/main/java/emu/grasscutter/Grasscutter.java
+++ b/src/main/java/emu/grasscutter/Grasscutter.java
@@ -149,14 +149,8 @@ public final class Grasscutter {
 
 	public static void loadLanguage() {
 		var locale = config.LocaleLanguage;
-		String languageTag = locale.toLanguageTag();
-		if (languageTag.equals("und")) {
-			Grasscutter.getLogger().error("Illegal locale language, using en-US instead.");
-			language = Language.getLanguage("en-US");
-		} else {
-			languageTag = String.format("%s-%s", locale.getLanguage(), locale.getCountry());
-			language = Language.getLanguage(languageTag);
-		}
+		String languageTag = String.format("%s-%s", locale.getLanguage(), locale.getCountry());
+		language = Language.getLanguage(languageTag);
 	}
 
 	public static void saveConfig() {

--- a/src/main/java/emu/grasscutter/Grasscutter.java
+++ b/src/main/java/emu/grasscutter/Grasscutter.java
@@ -154,7 +154,7 @@ public final class Grasscutter {
 			Grasscutter.getLogger().error("Illegal locale language, using en-US instead.");
 			language = Language.getLanguage("en-US");
 		} else {
-			languageTag = String.format("%s-%s", locale.getCountry(), locale.getLanguage());
+			languageTag = String.format("%s-%s", locale.getLanguage(), locale.getCountry());
 			language = Language.getLanguage(languageTag);
 		}
 	}

--- a/src/main/java/emu/grasscutter/Grasscutter.java
+++ b/src/main/java/emu/grasscutter/Grasscutter.java
@@ -154,6 +154,7 @@ public final class Grasscutter {
 			Grasscutter.getLogger().error("Illegal locale language, using en-US instead.");
 			language = Language.getLanguage("en-US");
 		} else {
+			languageTag = String.format("%s-%s", locale.getCountry(), locale.getLanguage());
 			language = Language.getLanguage(languageTag);
 		}
 	}


### PR DESCRIPTION
When use `Locale.getDefault().toLanguageTag()`, it will be `zh-Hans-CN` for Chinese. But `zh-Hans-CN.json` cannot be found, using `zh-CN` is correct.