### PR TITLE
fix multiple '/' when loading files.

### DIFF
--- a/src/main/java/emu/grasscutter/Configuration.java
+++ b/src/main/java/emu/grasscutter/Configuration.java
@@ -51,15 +51,15 @@ public final class Configuration extends ConfigContainer {
      */
     
     public static String DATA(String path) {
-        return DATA_FOLDER + "/" + path;
+        return DATA_FOLDER + path;
     }
     
     public static String RESOURCE(String path) {
-        return RESOURCES_FOLDER + "/" + path;
+        return RESOURCES_FOLDER + path;
     }
     
     public static String SCRIPT(String path) {
-        return SCRIPTS_FOLDER + "/" + path;
+        return SCRIPTS_FOLDER + path;
     }
 
     /**

--- a/src/main/java/emu/grasscutter/server/http/handlers/GachaHandler.java
+++ b/src/main/java/emu/grasscutter/server/http/handlers/GachaHandler.java
@@ -32,7 +32,7 @@ public final class GachaHandler implements Router {
     private final String gachaMappings;
     
     public GachaHandler() {
-        this.gachaMappings = Utils.toFilePath(DATA("/gacha/mappings.js"));
+        this.gachaMappings = Utils.toFilePath(DATA("gacha/mappings.js"));
         if(!(new File(this.gachaMappings).exists())) {
             try {
                 Tools.createGachaMapping(this.gachaMappings);


### PR DESCRIPTION
## Description

There are '/' included in the config file, but DATA() and GachaHandler() still puts another '/' in the path

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.