### PR TITLE
Add a handbook search command

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/HandbookCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/HandbookCommand.java
@@ -1,0 +1,107 @@
+package emu.grasscutter.command.commands;
+
+import emu.grasscutter.Grasscutter;
+import emu.grasscutter.command.Command;
+import emu.grasscutter.command.CommandHandler;
+import emu.grasscutter.database.DatabaseHelper;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.utils.Utils;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static emu.grasscutter.utils.Language.translate;
+
+@Command(label = "handbook", usage = "handbook <search term>", description = "commands.handbook.description", aliases = {"hb"}, permission = "server.handbook")
+public final class HandbookCommand implements CommandHandler {
+    HashMap<String, HashMap<String, Integer>> handbook;
+    HashMap<Integer, String> realNames;
+    List<String> categories = Arrays.asList("// Avatars", "// Items", "// Scenes", "// Monsters");
+    Pattern entryRegex = Pattern.compile("(\\d+) : (.*)");
+    Pattern replaceRegex = Pattern.compile("\\W");
+
+    private void parseHandbook() {
+		String fileName = "./GM Handbook.txt";
+        handbook = new HashMap<String, HashMap<String, Integer>>();
+        realNames = new HashMap<Integer, String>();
+        
+        try {
+            FileInputStream stream = new FileInputStream(Utils.toFilePath(fileName));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
+			String line;
+            HashMap<String, Integer> category = null;
+            while ((line = reader.readLine()) != null) {
+				if (line.startsWith("//")) {
+                    if (categories.contains(line)) {
+                        category = new HashMap<String, Integer>();
+                        handbook.put(line, category);
+                    }
+                } else if (category != null) {
+                    Matcher match = entryRegex.matcher(line);
+                    if (match.find()) {
+                        int id = Integer.parseInt(match.group(1));
+                        String name = match.group(2);
+                        realNames.put(id, name);  // Our keys will not be nice to read so we want to be able to refer back to the real names
+                        if (name.length() > 0) {
+                            name = replaceRegex.matcher(name).replaceAll("");  // Strip all non-letters
+                            name = name.toLowerCase();
+                            category.put(name, id);
+                        }
+                    }
+                } else {
+                    // CommandHandler.sendMessage(null, line);
+                }
+			}
+            stream.close();
+		} catch (IOException e) {
+			Grasscutter.getLogger().warn("Failed to read handbook.");
+		} catch (NullPointerException ignored) {
+			Grasscutter.getLogger().warn("Failed to read handbook.");
+			return;
+		} catch (Exception e) {
+			Grasscutter.getLogger().warn("Failed to read handbook.");
+            return;
+        }
+    }
+
+    @Override
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
+        if (handbook == null) {
+            parseHandbook();
+        }
+        if (args.size() < 1) {
+            CommandHandler.sendMessage(sender, String.format("Usage: handbook. Entries: %d", handbook.size()));
+            return;
+        }
+
+        String query = args.get(0).toLowerCase();
+        ArrayList<Integer> matches = new ArrayList<Integer>();
+        ArrayList<String> matchesStrs = new ArrayList<String>();
+        for (String category : categories) {
+            boolean printedCategory = false;
+            HashMap<String, Integer> c = handbook.get(category);
+            // CommandHandler.sendMessage(sender, String.format("Checking category \"%s\" of size %d", category, c.size()));
+            for (String key : c.keySet()) {
+                if (key.contains(query)) {
+                    int id = c.get(key);
+                    matches.add(id);
+                    if (!printedCategory) {
+                        matchesStrs.add(category);
+                        printedCategory = true;
+                    }
+                    matchesStrs.add(String.format("%d : %s", id, realNames.get(id)));
+                }
+            }
+        }
+        CommandHandler.sendMessage(sender, String.join("\n", matchesStrs));
+    }
+}


### PR DESCRIPTION
## Description
Adds a `/handbook` command for quick searching of ids.
![image](https://user-images.githubusercontent.com/5397662/167443259-0642ebf8-1c3a-4638-be39-5923ed3ff823.png)

Searching is case-insensitive and strips all non-letter characters.

No idea how this will work on other languages. (also I haven't done the language file stuff yet)

Should probably be mostly offloaded into some Utils wrapper to better allow integration with other commands (i.e. let other commands take string parameters instead of itemIDs and succeed if there's one match, or print all matches and ask for the command again with a more specific query)

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.