### PR TITLE
feature(task): Implement pause, resume and cancel

### DIFF
--- a/src/main/java/emu/grasscutter/task/Task.java
+++ b/src/main/java/emu/grasscutter/task/Task.java
@@ -1,7 +1,5 @@
 package emu.grasscutter.task;
 
-import org.quartz.JobDataMap;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 

--- a/src/main/java/emu/grasscutter/task/TaskMap.java
+++ b/src/main/java/emu/grasscutter/task/TaskMap.java
@@ -67,6 +67,40 @@ public final class TaskMap {
         return this;
     }
 
+    public boolean pauseTask(String taskName) {
+        try {
+            Scheduler scheduler = schedulerFactory.getScheduler();
+            scheduler.pauseJob(new JobKey(taskName));
+        } catch (SchedulerException e) {
+            e.printStackTrace();
+            return false;
+        }
+        return true;
+    }
+
+    public boolean resumeTask(String taskName) {
+        try {
+            Scheduler scheduler = schedulerFactory.getScheduler();
+            scheduler.resumeJob(new JobKey(taskName));
+        } catch (SchedulerException e) {
+            e.printStackTrace();
+            return false;
+        }
+        return true;
+    }
+
+    public boolean cancelTask(String taskName) {
+        Task task = this.annotations.get(taskName);
+        if (task == null) return false;
+        try {
+            this.unregisterTask(this.tasks.get(taskName));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+        return true;
+    }
+
     public TaskMap registerTask(String taskName, TaskHandler task) {
         Task annotation = task.getClass().getAnnotation(Task.class);
         this.annotations.put(taskName, annotation);
@@ -116,7 +150,7 @@ public final class TaskMap {
         classes.forEach(annotated -> {
             try {
                 Task taskData = annotated.getAnnotation(Task.class);
-                Object object = annotated.newInstance();
+                Object object = annotated.getDeclaredConstructor().newInstance();
                 if (object instanceof TaskHandler) {
                     this.registerTask(taskData.taskName(), (TaskHandler) object);
                     if (taskData.executeImmediatelyAfterReset()) {


### PR DESCRIPTION
## Description

Add `pause`, `resume` & `cancel` functions to the `Task` module. Use as `pauseTask(taskName)`. They return boolean values to tell the developer if a timed task can be paused/resumed/cancelled properly. A little bit of testing shows that pausing and then resuming may execute the task multiple times. I may still need to troubleshoot this.

## Type of changes

- [ ] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.