### PR TITLE
[Fix] incorrect ascension level in givechar command

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/GiveCharCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveCharCommand.java
@@ -63,9 +63,10 @@ public final class GiveCharCommand implements CommandHandler {
         // Calculate ascension level.
         int ascension;
         if (level <= 40) {
-            ascension = (int) Math.ceil(level / 20f);
+            ascension = (int) Math.ceil(level / 20f) - 1;
         } else {
             ascension = (int) Math.ceil(level / 10f) - 3;
+            ascension = Math.min(ascension, 6);
         }
 
         Avatar avatar = new Avatar(avatarId);


### PR DESCRIPTION
1. Characters <= Lv.20 should never be asc 1.
2. Make Lv.20 asc 0 to allow testing with lv 20 characters without asc. Might be useful for testing world-level increase and other scenarios. People who give themselves characters <= lv90 clearly know what they want, also asc 1 is just one click away, so it should be fine. Same for other levels.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.