### PR TITLE
Disable falling damage for godmode

### DIFF
--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerCombatInvocationsNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerCombatInvocationsNotify.java
@@ -102,6 +102,10 @@ public class HandlerCombatInvocationsNotify extends PacketHandler {
 		if (cachedLandingSpeed < -28) {
 			damageFactor = 1f;
 		}
+		// Disable falling damage for players in god mode.
+		if (session.getPlayer() != null && session.getPlayer().inGodmode()) {
+			damageFactor = 0;
+		}
 		float damage = maxHP * damageFactor;
 		float newHP = currentHP - damage;
 		if (newHP < 0) {


### PR DESCRIPTION
## Description

Updated `HandlerCombatInvocationsNotify::handleFallOnGround`
Disables falling damage for players having their godmode on.

## Type of changes

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.