### PR TITLE
Don't silently overwrite config.json if there is an error.

### DIFF
--- a/src/main/java/emu/grasscutter/Grasscutter.java
+++ b/src/main/java/emu/grasscutter/Grasscutter.java
@@ -153,16 +153,23 @@ public final class Grasscutter {
 	 * Attempts to load the configuration from a file.
 	 */
 	public static void loadConfig() {
+		// Check if config.json exists. If not, we generate a new config.
+		if (!configFile.exists()) {
+			getLogger().info("config.json could not be found. Generating a default configuration ...");
+			Grasscutter.saveConfig(null);
+			config = new ConfigContainer();
+			return;
+		} 
+
+		// If the file already exists, we attempt to load it.
 		try (FileReader file = new FileReader(configFile)) {
 			config = gson.fromJson(file, ConfigContainer.class);
-		} catch (Exception exception) {
-			Grasscutter.saveConfig(null);
-			config = new ConfigContainer();
-		} catch (Error error) {
-			// Occurred probably from an outdated config file.
-			Grasscutter.saveConfig(null);
-			config = new ConfigContainer();
 		}
+		// If loading was not successfull, we terminate with a useful error message. 
+		catch (Exception exception) {
+			getLogger().error("There was an error while trying to load the configuration from config.json. Please make sure that there are no syntax errors. If you want to start with a default configuration, delete your existing config.json.");
+			System.exit(1);
+		} 
 	}
 
 	public static void loadLanguage() {

--- a/src/main/java/emu/grasscutter/Grasscutter.java
+++ b/src/main/java/emu/grasscutter/Grasscutter.java
@@ -156,8 +156,8 @@ public final class Grasscutter {
 		// Check if config.json exists. If not, we generate a new config.
 		if (!configFile.exists()) {
 			getLogger().info("config.json could not be found. Generating a default configuration ...");
-			Grasscutter.saveConfig(null);
 			config = new ConfigContainer();
+			Grasscutter.saveConfig(config);
 			return;
 		} 
 


### PR DESCRIPTION
## Description

Currently, when loading config.json encounters an error, we silently replace it with a default config. This PR changes the behavior of config loading as follows:
- When there is _no_ config file, we create a default config.
- When the config file could be loaded successfully, we proceed as usual.
- When the config file could not be loaded, we print a useful error message and terminate.

I also removed the `catch (Error)` we had in the config loading logic, for obvious reasons.

## Issues fixed by this PR

#794

## Type of changes

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.