### PR TITLE
[Enhance] Temporarily set statue auto use to 1 and 100%.

### DIFF
--- a/src/main/java/emu/grasscutter/game/managers/SotSManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/SotSManager.java
@@ -93,9 +93,14 @@ public class SotSManager {
     }
 
     public void refillSpringVolume() {
-        // TODO: max spring volume depends on level of the statues in Mondstadt and Liyue.
+        // Temporary: Max spring volume depends on level of the statues in Mondstadt and Liyue. Override until we have statue level.
+        // TODO: remove
         // https://genshin-impact.fandom.com/wiki/Statue_of_The_Seven#:~:text=region%20of%20Inazuma.-,Statue%20Levels,-Upon%20first%20unlocking
         player.setProperty(PlayerProperty.PROP_MAX_SPRING_VOLUME, 8500000);
+        // Temporary: Auto enable 100% statue recovery until we can adjust statue settings in game
+        // TODO: remove
+        player.setProperty(PlayerProperty.PROP_SPRING_AUTO_USE_PERCENT, 100);
+        player.setProperty(PlayerProperty.PROP_IS_SPRING_AUTO_USE, 1);
 
         long now = System.currentTimeMillis() / 1000;
         long secondsSinceLastUsed = now - player.getSpringLastUsed();


### PR DESCRIPTION
## Description

People are complaining that they can only recover 50% at the statue, which is the default settings for new player. Temporarily set to 100% until we can adjust this settings in game.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.