### PR TITLE
[Plugin API Support] Add verifyUser to AuthenticationHandler

### DIFF
--- a/src/main/java/emu/grasscutter/server/dispatch/authentication/AuthenticationHandler.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/authentication/AuthenticationHandler.java
@@ -12,5 +12,12 @@ public interface AuthenticationHandler {
     void handleRegister(Request req, Response res);
     void handleChangePassword(Request req, Response res);
 
+    /**
+     * Other plugins may need to verify a user's identity using details from handleLogin()
+     * @param details The user's unique one-time token that needs to be verified
+     * @return If the verification was successful
+     */
+    boolean verifyUser(String details);
+
     LoginResultJson handleGameLogin(Request req, LoginAccountRequestJson requestData);
 }

--- a/src/main/java/emu/grasscutter/server/dispatch/authentication/DefaultAuthenticationHandler.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/authentication/DefaultAuthenticationHandler.java
@@ -29,6 +29,12 @@ public class DefaultAuthenticationHandler implements AuthenticationHandler {
     }
 
     @Override
+    public boolean verifyUser(String details) {
+        Grasscutter.getLogger().info(translate("dispatch.authentication.default_unable_to_verify"));
+        return false;
+    }
+
+    @Override
     public LoginResultJson handleGameLogin(Request req, LoginAccountRequestJson requestData) {
         LoginResultJson responseData = new LoginResultJson();
 

--- a/src/main/resources/languages/en-US.json
+++ b/src/main/resources/languages/en-US.json
@@ -16,6 +16,9 @@
         "no_keystore_error": "[Dispatch] No SSL cert found! Falling back to HTTP server.",
         "default_password": "[Dispatch] The default keystore password was loaded successfully. Please consider setting the password to 123456 in config.json."
       },
+      "authentication": {
+        "default_unable_to_verify": "[Authentication] Something called the verifyUser method which is unavailable in the default authentication handler"
+      },
       "no_commands_error": "Commands are not supported in dispatch only mode.",
       "unhandled_request_error": "[Dispatch] Potential unhandled %s request: %s",
       "account": {


### PR DESCRIPTION
## Description

This PR adds a verifyUser function to the AuthenticationHandler for other plugins to call to verify a user's identity through whatever handleLogin returned.

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR
None.
<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.