### PR TITLE
Fix "illegal data type conversion to int" and change BANNED_PACKETS to HashSet

### DIFF
--- a/src/main/java/emu/grasscutter/net/packet/PacketOpcodes.java
+++ b/src/main/java/emu/grasscutter/net/packet/PacketOpcodes.java
@@ -1,6 +1,7 @@
 package emu.grasscutter.net.packet;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 public class PacketOpcodes {
@@ -1556,5 +1557,8 @@ public class PacketOpcodes {
     public static final int UNKNOWN_44 = 8983;
     public static final int UNKNOWN_45 = 943;
 
-    public static final List<Integer> BANNED_PACKETS = Arrays.asList(PacketOpcodes.WindSeedClientNotify, PacketOpcodes.PlayerLuaShellNotify);
+    public static final HashSet<Integer> BANNED_PACKETS = new HashSet<Integer>() {{
+        add(PacketOpcodes.WindSeedClientNotify);
+        add(PacketOpcodes.PlayerLuaShellNotify);
+    }};
 }

--- a/src/main/java/emu/grasscutter/net/packet/PacketOpcodesUtil.java
+++ b/src/main/java/emu/grasscutter/net/packet/PacketOpcodesUtil.java
@@ -17,10 +17,12 @@ public class PacketOpcodesUtil {
 		Field[] fields = PacketOpcodes.class.getFields();
 
 		for (Field f : fields) {
-			try {
-				opcodeMap.put(f.getInt(null), f.getName());
-			} catch (Exception e) {
-				e.printStackTrace();
+			if(f.getType().equals(int.class)) {
+				try {
+					opcodeMap.put(f.getInt(null), f.getName());
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description
When ``DebugMode`` is set to ``MISSING`` (Not tested with ``ALL``), an error (listed below) because PacketOpcodesUtil was expecting everything inside ``PacketOpcodes`` to be an int. However, it found a list causing the error below. This list was added in #582 and must have went unnoticed until now.

After a request from Melledy, I have also changed BANNED_PACKETS from a List to a HashSet

```
java.lang.IllegalArgumentException: Attempt to get java.util.List field "emu.grasscutter.net.packet.PacketOpcodes.BANNED_PACKETS" with illegal data type conversion to int
        at java.base/jdk.internal.reflect.UnsafeFieldAccessorImpl.newGetIllegalArgumentException(UnsafeFieldAccessorImpl.java:69)
        at java.base/jdk.internal.reflect.UnsafeFieldAccessorImpl.newGetIntIllegalArgumentException(UnsafeFieldAccessorImpl.java:132)
        at java.base/jdk.internal.reflect.UnsafeQualifiedStaticObjectFieldAccessorImpl.getInt(UnsafeQualifiedStaticObjectFieldAccessorImpl.java:58)
        at java.base/java.lang.reflect.Field.getInt(Field.java:601)
        at emu.grasscutter.net.packet.PacketOpcodesUtil.<clinit>(PacketOpcodesUtil.java:22)
        at emu.grasscutter.server.game.GameServerPacketHandler.handle(GameServerPacketHandler.java:98)
        at emu.grasscutter.server.game.GameSession.onMessage(GameSession.java:250)
        at emu.grasscutter.netty.KcpChannel.channelRead(KcpChannel.java:43)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
        at io.jpower.kcp.netty.UkcpServerChannel$UkcpServerUnsafe.read(UkcpServerChannel.java:603)
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:722)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR
No related issues within the issue tracker (from what I could see anyway). However, look at the description for the issue that is being fixed by this PR.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.