### PR TITLE
Add a plugin schema

### DIFF
--- a/plugin-schema.json
+++ b/plugin-schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for a Grasscutter Plugin",
+  "type": "object",
+  "additionalProperties": true,
+  "definitions": {
+    "plugin-name": {
+      "type": "string",
+      "pattern": "^[A-Za-z\\d_.-]+$"
+    }
+  },
+  "required": [ "name", "description", "mainClass" ],
+  "properties": {
+    "name": {
+      "description": "The unique name of plugin.",
+      "$ref": "#/definitions/plugin-name"
+    },
+    "mainClass": {
+      "description": "The plugin's initial class file.",
+      "type": "string",
+      "pattern": "^(?!org\\.bukkit\\.)([a-zA-Z_$][a-zA-Z\\d_$]*\\.)*[a-zA-Z_$][a-zA-Z\\d_$]*$"
+    },
+    "version": {
+      "description": "A plugin revision identifier.",
+      "type": [ "string", "number" ]
+    },
+    "description": {
+      "description": "Human readable plugin summary.",
+      "type": "string"
+    },
+    "author": {
+      "description": "The plugin author.",
+      "type": "string"
+    },
+    "authors": {
+      "description": "The plugin contributors.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "website": {
+      "title": "Website",
+      "description": "The URL to the plugin's site",
+      "type": "string",
+      "format": "uri"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds a schema for constructing plugin configuration files.
Useful for IDEs!

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.