### PR TITLE
Change `account delete` to delete all data elements referenced by the deleted account.

### DIFF
--- a/src/main/java/emu/grasscutter/database/DatabaseHelper.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseHelper.java
@@ -3,6 +3,8 @@ package emu.grasscutter.database;
 import java.util.List;
 
 import com.mongodb.client.result.DeleteResult;
+
+import dev.morphia.experimental.MorphiaSession;
 import dev.morphia.query.FindOptions;
 import dev.morphia.query.Sort;
 import dev.morphia.query.experimental.filters.Filters;
@@ -95,8 +97,31 @@ public final class DatabaseHelper {
 		return DatabaseManager.getDatastore().find(Account.class).filter(Filters.eq("playerId", playerId)).first();
 	}
 
-	public static boolean deleteAccount(String username) {
-		return DatabaseManager.getDatastore().find(Account.class).filter(Filters.eq("username", username)).delete().getDeletedCount() > 0;
+	//public static boolean deleteAccount(String username) {
+	//	return DatabaseManager.getDatastore().find(Account.class).filter(Filters.eq("username", username)).delete().getDeletedCount() > 0;
+	//}
+	public static void deleteAccount(Account target) {
+		// To delete an account, we need to also delete all the other documents in the database that reference the account.
+		// This should optimally be wrapped inside a transaction, to make sure an error thrown mid-way does not leave the
+		// database in an inconsistent state, but unfortunately Mongo only supports that when we have a replica set ...
+		
+		// Delete mails, gacha records, items and avatars.
+		DatabaseManager.getDatastore().find(Mail.class).filter(Filters.eq("ownerUid", target.getPlayerUid())).delete();
+		DatabaseManager.getDatastore().find(GachaRecord.class).filter(Filters.eq("ownerId", target.getPlayerUid())).delete();
+		DatabaseManager.getDatastore().find(GameItem.class).filter(Filters.eq("ownerId", target.getPlayerUid())).delete();
+		DatabaseManager.getDatastore().find(Avatar.class).filter(Filters.eq("ownerId", target.getPlayerUid())).delete();
+
+		// Delete friendships.
+		// Here, we need to make sure to not only delete the deleted account's friendships,
+		// but also all friendship entries for that account's friends.
+		DatabaseManager.getDatastore().find(Friendship.class).filter(Filters.eq("ownerId", target.getPlayerUid())).delete();
+		DatabaseManager.getDatastore().find(Friendship.class).filter(Filters.eq("friendId", target.getPlayerUid())).delete();
+
+		// Delete the player.
+		DatabaseManager.getDatastore().find(Player.class).filter(Filters.eq("id", target.getPlayerUid())).delete();
+
+		// Finally, delete the account itself.
+		DatabaseManager.getDatastore().find(Account.class).filter(Filters.eq("id", target.getId())).delete();
 	}
 
 	public static List<Player> getAllPlayers() {

--- a/src/main/java/emu/grasscutter/database/DatabaseHelper.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseHelper.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import com.mongodb.client.result.DeleteResult;
 
-import dev.morphia.experimental.MorphiaSession;
 import dev.morphia.query.FindOptions;
 import dev.morphia.query.Sort;
 import dev.morphia.query.experimental.filters.Filters;
@@ -97,14 +96,11 @@ public final class DatabaseHelper {
 		return DatabaseManager.getDatastore().find(Account.class).filter(Filters.eq("playerId", playerId)).first();
 	}
 
-	//public static boolean deleteAccount(String username) {
-	//	return DatabaseManager.getDatastore().find(Account.class).filter(Filters.eq("username", username)).delete().getDeletedCount() > 0;
-	//}
 	public static void deleteAccount(Account target) {
 		// To delete an account, we need to also delete all the other documents in the database that reference the account.
 		// This should optimally be wrapped inside a transaction, to make sure an error thrown mid-way does not leave the
 		// database in an inconsistent state, but unfortunately Mongo only supports that when we have a replica set ...
-		
+
 		// Delete mails, gacha records, items and avatars.
 		DatabaseManager.getDatastore().find(Mail.class).filter(Filters.eq("ownerUid", target.getPlayerUid())).delete();
 		DatabaseManager.getDatastore().find(GachaRecord.class).filter(Filters.eq("ownerId", target.getPlayerUid())).delete();


### PR DESCRIPTION
## Description

Currently, the `account delete` command only deletes the account itself, not any other data elements belonging to that account, like player, items, avatars etc. Judging by the messages in the #support channel on Discord, this has lead to some confusion and problems.

This PR changes the behavior of `account delete` to delete everything that belongs to the deleted account. It also makes sure that the player that belongs to the deleted account is kicked before the deletion, if they are currently online.

## Type of changes

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.