### PR TITLE
optimized the lua serializer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ dependencies {
     implementation group: 'org.luaj', name: 'luaj-jse', version: '3.0.1'
 
     implementation group:  'ch.ethz.globis.phtree', name : 'phtree', version: '2.5.0'
+    implementation group:  'com.esotericsoftware', name : 'reflectasm', version: '1.11.9'
 
     protobuf files('proto/')
 

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -241,7 +241,7 @@ public class SceneScriptManager {
 	}
 	
 	public void spawnGadgetsInGroup(SceneGroup group, SceneSuite suite) {
-		List<SceneGadget> gadgets = group.gadgets;
+		var gadgets = group.gadgets.values();
 		
 		if (suite != null) {
 			gadgets = suite.sceneGadgets;

--- a/src/main/java/emu/grasscutter/scripts/data/SceneBlock.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneBlock.java
@@ -6,6 +6,8 @@ import emu.grasscutter.Grasscutter;
 import emu.grasscutter.scripts.SceneIndexManager;
 import emu.grasscutter.scripts.ScriptLoader;
 import emu.grasscutter.utils.Position;
+import lombok.Setter;
+import lombok.ToString;
 
 import javax.script.Bindings;
 import javax.script.CompiledScript;
@@ -14,6 +16,8 @@ import java.util.List;
 
 import static emu.grasscutter.Configuration.SCRIPT;
 
+@ToString
+@Setter
 public class SceneBlock {
 	public int id;
 	public Position max;

--- a/src/main/java/emu/grasscutter/scripts/data/SceneConfig.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneConfig.java
@@ -1,7 +1,11 @@
 package emu.grasscutter.scripts.data;
 
 import emu.grasscutter.utils.Position;
+import lombok.Setter;
+import lombok.ToString;
 
+@ToString
+@Setter
 public class SceneConfig {
 	public Position vision_anchor;
 	public Position born_pos;

--- a/src/main/java/emu/grasscutter/scripts/data/SceneGadget.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneGadget.java
@@ -1,5 +1,10 @@
 package emu.grasscutter.scripts.data;
 
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@Setter
 public class SceneGadget extends SceneObject{
 	public int gadget_id;
 	public int state;

--- a/src/main/java/emu/grasscutter/scripts/data/SceneInitConfig.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneInitConfig.java
@@ -1,7 +1,10 @@
 package emu.grasscutter.scripts.data;
 
-import emu.grasscutter.utils.Position;
+import lombok.Setter;
+import lombok.ToString;
 
+@ToString
+@Setter
 public class SceneInitConfig {
 	public int suite;
 	public int end_suite;

--- a/src/main/java/emu/grasscutter/scripts/data/SceneMeta.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneMeta.java
@@ -5,6 +5,9 @@ import ch.ethz.globis.phtree.v16.PhTree16;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.scripts.SceneIndexManager;
 import emu.grasscutter.scripts.ScriptLoader;
+import lombok.Data;
+import lombok.Setter;
+import lombok.ToString;
 
 import javax.script.Bindings;
 import javax.script.CompiledScript;
@@ -15,6 +18,8 @@ import java.util.stream.Collectors;
 
 import static emu.grasscutter.Configuration.SCRIPT;
 
+@ToString
+@Setter
 public class SceneMeta {
 
     public SceneConfig config;

--- a/src/main/java/emu/grasscutter/scripts/data/SceneMonster.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneMonster.java
@@ -1,5 +1,10 @@
 package emu.grasscutter.scripts.data;
 
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@Setter
 public class SceneMonster extends SceneObject{
 	public int monster_id;
 }

--- a/src/main/java/emu/grasscutter/scripts/data/SceneObject.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneObject.java
@@ -1,7 +1,11 @@
 package emu.grasscutter.scripts.data;
 
 import emu.grasscutter.utils.Position;
+import lombok.Setter;
+import lombok.ToString;
 
+@ToString
+@Setter
 public class SceneObject {
     public int level;
     public int config_id;
@@ -11,5 +15,5 @@ public class SceneObject {
     /**
      * not set by lua
      */
-    public int groupId;
+    public transient int groupId;
 }

--- a/src/main/java/emu/grasscutter/scripts/data/SceneRegion.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneRegion.java
@@ -5,7 +5,12 @@ import emu.grasscutter.scripts.constants.ScriptRegionShape;
 import emu.grasscutter.utils.Position;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import lombok.Data;
+import lombok.Setter;
+import lombok.ToString;
 
+@ToString
+@Setter
 public class SceneRegion {
 	public int config_id;
 	public int shape;

--- a/src/main/java/emu/grasscutter/scripts/data/SceneSuite.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneSuite.java
@@ -2,8 +2,11 @@ package emu.grasscutter.scripts.data;
 
 import java.util.List;
 
-import emu.grasscutter.utils.Position;
+import lombok.Setter;
+import lombok.ToString;
 
+@ToString
+@Setter
 public class SceneSuite {
 	public List<Integer> monsters;
 	public List<Integer> gadgets;

--- a/src/main/java/emu/grasscutter/scripts/data/SceneTrigger.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneTrigger.java
@@ -1,5 +1,8 @@
 package emu.grasscutter.scripts.data;
 
+import lombok.Setter;
+
+@Setter
 public class SceneTrigger {
 	public String name;
 	public int config_id;
@@ -8,6 +11,7 @@ public class SceneTrigger {
 	public String condition;
 	public String action;
 
+	public SceneGroup currentGroup;
 	@Override
 	public boolean equals(Object obj) {
 		if(obj instanceof SceneTrigger sceneTrigger){

--- a/src/main/java/emu/grasscutter/scripts/data/SceneVar.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneVar.java
@@ -1,5 +1,10 @@
 package emu.grasscutter.scripts.data;
 
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@Setter
 public class SceneVar {
 	public String name;
 	public int value;


### PR DESCRIPTION
## Description
The Lua serializer lookup fields every time before and the performance is poor, so I refactor it by using reflectAsm and cache the field metadata.

Tested by the code below show that it has 80% faster.

```java
public static void main(String[] args) throws Exception {
	Grasscutter.loadConfig();
	ScriptLoader.init();
	long time = System.currentTimeMillis();

	var meta = new SceneMeta();
	meta.load(3);
	meta.blocks.values().forEach(b -> b.load(3, meta.context));
	meta.blocks.values().stream().map(b -> b.groups).flatMap(Collection::stream)
					.forEach(g -> g.load(3, meta.context));

	System.out.println("cost Time:" + (System.currentTimeMillis() - time));
}
```
> cost Time:40327 (before)

> cost Time:6934 (now)

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.