### PR TITLE
[FIX] Stamina: only handle motion notify for current entity.

### DIFF
--- a/src/main/java/emu/grasscutter/game/managers/StaminaManager/StaminaManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/StaminaManager/StaminaManager.java
@@ -243,15 +243,16 @@ public class StaminaManager {
         cachedEntity = entity;
         MotionInfo motionInfo = moveInfo.getMotionInfo();
         MotionState motionState = motionInfo.getState();
-        boolean isReliable = moveInfo.getIsReliable();
-        Grasscutter.getLogger().trace("" + motionState + "\t" + (isReliable ? "reliable" : ""));
-        if (isReliable) {
-            currentState = motionState;
-            Vector posVector = motionInfo.getPos();
-            Position newPos = new Position(posVector.getX(), posVector.getY(), posVector.getZ());
-            if (newPos.getX() != 0 && newPos.getY() != 0 && newPos.getZ() != 0) {
-                currentCoordinates = newPos;
-            }
+        int notifyEntityId = entity.getId();
+        int currentAvatarEntityId = session.getPlayer().getTeamManager().getCurrentAvatarEntity().getId();
+        if (notifyEntityId != currentAvatarEntityId) {
+            return;
+        }
+        currentState = motionState;
+        Vector posVector = motionInfo.getPos();
+        Position newPos = new Position(posVector.getX(), posVector.getY(), posVector.getZ());
+        if (newPos.getX() != 0 && newPos.getY() != 0 && newPos.getZ() != 0) {
+            currentCoordinates = newPos;
         }
         startSustainedStaminaHandler();
         handleImmediateStamina(session, motionInfo, motionState, entity);


### PR DESCRIPTION
Before I can invest more time working on the stamina system, let's get this in so the system is at least slightly more accurate.

---

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.

