### PR TITLE
Add block game update option

### DIFF
--- a/src/main/java/emu/grasscutter/utils/ConfigContainer.java
+++ b/src/main/java/emu/grasscutter/utils/ConfigContainer.java
@@ -126,6 +126,7 @@ public class ConfigContainer {
         public Region[] regions = {};
 
         public String defaultName = "Grasscutter";
+        public boolean blockGameUpdate = false;
     }
 
     public static class Game {

--- a/src/main/resources/languages/en-US.json
+++ b/src/main/resources/languages/en-US.json
@@ -36,7 +36,8 @@
         "session_key_error": "Wrong session key.",
         "username_error": "Username not found.",
         "username_create_error": "Username not found, create failed."
-      }
+      },
+      "block_game_update_tlsv1": "blockGameUpdate will not work because TLSv1 not enabled in current Java runtime. Change 'jdk.tls.disabledAlgorithms' option in 'conf/security/java.security' file"
     },
     "status": {
       "free_software": "Grasscutter is FREE software. If you have paid for this, you may have been scammed. Homepage: https://github.com/Grasscutters/Grasscutter",


### PR DESCRIPTION
## Description
Implemented fake update check API to block game update, enable the game to be played without internet connetion. current mitmproxy script (and fiddler script i guess) require dns lookup and will establish conneciton with official server (without sending data though). so it must be used together with my mitmproxy script 


this option is disabled by default as it needed to modify config file in JRE: https://www.petefreitag.com/item/916.cfm ,
and i have only tested on my up-to-date 2.6 global client

## Issues fixed by this PR
https://github.com/Grasscutters/Grasscutter/issues/326
https://github.com/Grasscutters/Grasscutter/issues/664

## Type of changes
<!--- Put an `x` in all the boxes that apply your changes. -->


- [ ] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.