### PR TITLE
verifyUser now returns the user's Account instead of a boolean

### DIFF
--- a/src/main/java/emu/grasscutter/auth/AuthenticationSystem.java
+++ b/src/main/java/emu/grasscutter/auth/AuthenticationSystem.java
@@ -1,5 +1,6 @@
 package emu.grasscutter.auth;
 
+import emu.grasscutter.game.Account;
 import emu.grasscutter.server.http.objects.*;
 import express.http.Request;
 import express.http.Response;
@@ -30,10 +31,10 @@ public interface AuthenticationSystem {
 
     /**
      * Called by plugins to internally verify a user's identity.
-     * @param details A unique, one-time token to verify the user.
-     * @return True if the user is verified, False otherwise.
+     * @param details A unique identifier to identify the user. (For example: a JWT token)
+     * @return The user's account if the verification was successful, null if the user was unable to be verified.
      */
-    boolean verifyUser(String details);
+    Account verifyUser(String details);
 
     /**
      * This is the authenticator used for password authentication.

--- a/src/main/java/emu/grasscutter/auth/DefaultAuthentication.java
+++ b/src/main/java/emu/grasscutter/auth/DefaultAuthentication.java
@@ -2,6 +2,7 @@ package emu.grasscutter.auth;
 
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.auth.DefaultAuthenticators.*;
+import emu.grasscutter.game.Account;
 import emu.grasscutter.server.http.objects.ComboTokenResJson;
 import emu.grasscutter.server.http.objects.LoginResultJson;
 
@@ -26,11 +27,11 @@ public final class DefaultAuthentication implements AuthenticationSystem {
     public void resetPassword(String username) {
         // Unhandled. The default authenticator doesn't store passwords.
     }
-    
+
     @Override
-    public boolean verifyUser(String details) {
+    public Account verifyUser(String details) {
         Grasscutter.getLogger().info(translate("dispatch.authentication.default_unable_to_verify"));
-        return false;
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## Description

verifyUser now returns the user's Account instead of a boolean. 
The intended use of verifyUser was to make sure the user was valid with the given verification key. However, the current solution doesn't provide a way for the plugin to get the user based on that verification key. This is probably the best way to do it. (Whoops my bad)

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR
N/A

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.