### PR TITLE
Fix InRouting on dispatch server

### DIFF
--- a/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/DispatchServer.java
@@ -117,7 +117,7 @@ public final class DispatchServer {
 						.setTitle(DISPATCH_INFO.defaultName)
 						.setType("DEV_PUBLIC")
 						.setDispatchUrl(
-								"http" + (DISPATCH_ENCRYPTION.useEncryption ? "s" : "") + "://"
+								"http" + (DISPATCH_ENCRYPTION.useInRouting ? "s" : "") + "://"
 										+ lr(DISPATCH_INFO.accessAddress, DISPATCH_INFO.bindAddress) + ":"
 										+ lr(DISPATCH_INFO.accessPort, DISPATCH_INFO.bindPort)
 										+ "/query_cur_region/" + defaultServerName)
@@ -150,7 +150,7 @@ public final class DispatchServer {
 						.setTitle(regionInfo.Title)
 						.setType("DEV_PUBLIC")
 						.setDispatchUrl(
-								"http" + (DISPATCH_ENCRYPTION.useEncryption ? "s" : "") + "://"
+								"http" + (DISPATCH_ENCRYPTION.useInRouting ? "s" : "") + "://"
 										+ lr(DISPATCH_INFO.accessAddress, DISPATCH_INFO.bindAddress) + ":" 
 										+ lr(DISPATCH_INFO.accessPort, DISPATCH_INFO.bindPort) 
 										+ "/query_cur_region/" + regionInfo.Name)


### PR DESCRIPTION
## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR

Currently, Dispatch server only sends the Game server as https if the encryption is enabled. That can cause problems for people which run Grasscutter via a reverse proxy.
<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.