### PR TITLE
[Feature/Fix] Update stamina manager

### DIFF
--- a/src/main/java/emu/grasscutter/Grasscutter.java
+++ b/src/main/java/emu/grasscutter/Grasscutter.java
@@ -4,6 +4,7 @@ import java.io.*;
 import java.util.Calendar;
 
 import emu.grasscutter.command.CommandMap;
+import emu.grasscutter.game.managers.StaminaManager.StaminaManager;
 import emu.grasscutter.plugin.PluginManager;
 import emu.grasscutter.plugin.api.ServerHook;
 import emu.grasscutter.scripts.ScriptLoader;
@@ -110,6 +111,9 @@ public final class Grasscutter {
 		new ServerHook(gameServer, dispatchServer);
 		// Create plugin manager instance.
 		pluginManager = new PluginManager();
+
+		// TODO: find a better place?
+		StaminaManager.initialize();
 	
 		// Start servers.
 		var runMode = SERVER.runMode;

--- a/src/main/java/emu/grasscutter/game/managers/StaminaManager/AfterUpdateStaminaListener.java
+++ b/src/main/java/emu/grasscutter/game/managers/StaminaManager/AfterUpdateStaminaListener.java
@@ -8,5 +8,5 @@ public interface AfterUpdateStaminaListener {
      * @param reason     Why updating stamina.
      * @param newStamina New Stamina value.
      */
-    void onAfterUpdateStamina(String reason, int newStamina);
+    void onAfterUpdateStamina(String reason, int newStamina, boolean isCharacterStamina);
 }

--- a/src/main/java/emu/grasscutter/game/managers/StaminaManager/BeforeUpdateStaminaListener.java
+++ b/src/main/java/emu/grasscutter/game/managers/StaminaManager/BeforeUpdateStaminaListener.java
@@ -8,7 +8,7 @@ public interface BeforeUpdateStaminaListener {
      * @param newStamina New ABSOLUTE stamina value.
      * @return true if you want to cancel this update, otherwise false.
      */
-    int onBeforeUpdateStamina(String reason, int newStamina);
+    int onBeforeUpdateStamina(String reason, int newStamina, boolean isCharacterStamina);
     /**
      * onBeforeUpdateStamina() will be called before StaminaManager attempt to update the player's current stamina.
      * This gives listeners a chance to intercept this update.
@@ -16,5 +16,5 @@ public interface BeforeUpdateStaminaListener {
      * @param consumption ConsumptionType and RELATIVE stamina change amount.
      * @return true if you want to cancel this update, otherwise false.
      */
-    Consumption onBeforeUpdateStamina(String reason, Consumption consumption);
+    Consumption onBeforeUpdateStamina(String reason, Consumption consumption, boolean isCharacterStamina);
 }

--- a/src/main/java/emu/grasscutter/game/managers/StaminaManager/ConsumptionType.java
+++ b/src/main/java/emu/grasscutter/game/managers/StaminaManager/ConsumptionType.java
@@ -13,18 +13,19 @@ public enum ConsumptionType {
     // Slow swimming is handled per movement, not per second.
     // Arm movement frequency depends on gender/age/height.
     // TODO: Instead of cost -80 per tick, find a proper way to calculate cost.
-    SKIFF(-300), // TODO: Get real value
+    SKIFF_DASH(-204),
     SPRINT(-1800),
-    SWIM_DASH_START(-20),
+    SWIM_DASH_START(-2000),
     SWIM_DASH(-204), // -10.2 per second, 5Hz = -204 each tick
     SWIMMING(-80),
     TALENT_DASH(-300), // -1500 per second, 5Hz = -300 each tick
     TALENT_DASH_START(-1000),
 
     // restore
-    POWERED_FLY(500), // TODO: Get real value
-    POWERED_SKIFF(2000), // TODO: Get real value
+    POWERED_FLY(500),
+    POWERED_SKIFF(500),
     RUN(500),
+    SKIFF(500),
     STANDBY(500),
     WALK(500);
 

--- a/src/main/java/emu/grasscutter/game/managers/StaminaManager/StaminaManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/StaminaManager/StaminaManager.java
@@ -262,7 +262,7 @@ public class StaminaManager {
             }
         }
         int maxStamina = isCharacterStamina ? getMaxCharacterStamina() : getMaxVehicleStamina();
-        logger.warn((isCharacterStamina ? "C " : "V ") + currentStamina + "/" + maxStamina + "\t" + currentState + "\t" +
+        logger.trace((isCharacterStamina ? "C " : "V ") + currentStamina + "/" + maxStamina + "\t" + currentState + "\t" +
                 (isPlayerMoving() ? "moving" : "      ") + "\t(" + consumption.type + "," +
                 consumption.amount + ")");
         int newStamina = currentStamina + consumption.amount;

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -1237,7 +1237,7 @@ public class Player {
 		} else if (prop == PlayerProperty.PROP_IS_TRANSFERABLE) { // 10009
 			if (!(0 <= value && value <= 1)) { return false; }
 		} else if (prop == PlayerProperty.PROP_MAX_STAMINA) { // 10010
-			if (!(value >= 0 && value <= StaminaManager.GlobalMaximumStamina)) { return false; }
+			if (!(value >= 0 && value <= StaminaManager.GlobalCharacterMaximumStamina)) { return false; }
 		} else if (prop == PlayerProperty.PROP_CUR_PERSIST_STAMINA) { // 10011
 			int playerMaximumStamina = getProperty(PlayerProperty.PROP_MAX_STAMINA);
 			if (!(value >= 0 && value <= playerMaximumStamina)) { return false; }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerVehicleInteractReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerVehicleInteractReq.java
@@ -14,6 +14,7 @@ public class HandlerVehicleInteractReq extends PacketHandler {
 	@Override
 	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
 		VehicleInteractReqOuterClass.VehicleInteractReq req = VehicleInteractReqOuterClass.VehicleInteractReq.parseFrom(payload);
+		session.getPlayer().getStaminaManager().handleVehicleInteractReq(session, req.getEntityId(), req.getInteractType());
 		session.send(new PacketVehicleInteractRsp(session.getPlayer(), req.getEntityId(), req.getInteractType()));
 	}
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketVehicleStaminaNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketVehicleStaminaNotify.java
@@ -1,17 +1,16 @@
 package emu.grasscutter.server.packet.send;
 
-import emu.grasscutter.game.entity.GameEntity;
 import emu.grasscutter.net.packet.BasePacket;
 import emu.grasscutter.net.packet.PacketOpcodes;
 import emu.grasscutter.net.proto.VehicleStaminaNotifyOuterClass.VehicleStaminaNotify;
 
 public class PacketVehicleStaminaNotify extends BasePacket {
 
-	public PacketVehicleStaminaNotify(GameEntity entity, int newStamina) {
+	public PacketVehicleStaminaNotify(int vehicleId, float newStamina) {
 		super(PacketOpcodes.VehicleStaminaNotify);
 		VehicleStaminaNotify.Builder proto = VehicleStaminaNotify.newBuilder();
 
-		proto.setEntityId(entity.getId());
+		proto.setEntityId(vehicleId);
 		proto.setCurStamina(newStamina);
 
 		this.setData(proto.build());

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketVehicleStaminaNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketVehicleStaminaNotify.java
@@ -1,0 +1,19 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.game.entity.GameEntity;
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.VehicleStaminaNotifyOuterClass.VehicleStaminaNotify;
+
+public class PacketVehicleStaminaNotify extends BasePacket {
+
+	public PacketVehicleStaminaNotify(GameEntity entity, int newStamina) {
+		super(PacketOpcodes.VehicleStaminaNotify);
+		VehicleStaminaNotify.Builder proto = VehicleStaminaNotify.newBuilder();
+
+		proto.setEntityId(entity.getId());
+		proto.setCurStamina(newStamina);
+
+		this.setData(proto.build());
+	}
+}


### PR DESCRIPTION
## Description

1. Update function signatures to prepare for vehicle stamina.
3. Remove hard-coded skills.
2. Wind resonance -15% stamina cost.
4. Climb talent cost reduction.
5. Swim talent cost reduction.
6. Diluc will now consume stamina at full price if talent not activated.
7. Sayu's windwheel no longer consumes stamina.
8. Removed "[StaminaManager]" prefix from log.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.