### PR TITLE
Add handler for announcement images

### DIFF
--- a/data/GameAnnouncement.json
+++ b/data/GameAnnouncement.json
@@ -4,7 +4,7 @@
       "ann_id": 1,
       "title": "<strong>Welcome to Grasscutter!</strong>",
       "subtitle": "Welcome!",
-      "banner": "https://uploadstatic-sea.mihoyo.com/announcement/2020/09/17/f4aa42d505822805eebf4a55d72a78d8_2755691727027973637.jpg",
+      "banner": "https://uploadstatic-sea.mihoyo.com/hk4e/announcement/image/banner2.jpg",
       "content": "<p>Hi there!</p><p>First of all, welcome to Grasscutter. If you have any issues, please let us know so that Lawnmower can help you!</p><br><p><strong>〓Discord〓</strong></p><a href=\"https://discord.gg/T5vZU6UyeG\">https://discord.gg/T5vZU6UyeG</a><br><br><p><strong>〓GitHub〓</strong><a href=\"https://github.com/Grasscutters/Grasscutter\">https://github.com/Grasscutters/Grasscutter</a>",
 
       "lang": "en-US"
@@ -13,8 +13,16 @@
       "ann_id": 2,
       "title": "<strong>How to use announcements</strong>",
       "subtitle": "How to use announcements",
-      "banner": "https://uploadstatic-sea.mihoyo.com/announcement/2020/09/17/f4aa42d505822805eebf4a55d72a78d8_2755691727027973637.jpg",
+      "banner": "https://uploadstatic-sea.mihoyo.com/hk4e/announcement/image/banner1.jpg",
       "content": "<p>Announcement content uses HTML. The specific content of the announcement is stored in the program directory <code>GameAnnouncement.json</code>, while <code>GameAnnouncementList.json</code> stores the announcement list data.</p><h2><code>GameAnnouncement</code></h2><table><tr><th>Parameter</th><th>Description</th></tr><tr><td>ann_id</td><td>Unique ID</td></tr><tr><td>title</td><td>Title shown at the top of the content</td></tr><tr><td>subtitle</td><td>Short title shown on the left</td></tr><tr><td>banner</td><td>Image to display between content and title</td></tr><tr><td>content</td><td>Content body in HTML</td></tr><tr><td>lang</td><td>Language code for this entry</td></tr></table><h2><code>GameAnnouncementList</code></h2><p>If you want to add an announcement, please add the list data in the announcement type corresponding to <code>GameAnnouncementList</code>, and finally add the announcement content in <code>GameAnnouncement</code>.</p>",
+      "lang": "en-US"
+    },
+    {
+      "ann_id": 3,
+      "title": "<strong>Hello</strong>",
+      "subtitle": "How to use Genshin Impact",
+      "banner": "https://uploadstatic-sea.mihoyo.com/hk4e/announcement/image/banner3.jpg",
+      "content": "<p>Genshin Impact is great. </p>",
       "lang": "en-US"
     }
   ],

--- a/data/GameAnnouncementList.json
+++ b/data/GameAnnouncementList.json
@@ -8,8 +8,8 @@
 
           "title": "<strong>Welcome to Grasscutter!</strong>",
           "subtitle": "Welcome!",
-          "banner": "https://uploadstatic-sea.mihoyo.com/announcement/2020/09/22/7d85f19b152d218e73224d7c138a0fd0_5818585260283672899.jpg",
-          "tag_icon": "https://uploadstatic-sea.mihoyo.com/announcement/2020/03/05/a2588f1a51faee9fa8dfe9aead649dd6_7237021399135895303.png",
+          "banner": "https://uploadstatic-sea.mihoyo.com/hk4e/announcement/image/banner2.jpg",
+          "tag_icon": "https://uploadstatic-sea.mihoyo.com/hk4e/announcement/image/alert/warning.png",
           "type": 2,
           "type_label": "System",
           "lang": "en-US",
@@ -22,8 +22,8 @@
           "ann_id": 2,
           "title": "<strong>How to use announcements</strong>",
           "subtitle": "How to use announcements",
-          "banner": "https://uploadstatic-sea.mihoyo.com/announcement/2020/09/22/7d85f19b152d218e73224d7c138a0fd0_5818585260283672899.jpg",
-          "tag_icon": "https://uploadstatic-sea.mihoyo.com/announcement/2020/03/05/a2588f1a51faee9fa8dfe9aead649dd6_7237021399135895303.png",
+          "banner": "https://uploadstatic-sea.mihoyo.com/hk4e/announcement/image/banner2.jpg",
+          "tag_icon": "https://uploadstatic-sea.mihoyo.com/hk4e/announcement/image/alert/warning.png",
           "type": 2,
           "type_label": "System",
           "lang": "en-US",
@@ -38,10 +38,24 @@
     },
     {
       "list": [
-        {}
+        {
+          "ann_id": 3,
+
+          "title": "<strong>Welcome to Genshin Impact!</strong>",
+          "subtitle": "Genshin Impact!",
+          "banner": "https://uploadstatic-sea.mihoyo.com/hk4e/announcement/image/banner2.jpg",
+          "tag_icon": "https://uploadstatic-sea.mihoyo.com/hk4e/announcement/image/alert/warning.png",
+          "type": 2,
+          "type_label": "Activity",
+          "lang": "en-US",
+          "start_time": "2020-09-25 04:05:30",
+          "end_time": "2030-10-30 11:00:00",
+          "content": "",
+          "has_content": true
+        }
       ],
       "type_id": 3,
-      "type_label": "Events"
+      "type_label": "Activity"
     }
   ],
   "total": 2,

--- a/src/main/java/emu/grasscutter/server/dispatch/http/AnnouncementIndexHandler.java
+++ b/src/main/java/emu/grasscutter/server/dispatch/http/AnnouncementIndexHandler.java
@@ -46,6 +46,14 @@ public class AnnouncementIndexHandler implements HttpContextHandler {
                         res.type("text/css");
                         res.send(FileUtils.read(renderFile));
                         break;
+                    case "png":
+                        res.type("image/png");
+                        res.send(FileUtils.read(renderFile));
+                        break;
+                    case "jpg":
+                        res.type("image/jpeg");
+                        res.send(FileUtils.read(renderFile));
+                        break;
                     case "js":
                     default:
                         res.send(FileUtils.read(renderFile));


### PR DESCRIPTION
## Description

AnnouncePage Files: [Grasscutter_AnnouncementPage](https://github.com/NekoBakaBaka/Grasscutter_AnnouncementPage)

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.