### PR TITLE
[Config-breaking] Gacha revamp

### DIFF
--- a/data/Banners.json
+++ b/data/Banners.json
@@ -6,7 +6,9 @@
 		"prefabPath": "GachaShowPanel_A022",
 		"previewPrefabPath": "UI_Tab_GachaShowPanel_A022",
 		"titlePath": "UI_GACHA_SHOW_PANEL_A022_TITLE",
-		"costItem": 224,
+		"costItemId": 224,
+		"costItemAmount": 1,
+		"costItemAmount10": 10,
 		"beginTime": 0,
 		"endTime": 1924992000,
 		"sortId": 1000,
@@ -21,7 +23,7 @@
 		"prefabPath": "GachaShowPanel_A079",
 		"previewPrefabPath": "UI_Tab_GachaShowPanel_A079",
 		"titlePath": "UI_GACHA_SHOW_PANEL_A048_TITLE",
-		"costItem": 223,
+		"costItemId": 223,
 		"beginTime": 0,
 		"endTime": 1924992000,
 		"sortId": 9998,
@@ -37,7 +39,7 @@
 		"prefabPath": "GachaShowPanel_A080",
 		"previewPrefabPath": "UI_Tab_GachaShowPanel_A080",
 		"titlePath": "UI_GACHA_SHOW_PANEL_A021_TITLE",
-		"costItem": 223,
+		"costItemId": 223,
 		"beginTime": 0,
 		"endTime": 1924992000,
 		"sortId": 9997,
@@ -47,6 +49,7 @@
 		"rateUpItems4": [11401, 12402, 13407, 14401, 15401],
 		"rateUpItems5": [11509, 12504],
 		"fallbackItems5Pool1": [],
+		"weights4": [[1,600], [7,600], [8, 6600], [10,12600]],
 		"weights5": [[1,100], [62,100], [73, 7800], [80,10000]]
 	}
 ]

--- a/data/Banners.json
+++ b/data/Banners.json
@@ -10,8 +10,9 @@
 		"beginTime": 0,
 		"endTime": 1924992000,
 		"sortId": 1000,
-		"rateUpItems1": [],
-		"rateUpItems2": []
+		"fallbackItems4Pool1": [1006, 1014, 1015, 1020, 1021, 1023, 1024, 1025, 1027, 1031, 1032, 1034, 1036, 1039, 1043, 1044, 1045, 1048, 1053, 1055, 1056, 1064],
+		"weights4": [[1,510], [8,510], [10,10000]],
+		"weights5": [[1,75], [73,150], [90,10000]]
 	},
 	{
 		"gachaType": 301,
@@ -24,9 +25,10 @@
 		"beginTime": 0,
 		"endTime": 1924992000,
 		"sortId": 9998,
-		"maxItemType": 1,
-		"rateUpItems1": [1002],
-		"rateUpItems2": [1053, 1020, 1045]
+		"rateUpItems4": [1053, 1020, 1045],
+		"rateUpItems5": [1002],
+		"fallbackItems5Pool2": [],
+		"weights5": [[1,80], [73,80], [90,10000]]
 	},
 	{
 		"gachaType": 302,
@@ -39,11 +41,12 @@
 		"beginTime": 0,
 		"endTime": 1924992000,
 		"sortId": 9997,
-		"minItemType": 2,
 		"eventChance": 75,
 		"softPity": 80,
 		"hardPity": 80,
-		"rateUpItems1": [11509, 12504],
-		"rateUpItems2": [11401, 12402, 13407, 14401, 15401]
+		"rateUpItems4": [11401, 12402, 13407, 14401, 15401],
+		"rateUpItems5": [11509, 12504],
+		"fallbackItems5Pool1": [],
+		"weights5": [[1,100], [62,100], [73, 7800], [80,10000]]
 	}
 ]

--- a/src/main/java/emu/grasscutter/game/gacha/GachaBanner.java
+++ b/src/main/java/emu/grasscutter/game/gacha/GachaBanner.java
@@ -6,6 +6,7 @@ import emu.grasscutter.utils.Utils;
 
 import static emu.grasscutter.Configuration.*;
 
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.common.ItemParamData;
 
 public class GachaBanner {
@@ -145,25 +146,26 @@ public class GachaBanner {
 						+ "/gacha/details?s=" + sessionKey + "&gachaType=" + gachaType;
 
 		// Grasscutter.getLogger().info("record = " + record);
+		ItemParamData costItem1 = this.getCost(1);
+		ItemParamData costItem10 = this.getCost(10);
 		GachaInfo.Builder info = GachaInfo.newBuilder()
 				.setGachaType(this.getGachaType())
 				.setScheduleId(this.getScheduleId())
 				.setBeginTime(this.getBeginTime())
 				.setEndTime(this.getEndTime())
-				.setCostItemId(this.getCostItem())
-	            .setCostItemNum(1)
+				.setCostItemId(costItem1.getId())
+	            .setCostItemNum(costItem1.getCount())
+	            .setTenCostItemId(costItem10.getId())
+	            .setTenCostItemNum(costItem10.getCount())
 	            .setGachaPrefabPath(this.getPrefabPath())
 	            .setGachaPreviewPrefabPath(this.getPreviewPrefabPath())
 	            .setGachaProbUrl(details)
 	            .setGachaProbUrlOversea(details)
 	            .setGachaRecordUrl(record)
 	            .setGachaRecordUrlOversea(record)
-	            .setTenCostItemId(this.getCostItem())
-	            .setTenCostItemNum(10)
 	            .setLeftGachaTimes(Integer.MAX_VALUE)
 	            .setGachaTimesLimit(Integer.MAX_VALUE)
 	            .setGachaSortId(this.getSortId());
-		
 		if (this.getTitlePath() != null) {
 			info.setGachaTitlePath(this.getTitlePath());
 		}

--- a/src/main/java/emu/grasscutter/game/gacha/GachaBanner.java
+++ b/src/main/java/emu/grasscutter/game/gacha/GachaBanner.java
@@ -2,6 +2,7 @@ package emu.grasscutter.game.gacha;
 
 import emu.grasscutter.net.proto.GachaInfoOuterClass.GachaInfo;
 import emu.grasscutter.net.proto.GachaUpInfoOuterClass.GachaUpInfo;
+import emu.grasscutter.utils.Utils;
 
 import static emu.grasscutter.Configuration.*;
 
@@ -15,14 +16,31 @@ public class GachaBanner {
 	private int beginTime;
 	private int endTime;
 	private int sortId;
-	private int[] rateUpItems1;
-	private int[] rateUpItems2;
-	private int baseYellowWeight = 60; // Max 10000
-	private int basePurpleWeight = 510; // Max 10000
-	private int eventChance = 50; // Chance to win a featured event item
-	private int softPity = 75;
-	private int hardPity = 90;
+	private int[] rateUpItems4 = {};
+	private int[] rateUpItems5 = {};
+	private int[] fallbackItems3 = {11301, 11302, 11306, 12301, 12302, 12305, 13303, 14301, 14302, 14304, 15301, 15302, 15304};
+	private int[] fallbackItems4Pool1 = {1014, 1020, 1023, 1024, 1025, 1027, 1031, 1032, 1034, 1036, 1039, 1043, 1044, 1045, 1048, 1053, 1055, 1056, 1064};
+	private int[] fallbackItems4Pool2 = {11401, 11402, 11403, 11405, 12401, 12402, 12403, 12405, 13401, 13407, 14401, 14402, 14403, 14409, 15401, 15402, 15403, 15405};
+	private int[] fallbackItems5Pool1 = {1003, 1016, 1042, 1035, 1041};
+	private int[] fallbackItems5Pool2 = {11501, 11502, 12501, 12502, 13502, 13505, 14501, 14502, 15501, 15502};
+	private boolean removeC6FromPool = false;
+	private boolean autoStripRateUpFromFallback = true;
+	private int[][] weights4 = {{1,510}, {8,510}, {10,10000}};
+	private int[][] weights5 = {{1,75}, {73,150}, {90,10000}};
+	private int[][] poolBalanceWeights4 = {{1,255}, {17,255}, {21,10455}};
+	private int[][] poolBalanceWeights5 = {{1,30}, {147,150}, {181,10230}};
+	private int eventChance4 = 50; // Chance to win a featured event item
+	private int eventChance5 = 50; // Chance to win a featured event item
 	private BannerType bannerType = BannerType.STANDARD;
+
+	// Kinda wanna deprecate these but they're in people's configs
+	private int[] rateUpItems1 = {};
+	private int[] rateUpItems2 = {};
+	private int softPity = -1;
+	private int hardPity = -1;
+	private int eventChance = -1;
+	private int baseYellowWeight = -1;
+	private int basePurpleWeight = -1;
 	
 	public int getGachaType() {
 		return gachaType;
@@ -72,24 +90,42 @@ public class GachaBanner {
 		return basePurpleWeight;
 	}
 
-	public int[] getRateUpItems1() {
-		return rateUpItems1;
+	public int[] getRateUpItems4() {
+		return (rateUpItems2.length > 0) ? rateUpItems2 : rateUpItems4;
+	}
+	public int[] getRateUpItems5() {
+		return (rateUpItems1.length > 0) ? rateUpItems1 : rateUpItems5;
 	}
 
-	public int[] getRateUpItems2() {
-		return rateUpItems2;
-	}
-	
-	public int getSoftPity() {
-		return softPity - 1;
+	public int[] getFallbackItems3() {return fallbackItems3;}
+	public int[] getFallbackItems4Pool1() {return fallbackItems4Pool1;}
+	public int[] getFallbackItems4Pool2() {return fallbackItems4Pool2;}
+	public int[] getFallbackItems5Pool1() {return fallbackItems5Pool1;}
+	public int[] getFallbackItems5Pool2() {return fallbackItems5Pool2;}
+
+	public boolean getRemoveC6FromPool() {return removeC6FromPool;}
+	public boolean getAutoStripRateUpFromFallback() {return autoStripRateUpFromFallback;}
+
+
+	public int getWeight(int rarity, int pity) {
+		return switch(rarity) {
+			case 4 -> Utils.lerp(pity, weights4);
+			default -> Utils.lerp(pity, weights5);
+		};
 	}
 
-	public int getHardPity() {
-		return hardPity - 1;
+	public int getPoolBalanceWeight(int rarity, int pity) {
+		return switch(rarity) {
+			case 4 -> Utils.lerp(pity, poolBalanceWeights4);
+			default -> Utils.lerp(pity, poolBalanceWeights5);
+		};
 	}
 
-	public int getEventChance() {
-		return eventChance;
+	public int getEventChance(int rarity) {
+		return switch(rarity) {
+			case 4 -> eventChance4;
+			default -> (eventChance > -1) ? eventChance : eventChance5;
+		};
 	}
 
 	@Deprecated
@@ -131,10 +167,10 @@ public class GachaBanner {
 			info.setGachaTitlePath(this.getTitlePath());
 		}
 		
-		if (this.getRateUpItems1().length > 0) {
+		if (this.getRateUpItems5().length > 0) {
 			GachaUpInfo.Builder upInfo = GachaUpInfo.newBuilder().setItemParentType(1);
 			
-			for (int id : getRateUpItems1()) {
+			for (int id : getRateUpItems5()) {
 				upInfo.addItemIdList(id);
 				info.addMainNameId(id);
 			}
@@ -142,10 +178,10 @@ public class GachaBanner {
 			info.addGachaUpInfoList(upInfo);
 		}
 		
-		if (this.getRateUpItems2().length > 0) {
+		if (this.getRateUpItems4().length > 0) {
 			GachaUpInfo.Builder upInfo = GachaUpInfo.newBuilder().setItemParentType(2);
 			
-			for (int id : getRateUpItems2()) {
+			for (int id : getRateUpItems4()) {
 				upInfo.addItemIdList(id);
 				if (info.getSubNameIdCount() == 0) {
 					info.addSubNameId(id);

--- a/src/main/java/emu/grasscutter/game/gacha/GachaBanner.java
+++ b/src/main/java/emu/grasscutter/game/gacha/GachaBanner.java
@@ -6,13 +6,18 @@ import emu.grasscutter.utils.Utils;
 
 import static emu.grasscutter.Configuration.*;
 
+import emu.grasscutter.data.common.ItemParamData;
+
 public class GachaBanner {
 	private int gachaType;
 	private int scheduleId;
 	private String prefabPath;
 	private String previewPrefabPath;
 	private String titlePath;
-	private int costItem;
+	private int costItemId = 0;
+	private int costItemAmount = 1;
+	private int costItemId10 = 0;
+	private int costItemAmount10 = 10;
 	private int beginTime;
 	private int endTime;
 	private int sortId;
@@ -36,11 +41,8 @@ public class GachaBanner {
 	// Kinda wanna deprecate these but they're in people's configs
 	private int[] rateUpItems1 = {};
 	private int[] rateUpItems2 = {};
-	private int softPity = -1;
-	private int hardPity = -1;
 	private int eventChance = -1;
-	private int baseYellowWeight = -1;
-	private int basePurpleWeight = -1;
+	private int costItem = 0;
 	
 	public int getGachaType() {
 		return gachaType;
@@ -66,8 +68,15 @@ public class GachaBanner {
 		return titlePath;
 	}
 
+	public ItemParamData getCost(int numRolls) {
+		return switch (numRolls) {
+			case 10 -> new ItemParamData((costItemId10 > 0) ? costItemId10 : getCostItem(), costItemAmount10);
+			default -> new ItemParamData(getCostItem(), costItemAmount * numRolls);
+		};
+	}
+
 	public int getCostItem() {
-		return costItem;
+		return (costItem > 0) ? costItem : costItemId;
 	}
 
 	public int getBeginTime() {
@@ -80,14 +89,6 @@ public class GachaBanner {
 
 	public int getSortId() {
 		return sortId;
-	}
-
-	public int getBaseYellowWeight() {
-		return baseYellowWeight;
-	}
-
-	public int getBasePurpleWeight() {
-		return basePurpleWeight;
 	}
 
 	public int[] getRateUpItems4() {

--- a/src/main/java/emu/grasscutter/game/gacha/GachaManager.java
+++ b/src/main/java/emu/grasscutter/game/gacha/GachaManager.java
@@ -17,7 +17,6 @@ import emu.grasscutter.data.common.ItemParamData;
 import emu.grasscutter.data.def.ItemData;
 import emu.grasscutter.database.DatabaseHelper;
 import emu.grasscutter.game.avatar.Avatar;
-import emu.grasscutter.game.gacha.GachaBanner.BannerType;
 import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.game.inventory.Inventory;
 import emu.grasscutter.game.inventory.ItemType;
@@ -78,10 +77,6 @@ public class GachaManager {
 			if(banners.size() > 0) {
 				for (GachaBanner banner : banners) {
 					getGachaBanners().put(banner.getGachaType(), banner);
-					Grasscutter.getLogger().info(String.format("Testing lerp code for banner gachaType %d :", banner.getGachaType()));  // TODO: remove this before merging!
-					for (int i=1; i<91; i++) {
-						Grasscutter.getLogger().info(String.format("Pity %d : Weight %d", i, banner.getWeight(5, i)));
-					}
 				}
 				Grasscutter.getLogger().info("Banners successfully loaded.");
 

--- a/src/main/java/emu/grasscutter/game/gacha/GachaManager.java
+++ b/src/main/java/emu/grasscutter/game/gacha/GachaManager.java
@@ -19,6 +19,7 @@ import emu.grasscutter.database.DatabaseHelper;
 import emu.grasscutter.game.avatar.Avatar;
 import emu.grasscutter.game.gacha.GachaBanner.BannerType;
 import emu.grasscutter.game.inventory.GameItem;
+import emu.grasscutter.game.inventory.Inventory;
 import emu.grasscutter.game.inventory.ItemType;
 import emu.grasscutter.game.inventory.MaterialType;
 import emu.grasscutter.game.player.Player;
@@ -233,7 +234,8 @@ public class GachaManager {
 		if (times != 10 && times != 1) {
 			return;
 		} 
-		if (player.getInventory().getInventoryTab(ItemType.ITEM_WEAPON).getSize() + times > player.getInventory().getInventoryTab(ItemType.ITEM_WEAPON).getMaxCapacity()) {
+		Inventory inventory = player.getInventory();
+		if (inventory.getInventoryTab(ItemType.ITEM_WEAPON).getSize() + times > inventory.getInventoryTab(ItemType.ITEM_WEAPON).getMaxCapacity()) {
 			player.sendPacket(new PacketDoGachaRsp());
 			return;
 		}
@@ -246,7 +248,8 @@ public class GachaManager {
 		}
 
 		// Spend currency
-		if (banner.getCostItem() > 0 && !player.getInventory().payItem(banner.getCostItem(), times)) {
+		ItemParamData cost = banner.getCost(times);
+		if (cost.getCount() > 0 && !inventory.payItem(cost)) {
 			return;
 		}
 		
@@ -304,9 +307,9 @@ public class GachaManager {
 						}
 						addStarglitter = (itemData.getRankLevel()==5)? 10 : 2;
 						int constItemId = itemId + 100;
-						GameItem constItem = player.getInventory().getInventoryTab(ItemType.ITEM_MATERIAL).getItemById(constItemId);
+						GameItem constItem = inventory.getInventoryTab(ItemType.ITEM_MATERIAL).getItemById(constItemId);
 						gachaItem.addTransferItems(GachaTransferItem.newBuilder().setItem(ItemParam.newBuilder().setItemId(constItemId).setCount(1)).setIsTransferItemNew(constItem == null));
-						player.getInventory().addItem(constItemId, 1);
+						inventory.addItem(constItemId, 1);
 					}
 					isTransferItem = true;
 					break;
@@ -315,7 +318,7 @@ public class GachaManager {
 			// Create item
 			GameItem item = new GameItem(itemData);
 			gachaItem.setGachaItem(item.toItemParam());
-			player.getInventory().addItem(item);
+			inventory.addItem(item);
 			
 			stardust += addStardust;
 			starglitter += addStarglitter;
@@ -336,10 +339,10 @@ public class GachaManager {
 		
 		// Add stardust/starglitter
 		if (stardust > 0) {
-			player.getInventory().addItem(stardustId, stardust);
+			inventory.addItem(stardustId, stardust);
 		}
 		if (starglitter > 0) {
-			player.getInventory().addItem(starglitterId, starglitter);
+			inventory.addItem(starglitterId, starglitter);
 		}
 		
 		// Packets

--- a/src/main/java/emu/grasscutter/game/gacha/PlayerGachaBannerInfo.java
+++ b/src/main/java/emu/grasscutter/game/gacha/PlayerGachaBannerInfo.java
@@ -7,6 +7,11 @@ public class PlayerGachaBannerInfo {
 	private int pity5 = 0;
 	private int pity4 = 0;
 	private int failedFeaturedItemPulls = 0;
+	private int failedFeatured4ItemPulls = 0;
+	private int pity5Pool1 = 0;
+	private int pity5Pool2 = 0;
+	private int pity4Pool1 = 0;
+	private int pity4Pool2 = 0;
 	
 	public int getPity5() {
 		return pity5;
@@ -32,15 +37,82 @@ public class PlayerGachaBannerInfo {
 		this.pity4 += amount;
 	}
 	
-	public int getFailedFeaturedItemPulls() {
-		return failedFeaturedItemPulls;
+	public int getFailedFeaturedItemPulls(int rarity) {
+		return switch (rarity) {
+			case 4 -> failedFeatured4ItemPulls;
+			default -> failedFeaturedItemPulls;  // 5
+		};
 	}
 	
-	public void setFailedFeaturedItemPulls(int failedEventCharacterPulls) {
-		this.failedFeaturedItemPulls = failedEventCharacterPulls;
+	public void setFailedFeaturedItemPulls(int rarity, int amount) {
+		switch (rarity) {
+			case 4 -> failedFeatured4ItemPulls = amount;
+			default -> failedFeaturedItemPulls = amount;  // 5
+		};
 	}
 	
-	public void addFailedFeaturedItemPulls(int amount) {
-		failedFeaturedItemPulls += amount;
+	public void addFailedFeaturedItemPulls(int rarity, int amount) {
+		switch (rarity) {
+			case 4 -> failedFeatured4ItemPulls += amount;
+			default -> failedFeaturedItemPulls += amount;  // 5
+		};
+	}
+	
+	public int getPityPool(int rarity, int pool) {
+		return switch (rarity) {
+			case 4 -> switch (pool) {
+				case 1 -> pity4Pool1;
+				default -> pity4Pool2;
+			};
+			default -> switch (pool) {
+				case 1 -> pity5Pool1;
+				default -> pity5Pool2;
+			};
+		};
+	}
+	
+	public void setPityPool(int rarity, int pool, int amount) {
+		switch (rarity) {
+			case 4:
+				switch (pool) {
+					case 1 -> pity4Pool1 = amount;
+					default -> pity4Pool2 = amount;
+				};
+				break;
+			case 5:
+			default:
+				switch (pool) {
+					case 1 -> pity5Pool1 = amount;
+					default -> pity5Pool2 = amount;
+				};
+				break;
+		};
+	}
+	
+	public void addPityPool(int rarity, int pool, int amount) {
+		switch (rarity) {
+			case 4:
+				switch (pool) {
+					case 1 -> pity4Pool1 += amount;
+					default -> pity4Pool2 += amount;
+				};
+				break;
+			case 5:
+			default:
+				switch (pool) {
+					case 1 -> pity5Pool1 += amount;
+					default -> pity5Pool2 += amount;
+				};
+				break;
+		};
+	}
+
+	public void incPityAll() {
+		pity4++;
+		pity5++;
+		pity4Pool1++;
+		pity4Pool2++;
+		pity5Pool1++;
+		pity5Pool2++;
 	}
 }

--- a/src/main/java/emu/grasscutter/server/dispatch/http/GachaDetailsHandler.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/http/GachaDetailsHandler.java
@@ -62,28 +62,24 @@ public final class GachaDetailsHandler implements HttpContextHandler {
 		// Add 5-star items.
 		Set<String> fiveStarItems = new LinkedHashSet<>();
 
-		Arrays.stream(banner.getRateUpItems1()).forEach(i -> fiveStarItems.add(Integer.toString(i)));
-		if (banner.getBannerType() == BannerType.STANDARD || banner.getBannerType() == BannerType.EVENT) {
-			Arrays.stream(manager.getYellowAvatars()).forEach(i -> fiveStarItems.add(Integer.toString(i)));
-		}
-		if (banner.getBannerType() == BannerType.STANDARD || banner.getBannerType() == BannerType.WEAPON) {
-			Arrays.stream(manager.getYellowWeapons()).forEach(i -> fiveStarItems.add(Integer.toString(i)));
-		}
+		Arrays.stream(banner.getRateUpItems5()).forEach(i -> fiveStarItems.add(Integer.toString(i)));
+		Arrays.stream(banner.getFallbackItems5Pool1()).forEach(i -> fiveStarItems.add(Integer.toString(i)));
+		Arrays.stream(banner.getFallbackItems5Pool2()).forEach(i -> fiveStarItems.add(Integer.toString(i)));
 
 		response = response.replace("{{FIVE_STARS}}", "[" + String.join(",", fiveStarItems) + "]");
 		
 		// Add 4-star items.
 		Set<String> fourStarItems = new LinkedHashSet<>();
 
-		Arrays.stream(banner.getRateUpItems2()).forEach(i -> fourStarItems.add(Integer.toString(i)));
-		Arrays.stream(manager.getPurpleAvatars()).forEach(i -> fourStarItems.add(Integer.toString(i)));
-		Arrays.stream(manager.getPurpleWeapons()).forEach(i -> fourStarItems.add(Integer.toString(i)));
+		Arrays.stream(banner.getRateUpItems4()).forEach(i -> fourStarItems.add(Integer.toString(i)));
+		Arrays.stream(banner.getFallbackItems4Pool1()).forEach(i -> fourStarItems.add(Integer.toString(i)));
+		Arrays.stream(banner.getFallbackItems4Pool2()).forEach(i -> fourStarItems.add(Integer.toString(i)));
 
 		response = response.replace("{{FOUR_STARS}}", "[" + String.join(",", fourStarItems) + "]");
 
 		// Add 3-star items.
 		Set<String> threeStarItems = new LinkedHashSet<>();
-		Arrays.stream(manager.getBlueWeapons()).forEach(i -> threeStarItems.add(Integer.toString(i)));
+		Arrays.stream(banner.getFallbackItems3()).forEach(i -> threeStarItems.add(Integer.toString(i)));
 		response = response.replace("{{THREE_STARS}}", "[" + String.join(",", threeStarItems) + "]");
 
 		// Done.

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketDoGachaRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketDoGachaRsp.java
@@ -2,6 +2,7 @@ package emu.grasscutter.server.packet.send;
 
 import java.util.List;
 
+import emu.grasscutter.data.common.ItemParamData;
 import emu.grasscutter.game.gacha.GachaBanner;
 import emu.grasscutter.net.packet.BasePacket;
 import emu.grasscutter.net.packet.PacketOpcodes;
@@ -14,16 +15,18 @@ public class PacketDoGachaRsp extends BasePacket {
 	public PacketDoGachaRsp(GachaBanner banner, List<GachaItem> list) {
 		super(PacketOpcodes.DoGachaRsp);
 
+		ItemParamData costItem = banner.getCost(1);
+		ItemParamData costItem10 = banner.getCost(10);
 		DoGachaRsp p = DoGachaRsp.newBuilder()
 				.setGachaType(banner.getGachaType())
 				.setGachaScheduleId(banner.getScheduleId())
 				.setGachaTimes(list.size())
 				.setNewGachaRandom(12345)
 				.setLeftGachaTimes(Integer.MAX_VALUE)
-				.setCostItemId(banner.getCostItem())
-	            .setCostItemNum(1)
-	            .setTenCostItemId(banner.getCostItem())
-	            .setTenCostItemNum(10)
+				.setCostItemId(costItem.getId())
+	            .setCostItemNum(costItem.getCount())
+	            .setTenCostItemId(costItem10.getId())
+	            .setTenCostItemNum(costItem10.getCount())
 	            .addAllGachaItemList(list)
 				.build();
 		

--- a/src/main/java/emu/grasscutter/utils/Utils.java
+++ b/src/main/java/emu/grasscutter/utils/Utils.java
@@ -15,6 +15,8 @@ import emu.grasscutter.Grasscutter;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
 
 import org.slf4j.Logger;
 
@@ -314,4 +316,68 @@ public final class Utils {
         return String.format("%s-%s", locale.getLanguage(), locale.getCountry());
     }
 
+	/**
+	 * Performs a linear interpolation using a table of fixed points to create an effective piecewise f(x) = y function.
+	 * @param x
+	 * @param xyArray Array of points in [[x0,y0], ... [xN, yN]] format
+	 * @return f(x) = y
+	 */
+	public static int lerp(int x, int[][] xyArray) {
+		try {
+			if (x <= xyArray[0][0]){  // Clamp to first point
+				return xyArray[0][1];
+			} else if (x >= xyArray[xyArray.length-1][0]) {  // Clamp to last point
+				return xyArray[xyArray.length-1][1];
+			}
+			// At this point we're guaranteed to have two lerp points, and pity be somewhere between them.
+			for (int i=0; i < xyArray.length-1; i++) {
+				if (x == xyArray[i+1][0]) {
+					return xyArray[i+1][1];
+				}
+				if (x < xyArray[i+1][0]) {
+					// We are between [i] and [i+1], interpolation time!
+					// Using floats would be slightly cleaner but we can just as easily use ints if we're careful with order of operations. 
+					int position = x - xyArray[i][0];
+					int fullDist = xyArray[i+1][0] - xyArray[i][0];
+					int prevValue = xyArray[i][1];
+					int fullDelta = xyArray[i+1][1] - prevValue;
+					return prevValue + ( (position * fullDelta) / fullDist );
+				}
+			}
+		} catch (IndexOutOfBoundsException e) {
+			Grasscutter.getLogger().error("Malformed lerp point array. Must be of form [[x0, y0], ..., [xN, yN]].");
+		}
+		return 0;
+	}
+
+	/**
+	 * Checks if an int is in an int[]
+	 * @param key int to look for
+	 * @param array int[] to look in
+	 * @return key in array
+	 */
+	public static boolean intInArray(int key, int[] array) {
+		for (int i : array) {
+			if (i == key) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Return a copy of minuend without any elements found in subtrahend.
+	 * @param minuend The array we want elements from
+	 * @param subtrahend The array whose elements we don't want
+	 * @return The array with only the elements we want, in the order that minuend had them
+	 */
+	public static int[] setSubtract(int[] minuend, int[] subtrahend) {
+		IntList temp = new IntArrayList();
+		for (int i : minuend) {
+			if (!intInArray(i, subtrahend)) {
+				temp.add(i);
+			}
+		}
+		return temp.toIntArray();
+	}
 }


### PR DESCRIPTION
## Key Goals & Concepts
- Use concepts outlined in #183 with default rates for each banner adjusted to better fit observed data from paimon.moe
### No base rates or pity, only lerp arrays
Instead of configuring via base rates, soft/hard pity, define some fixed points to lerp between.
For example, the 3-piece piecewise function for the weapon banner's 5-star probability mechanism shown below can be exactly represented as `"weights5": [[1,70], [62,70], [73,7770], [80,10220]]` in `Banners.json`
![image](https://user-images.githubusercontent.com/5397662/167259694-c82e5320-5b54-47b9-990e-97f3b2ef7c3c.png)
This is a relatively complex pity mechanism consisting of three different slopes, yet it is trivial to define and edit.
As for why this shouldn't just be hardcoded, statistics show that the 5* rates on all three vanilla banners are considerably different:
![image](https://user-images.githubusercontent.com/5397662/167259919-e52ec5e5-68f1-4abb-ba3b-caad97357122.png)
There's a clear trend on the standard banner - the 5* probability starts at 0.75% and climbs up to 1.5% before the steep climb of soft pity kicks in. The weapon and character banners are relatively flat in this region. The pity slopes on standard and character mostly line up, but weapon does its own thing.
| Banner | Stage 1 | Stage 2 | Stage 3 | Example Lerp |
| --- | --- | --- | --- | --- |
| Standard | Rising | Sharp rise | - | `[[1,75], [73,150], [90,10000]]` |
| Character | Flat | Sharp rise | - | `[[1,80], [73,80], [90,10000]]` |
| Weapon | Flat | Sharp rise | Slow rise | `[[1,70], [62,70], [73,7770], [80,10220]]` |

These would be a pain to hardcode each case for, and we'd be doing no favors to anyone who wants to mod their banner rates. This new format makes it easy for us to specify (current) vanilla behaviour and gives powerful tools to anyone who wants control over their banner rates. An approximation of the old variables in the new format would be `[[1, baseYellowRate], [softPity, baseYellowRate], [hardPity, 10000]]`


### More than just 5-stars
With all that said, as just a mechanism for 5-star rates, this might be an excessive rework. The real issue is that this also digs into 4-star rate behaviour (the weapon banner is different to the other two, peaks on 8 instead of 9), and non-rateUp (termed fallback in this PR) reward pools (avatars and weapons in vanilla, but I generically call them pool1 and pool2 everywhere). There is another rate mechanic similar to pity that is used to ensure that players don't go too long without getting an avatar, or without getting a high-rarity weapon. Some coefficients are proposed in the image below and I've converted a couple of them already.
![image](https://user-images.githubusercontent.com/5397662/167260632-f1b1369e-9a6a-4e8c-80a9-1a38276297e0.png)


### Better-than-vanilla server configs
I also included a function to remove C6 characters from the reward pools. This currently also preserves guarantees when you "lose a 50:50" by having no rate-up reward available.

### Remaining work
- ~Rigorous testing~
- ~Settling on vanilla default configs that will satisfy #183~
- Deciding on what to do with deprecated config fields. Currently I try to legacy support some of them but it's probably not worth it long-term.
- ~Harden up the edge cases surrounding empty reward pools, especially if removing items from existing pools is a desirable feature.~
- ~More rigorous testing~
- ~Syntax may have gotten a bit ridiculous during some of the refactoring, might need some fixup so that it's actually maintainable~
- ~More rigorous testing after that too~
- Try to stop giving maintainers headaches with ambitious reworks and do something smaller and more manageable next time