### PR TITLE
[Fix] Stamina will be set to full if Stamina is disabled.

### DIFF
--- a/src/main/java/emu/grasscutter/game/managers/StaminaManager/StaminaManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/StaminaManager/StaminaManager.java
@@ -190,17 +190,17 @@ public class StaminaManager {
 
     // Returns new stamina and sends PlayerPropNotify
     public int setStamina(GameSession session, String reason, int newStamina) {
-        if (Grasscutter.getConfig().OpenStamina) {
-            // set stamina
-            player.setProperty(PlayerProperty.PROP_CUR_PERSIST_STAMINA, newStamina);
-            session.send(new PacketPlayerPropNotify(player, PlayerProperty.PROP_CUR_PERSIST_STAMINA));
-            // notify updated
-            for (Map.Entry<String, AfterUpdateStaminaListener> listener : afterUpdateStaminaListeners.entrySet()) {
-                listener.getValue().onAfterUpdateStamina(reason, newStamina);
-            }
-            return newStamina;
+        if (!Grasscutter.getConfig().OpenStamina) {
+            newStamina = player.getProperty(PlayerProperty.PROP_MAX_STAMINA);
         }
-        return player.getProperty(PlayerProperty.PROP_CUR_PERSIST_STAMINA);
+        // set stamina
+        player.setProperty(PlayerProperty.PROP_CUR_PERSIST_STAMINA, newStamina);
+        session.send(new PacketPlayerPropNotify(player, PlayerProperty.PROP_CUR_PERSIST_STAMINA));
+        // notify updated
+        for (Map.Entry<String, AfterUpdateStaminaListener> listener : afterUpdateStaminaListeners.entrySet()) {
+            listener.getValue().onAfterUpdateStamina(reason, newStamina);
+        }
+        return newStamina;
     }
 
     // Kills avatar, removes entity and sends notification.


### PR DESCRIPTION
## Issues fixed by this PR
There are reports saying if they restart the server with stamina disabled when their stamina is empty, the stamina will remain empty and will not recover at all. This commit set stamina to full if stamina is disabled in the config.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.