### PR TITLE
Fix connot execute quest command in console

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/QuestCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/QuestCommand.java
@@ -37,7 +37,7 @@ public final class QuestCommand implements CommandHandler {
 		
 		switch (cmd) {
 			case "add" -> {
-				GameQuest quest = sender.getQuestManager().addQuest(questId);
+				GameQuest quest = targetPlayer.getQuestManager().addQuest(questId);
 				
 				if (quest != null) {
 					CommandHandler.sendMessage(sender, translate(sender, "commands.quest.added", questId));
@@ -47,7 +47,7 @@ public final class QuestCommand implements CommandHandler {
 				CommandHandler.sendMessage(sender, translate(sender, "commands.quest.not_found"));
 			}
 			case "finish" -> {
-				GameQuest quest = sender.getQuestManager().getQuestById(questId);
+				GameQuest quest = targetPlayer.getQuestManager().getQuestById(questId);
 				
 				if (quest == null) {
 					CommandHandler.sendMessage(sender, translate(sender, "commands.quest.not_found"));


### PR DESCRIPTION
## Description
When executing the /quest command, the program will get "quest" from "targetPlayer" instead of "sender" which will cause an error when using it in console.

## Issues fixed by this PR
Command quest is unable to run in console although you have already run /target before

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.