### PR TITLE
Add Server status API for three-party game launcher

### DIFF
--- a/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.protobuf.ByteString;
 
+import emu.grasscutter.GameConstants;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.Grasscutter.ServerDebugMode;
 import emu.grasscutter.Grasscutter.ServerRunMode;
@@ -257,6 +258,15 @@ public final class DispatchServer {
 		httpServer.post("/authentication/login", (req, res) -> this.getAuthHandler().handleLogin(req, res));
 		httpServer.post("/authentication/register", (req, res) -> this.getAuthHandler().handleRegister(req, res));
 		httpServer.post("/authentication/change_password", (req, res) -> this.getAuthHandler().handleChangePassword(req, res));
+
+		// Server Status
+		httpServer.get("/status/server", (req, res) -> {
+
+			int playerCount = Grasscutter.getGameServer().getPlayers().size();
+			String version = GameConstants.VERSION;
+
+			res.send("{\"retcode\":0,\"status\":{\"playerCount\":" + playerCount + ",\"version\":\"" + version + "\"}}");
+		});
 
 		// Dispatch
 		httpServer.get("/query_region_list", (req, res) -> {


### PR DESCRIPTION
## Description

- Show game version and number of players to three-party launcher

## Type of changes

- [ ] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.