### PR TITLE
Added to ability to specify main and substats for /giveart via names instead of IDs

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
@@ -70,14 +70,26 @@ public final class GiveArtifactCommand implements CommandHandler {
 
 		// If the argument was not an integer, we try to determine
 		// the append prop ID from the given text + artifact information.
-		// A substat string has the format `substat_tier`.
+		// A substat string has the format `substat_tier`, with the
+		// `_tier` part being optional.
 		String[] substatArgs = substatText.split("_");
-		if (substatArgs.length != 2) {
+		String substatType;
+		int substatTier;
+
+		if (substatArgs.length == 1) {
+			substatType = substatArgs[0];
+			substatTier = 
+				itemData.getRankLevel() == 1 ? 2 
+				: itemData.getRankLevel() == 2 ? 3 
+				: 4;
+		}
+		else if (substatArgs.length == 2) {
+			substatType = substatArgs[0];
+			substatTier = Integer.parseInt(substatArgs[1]);
+		}
+		else {
 			throw new IllegalArgumentException();
 		}
-
-		String substatType = substatArgs[0];
-		int substatTier = Integer.parseInt(substatArgs[1]);
 
 		// Check if the specified tier is legal for the artifact rarity.
 		if (substatTier < 1 || substatTier > 4) {

--- a/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
@@ -19,7 +19,7 @@ import static java.util.Map.entry;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "giveart", usage = "giveart <artifactId> <mainPropId> [<appendPropId>[,<times>]]... [level]", description = "Gives the player a specified artifact", aliases = {"gart"}, permission = "player.giveart")
+@Command(label = "giveart", usage = "giveart <artifactId> <mainPropId> [<appendPropId>[,<times>]]... [level]", aliases = {"gart"}, permission = "player.giveart", description = "commands.giveArtifact.description")
 public final class GiveArtifactCommand implements CommandHandler {
 	private static final Map<String, Map<EquipType, Integer>> mainPropMap = Map.ofEntries(
 		entry("hp", Map.ofEntries(entry(EquipType.EQUIP_BRACER, 14001))),

--- a/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
@@ -9,28 +9,109 @@ import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.game.inventory.ItemType;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.ActionReason;
+import emu.grasscutter.game.inventory.EquipType;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import static java.util.Map.entry;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "giveart", usage = "giveart <artifactId> <mainPropId> [<appendPropId>[,<times>]]... [level]", aliases = {"gart"}, permission = "player.giveart", description = "commands.giveArtifact.description")
+@Command(label = "giveart", usage = "giveart <artifactId> <mainPropId> [<appendPropId>[,<times>]]... [level]", description = "Gives the player a specified artifact", aliases = {"gart"}, permission = "player.giveart")
 public final class GiveArtifactCommand implements CommandHandler {
+	private static final Map<String, Map<EquipType, Integer>> mainPropMap = Map.ofEntries(
+		entry("hp", Map.ofEntries(entry(EquipType.EQUIP_BRACER, 14001))),
+		entry("hp%", Map.ofEntries(entry(EquipType.EQUIP_SHOES, 10980), entry(EquipType.EQUIP_RING, 50980), entry(EquipType.EQUIP_DRESS, 30980))),
+		entry("atk", Map.ofEntries(entry(EquipType.EQUIP_NECKLACE, 12001))),
+		entry("atk%", Map.ofEntries(entry(EquipType.EQUIP_SHOES, 10990), entry(EquipType.EQUIP_RING, 50990), entry(EquipType.EQUIP_DRESS, 30990))),
+		entry("def%", Map.ofEntries(entry(EquipType.EQUIP_SHOES, 10970), entry(EquipType.EQUIP_RING, 50970), entry(EquipType.EQUIP_DRESS, 30970))),
+		entry("er", Map.ofEntries(entry(EquipType.EQUIP_SHOES, 10960))),
+		entry("em", Map.ofEntries(entry(EquipType.EQUIP_SHOES, 10950), entry(EquipType.EQUIP_RING, 50880), entry(EquipType.EQUIP_DRESS, 30930))),
+		entry("hb", Map.ofEntries(entry(EquipType.EQUIP_DRESS, 30940))),
+		entry("cdmg", Map.ofEntries(entry(EquipType.EQUIP_DRESS, 30950))),
+		entry("cr", Map.ofEntries(entry(EquipType.EQUIP_DRESS, 30960))),
+		entry("phys%", Map.ofEntries(entry(EquipType.EQUIP_RING, 50890))),
+		entry("dendro%", Map.ofEntries(entry(EquipType.EQUIP_RING, 50900))),
+		entry("geo%", Map.ofEntries(entry(EquipType.EQUIP_RING, 50910))),
+		entry("anemo%", Map.ofEntries(entry(EquipType.EQUIP_RING, 50920))),
+		entry("hydro%", Map.ofEntries(entry(EquipType.EQUIP_RING, 50930))),
+		entry("cryo%", Map.ofEntries(entry(EquipType.EQUIP_RING, 50940))),
+		entry("electro%", Map.ofEntries(entry(EquipType.EQUIP_RING, 50950))),
+		entry("pyro%", Map.ofEntries(entry(EquipType.EQUIP_RING, 50960)))
+	);
+	private static final Map<String, String> appendPropMap = Map.ofEntries(
+		entry("hp", "0102"),
+		entry("hp%", "0103"),
+		entry("atk", "0105"),
+		entry("atk%", "0106"),
+		entry("def", "0108"),
+		entry("def%", "0109"),
+		entry("er", "0123"),
+		entry("em", "0124"),
+		entry("cr", "0120"),
+		entry("cdmg", "0122")
+	);
+
+	private int getAppendPropId(String substatText, ItemData itemData) {
+		int res;
+
+		// If the given substat text is an integer, we just use that
+		// as the append prop ID.
+		try {
+			res = Integer.parseInt(substatText);
+			return res;
+		}
+		catch (NumberFormatException ignores) {
+			// No need to handle this here. We just continue with the
+			// possibility of the argument being a substat string.
+		}
+
+		// If the argument was not an integer, we try to determine
+		// the append prop ID from the given text + artifact information.
+		// A substat string has the format `substat_tier`.
+		String[] substatArgs = substatText.split("_");
+		if (substatArgs.length != 2) {
+			throw new IllegalArgumentException();
+		}
+
+		String substatType = substatArgs[0];
+		int substatTier = Integer.parseInt(substatArgs[1]);
+
+		// Check if the specified tier is legal for the artifact rarity.
+		if (substatTier < 1 || substatTier > 4) {
+			throw new IllegalArgumentException();
+		}
+		if (itemData.getRankLevel() == 1 && substatTier > 2) {
+			throw new IllegalArgumentException();
+		}
+		if (itemData.getRankLevel() == 2 && substatTier > 3) {
+			throw new IllegalArgumentException();
+		} 
+
+		// Check if the given substat type string is a legal stat.
+		if (!appendPropMap.containsKey(substatType)) {
+			throw new IllegalArgumentException();
+		}
+
+		// Build the append prop ID.
+		return Integer.parseInt(Integer.toString(itemData.getRankLevel()) + appendPropMap.get(substatType) + Integer.toString(substatTier));
+	}
 
 	@Override
 	public void execute(Player sender, Player targetPlayer, List<String> args) {
+		// Sanity checks
 		if (targetPlayer == null) {
 			CommandHandler.sendMessage(sender, translate("commands.execution.need_target"));
 			return;
 		}
-
 		if (args.size() < 2) {
 			CommandHandler.sendMessage(sender, translate("commands.giveArtifact.usage"));
 			return;
 		}
 
+		// Get the artifact piece ID from the arguments.
 		int itemId;
 		try {
 			itemId = Integer.parseInt(args.remove(0));
@@ -38,20 +119,35 @@ public final class GiveArtifactCommand implements CommandHandler {
 			CommandHandler.sendMessage(sender, translate("commands.giveArtifact.id_error"));
 			return;
 		}
+
 		ItemData itemData = GameData.getItemDataMap().get(itemId);
 		if (itemData.getItemType() != ItemType.ITEM_RELIQUARY) {
 			CommandHandler.sendMessage(sender, translate("commands.giveArtifact.id_error"));
 			return;
 		}
 
+		// Get the main stat from the arguments.
+		// If the given argument is an integer, we use that.
+		// If not, we check if the argument string is in the main prop map.
+		String mainPropIdString = args.remove(0);
 		int mainPropId;
+
 		try {
-			mainPropId = Integer.parseInt(args.remove(0));
+			mainPropId = Integer.parseInt(mainPropIdString);
 		} catch (NumberFormatException ignored) {
+			mainPropId = -1;
+		}
+
+		if (mainPropMap.containsKey(mainPropIdString) && mainPropMap.get(mainPropIdString).containsKey(itemData.getEquipType())) {
+			mainPropId = mainPropMap.get(mainPropIdString).get(itemData.getEquipType());
+		}
+
+		if (mainPropId == -1) {
 			CommandHandler.sendMessage(sender, translate("commands.generic.execution.argument_error"));
 			return;
 		}
 
+		// Get the level from the arguments.
 		int level = 1;
 		try {
 			int last = Integer.parseInt(args.get(args.size()-1));
@@ -62,9 +158,13 @@ public final class GiveArtifactCommand implements CommandHandler {
 		} catch (NumberFormatException ignored) {  // Could be a stat,times string so no need to panic
 		}
 
-		List<Integer> appendPropIdList = new ArrayList<>();
+		// Get substats.
+		ArrayList<Integer> appendPropIdList = new ArrayList<>();
 		try {
+			// Every remaining argument is a substat.
 			args.forEach(it -> {
+				// The substat syntax permits specifying a number of rolls for the given
+				// substat. Split the string into stat and number if that is the case here.
 				String[] arr;
 				int n = 1;
 				if ((arr = it.split(",")).length == 2) {
@@ -74,13 +174,19 @@ public final class GiveArtifactCommand implements CommandHandler {
 						n = 200;
 					}
 				}
-				appendPropIdList.addAll(Collections.nCopies(n, Integer.parseInt(it)));
+
+				// Determine the substat ID.
+				int appendPropId = getAppendPropId(it, itemData);
+
+				// Add the current substat.
+				appendPropIdList.addAll(Collections.nCopies(n, appendPropId));
 			});
 		} catch (Exception ignored) {
 			CommandHandler.sendMessage(sender, translate("commands.execution.argument_error"));
 			return;
 		}
 
+		// Create item for the artifact.
 		GameItem item = new GameItem(itemData);
 		item.setLevel(level);
 		item.setMainPropId(mainPropId);

--- a/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveArtifactCommand.java
@@ -143,7 +143,7 @@ public final class GiveArtifactCommand implements CommandHandler {
 		}
 
 		if (mainPropId == -1) {
-			CommandHandler.sendMessage(sender, translate("commands.generic.execution.argument_error"));
+			CommandHandler.sendMessage(sender, translate("commands.execution.argument_error"));
 			return;
 		}
 


### PR DESCRIPTION
Allow the use of nice names for specifying main and substats when using `/giveart`, because I don't want to look up IDs all the time. For example, the following commands are now valid:

```
/giveart 77524 atk cr_4,3 cdmg_4,3 atk_4 21
/giveart 59530 cr cdmg_4,3 cdmg_3 er_2,2 21
/giveart 63110 phys% 1
/giveart 63410 cryo% cr_3,10 atk%_4 cdmg_4 er_4 21
/giveart 73550 er em_4,3 cr_3,2 cdmg_3 cdmg_4 atk_4,2 21
```

Main stats are specified as one of `hp`, `hp%`, `atk`, `atk%`, `def%`, `er`, `em`, `hb`, `cdmg`, `cr`, `phys%`, `dendro%`, `geo%`, `anemo%`, `hydro%`, `cryo%`, `electro%` and `pyro%`. The implementation is aware that mainstat IDs change depending on artifact piece, so for example `atk%` is mapped to `10990` for sands, `50990` for goblets and `30990` for circlets. The mapping only contains legal main stats for the given piece, so for example `/giveart 73550 cr em_4,3 cr_3,2 cdmg_3 cdmg_4 atk_4,2 21` gives an error (sands can't have a crit rate main stat).

Substats are specified as one of `hp`, `hp%`, `atk`, `atk%`, `def`, `def%`, `er`, `em`, `cr` and `cdmg`, and are followed by a number indicating the roll tier. So, for example, a max roll crit rate substat is `cr_4` (tier 4 roll). The implementation selects the right substat ID based on the specified stat, tier, as well as the rarity of the artifact (the commonly used substat IDs follow the pattern `RSSSST`, where `R` = rarity, `SSSS` = 4 digits specifying the stat, and `T` = tier). The implementation checks whether the specified tier is valid for the given piece. For example, `/giveart 51210 hp% atk_4 21` gives an error because a 2-star piece cannot have a tier 4 substat.

Of course, specifying numeric IDs instead of names is still possible as before.