### PR TITLE
Joinremove

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/JoinCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/JoinCommand.java
@@ -18,6 +18,11 @@ public class JoinCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, translate(sender, "commands.execution.need_target"));
+            return;
+        }
+
         List<Integer> avatarIds = new ArrayList<>();
         for (String arg : args) {
             try {
@@ -32,18 +37,18 @@ public class JoinCommand implements CommandHandler {
 
 
         for (int i = 0; i < args.size(); i++) {
-            Avatar avatar = sender.getAvatars().getAvatarById(avatarIds.get(i));
+            Avatar avatar = targetPlayer.getAvatars().getAvatarById(avatarIds.get(i));
             if (avatar == null) {
                 CommandHandler.sendMessage(sender, translate("commands.generic.invalid.avatarId"));
                 return;
             }
-            if (sender.getTeamManager().getCurrentTeamInfo().contains(avatar)){
+            if (targetPlayer.getTeamManager().getCurrentTeamInfo().contains(avatar)){
                 continue;
             }
-            sender.getTeamManager().getCurrentTeamInfo().addAvatar(avatar);
+            targetPlayer.getTeamManager().getCurrentTeamInfo().addAvatar(avatar);
         }
 
         // Packet
-        sender.getTeamManager().updateTeamEntities(new PacketChangeMpTeamAvatarRsp(sender, sender.getTeamManager().getCurrentTeamInfo()));
+        targetPlayer.getTeamManager().updateTeamEntities(new PacketChangeMpTeamAvatarRsp(targetPlayer, targetPlayer.getTeamManager().getCurrentTeamInfo()));
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/RemoveCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/RemoveCommand.java
@@ -8,7 +8,6 @@ import emu.grasscutter.server.packet.send.PacketChangeMpTeamAvatarRsp;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
@@ -28,7 +27,9 @@ public class RemoveCommand implements CommandHandler {
         for (String arg : args) {
             try {
                 int avatarIndex = Integer.parseInt(arg);
-                avatarIndexList.add(avatarIndex);
+                if (!avatarIndexList.contains(avatarIndex)) {
+                    avatarIndexList.add(avatarIndex);
+                }
             } catch (Exception ignored) {
                 ignored.printStackTrace();
                 CommandHandler.sendMessage(sender, translate("commands.remove.invalid_index"));
@@ -36,7 +37,7 @@ public class RemoveCommand implements CommandHandler {
             }
         }
 
-        Collections.reverse(avatarIndexList);
+        Collections.sort(avatarIndexList, Collections.reverseOrder());
 
         for (int i = 0; i < avatarIndexList.size(); i++) {
             if (avatarIndexList.get(i) > targetPlayer.getTeamManager().getCurrentTeamInfo().getAvatars().size() || avatarIndexList.get(i) <= 0) {

--- a/src/main/java/emu/grasscutter/command/commands/RemoveCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/RemoveCommand.java
@@ -19,6 +19,11 @@ public class RemoveCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
+        if (targetPlayer == null) {
+            CommandHandler.sendMessage(sender, translate(sender, "commands.execution.need_target"));
+            return;
+        }
+        
         List<Integer> avatarIndexList = new ArrayList<>();
         for (String arg : args) {
             try {
@@ -34,14 +39,14 @@ public class RemoveCommand implements CommandHandler {
         Collections.reverse(avatarIndexList);
 
         for (int i = 0; i < avatarIndexList.size(); i++) {
-            if (avatarIndexList.get(i) > sender.getTeamManager().getCurrentTeamInfo().getAvatars().size() || avatarIndexList.get(i) <= 0) {
-                CommandHandler.sendMessage(sender, translate("commands.remove.invalid_index"));
+            if (avatarIndexList.get(i) > targetPlayer.getTeamManager().getCurrentTeamInfo().getAvatars().size() || avatarIndexList.get(i) <= 0) {
+                CommandHandler.sendMessage(targetPlayer, translate("commands.remove.invalid_index"));
                 return;
             }
-            sender.getTeamManager().getCurrentTeamInfo().removeAvatar(avatarIndexList.get(i) - 1);
+            targetPlayer.getTeamManager().getCurrentTeamInfo().removeAvatar(avatarIndexList.get(i) - 1);
         }
 
         // Packet
-        sender.getTeamManager().updateTeamEntities(new PacketChangeMpTeamAvatarRsp(sender, sender.getTeamManager().getCurrentTeamInfo()));
+        targetPlayer.getTeamManager().updateTeamEntities(new PacketChangeMpTeamAvatarRsp(targetPlayer, targetPlayer.getTeamManager().getCurrentTeamInfo()));
     }
 }


### PR DESCRIPTION
## Description

Fixes targeting on join and remove commands.
Fixes a logic error on remove: command expected an ascending series of digits and produced incorrect results when fed anything else, e.g.:
`/remove 3 3 3 3` makes it remove position 3 four times, removing positions 3-6.
This fix prevents non-unique arguments from being handled, and sorts arguments descending instead of reversing the order.

Aside: the commands could use more feedback on them to indicate command success, and perhaps `join` could specify which avatarId failed and add all the valid ones instead of the current behaviour. Perhaps @lsCoding666 would like to follow up on that?

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.