### PR TITLE
Removed invalid code in getLanguageFileDescription,When the language is not discovered, it will use the built-in language fallback mechanism to fall back,At the same time, we also fix the issue that using language in the server does not save the settings of the server side locale

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/LanguageCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/LanguageCommand.java
@@ -44,6 +44,13 @@ public final class LanguageCommand implements CommandHandler {
             actualLangCode = languageInst.getLanguageCode();
             Grasscutter.setLanguage(languageInst);
         }
+
+        if (!langCode.equals(actualLangCode)) {
+            // I think there is no necessary to register this in language files
+            // since this will always be english
+            CommandHandler.sendMessage(sender, "currently, server does not have that language: " + langCode);
+        }
+
         CommandHandler.sendMessage(sender, translate(sender, "commands.language.language_changed", actualLangCode));
 
     }

--- a/src/main/java/emu/grasscutter/command/commands/LanguageCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/LanguageCommand.java
@@ -31,24 +31,24 @@ public final class LanguageCommand implements CommandHandler {
         }
 
         String langCode = args.get(0);
-        String actualLangCode = null;
+
+        var languageInst = Grasscutter.getLanguage(langCode);
+        var actualLangCode = languageInst.getLanguageCode();
+        var locale = Locale.forLanguageTag(actualLangCode);
         if (sender != null) {
-            var locale = Locale.forLanguageTag(langCode);
-            actualLangCode = Utils.getLanguageCode(locale);
             var account = sender.getAccount();
             account.setLocale(locale);
             account.save();
         }
         else {
-            var languageInst = Grasscutter.getLanguage(langCode);
-            actualLangCode = languageInst.getLanguageCode();
             Grasscutter.setLanguage(languageInst);
+            var config = Grasscutter.getConfig();
+            config.language.language = locale;
+            Grasscutter.saveConfig(config);
         }
 
         if (!langCode.equals(actualLangCode)) {
-            // I think there is no necessary to register this in language files
-            // since this will always be english
-            CommandHandler.sendMessage(sender, "currently, server does not have that language: " + langCode);
+            CommandHandler.sendMessage(sender, translate(sender, "commands.language.language_not_found", langCode));
         }
 
         CommandHandler.sendMessage(sender, translate(sender, "commands.language.language_changed", actualLangCode));

--- a/src/main/java/emu/grasscutter/utils/Language.java
+++ b/src/main/java/emu/grasscutter/utils/Language.java
@@ -125,23 +125,23 @@ public final class Language {
         InputStream file = Grasscutter.class.getResourceAsStream("/languages/" + fileName);
 
         if (file == null) { // Provided fallback language.
+            Grasscutter.getLogger().warn("Failed to load language file: " + fileName + ", falling back to: " + fallback);
             actualLanguageCode = fallbackLanguageCode;
             if (cachedLanguages.containsKey(actualLanguageCode)) {
                 return new LanguageStreamDescription(actualLanguageCode, null);
             }
             
             file = Grasscutter.class.getResourceAsStream("/languages/" + fallback);
-            Grasscutter.getLogger().warn("Failed to load language file: " + fileName + ", falling back to: " + fallback);
         }
 
         if(file == null) { // Fallback the fallback language.
+            Grasscutter.getLogger().warn("Failed to load language file: " + fallback + ", falling back to: en-US.json");
             actualLanguageCode = "en-US";
             if (cachedLanguages.containsKey(actualLanguageCode)) {
                 return new LanguageStreamDescription(actualLanguageCode, null);
             }
             
             file = Grasscutter.class.getResourceAsStream("/languages/en-US.json");
-            Grasscutter.getLogger().warn("Failed to load language file: " + fallback + ", falling back to: en-US.json");
         }
 
         if(file == null)

--- a/src/main/java/emu/grasscutter/utils/Language.java
+++ b/src/main/java/emu/grasscutter/utils/Language.java
@@ -116,12 +116,8 @@ public final class Language {
     private static LanguageStreamDescription getLanguageFileDescription(String languageCode, String fallbackLanguageCode) {
         var fileName = languageCode + ".json";
         var fallback = fallbackLanguageCode + ".json";
-
-        String actualLanguageCode = languageCode;
-        if (cachedLanguages.containsKey(actualLanguageCode)) {
-            return new LanguageStreamDescription(actualLanguageCode, null);
-        }
         
+        String actualLanguageCode = languageCode;
         InputStream file = Grasscutter.class.getResourceAsStream("/languages/" + fileName);
 
         if (file == null) { // Provided fallback language.

--- a/src/main/resources/languages/en-US.json
+++ b/src/main/resources/languages/en-US.json
@@ -191,6 +191,7 @@
     "language": {
       "current_language": "current language is %s",
       "language_changed": "language changed to %s",
+      "language_not_found": "currently, server does not have that language: %s",
       "description": "display or change current language"
     },
     "list": {

--- a/src/main/resources/languages/zh-CN.json
+++ b/src/main/resources/languages/zh-CN.json
@@ -191,6 +191,7 @@
     "language": {
       "current_language": "当前语言是: %s",
       "language_changed": "语言切换至: %s",
+      "language_not_found": "目前服务端没有这种语言: %s",
       "description": "显示或切换当前语言。"
     },
     "list": {


### PR DESCRIPTION
## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] My pull request is unique and no other pull requests have been opened for these changes
- [ ] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [ ] I am responsible for any copyright issues with my code if it occurs in the future.