### PR TITLE
optimized the Lua func binding

### DIFF
--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonChallenge.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonChallenge.java
@@ -138,7 +138,9 @@ public class DungeonChallenge {
 		getScene().getDungeonSettleObservers().forEach(o -> o.onDungeonSettle(getScene()));
 
 		if(!stage){
-			getScene().getScriptManager().callEvent(EventType.EVENT_DUNGEON_SETTLE, new ScriptArgs(this.isSuccess() ? 1 : 0));
+			getScene().getScriptManager().callEvent(EventType.EVENT_DUNGEON_SETTLE,
+					// TODO record the time in PARAM2 and used in action
+					new ScriptArgs(this.isSuccess() ? 1 : 0, 100));
 		}
 	}
 

--- a/src/main/java/emu/grasscutter/game/world/WorldDataManager.java
+++ b/src/main/java/emu/grasscutter/game/world/WorldDataManager.java
@@ -26,7 +26,7 @@ public class WorldDataManager {
     }
 
     public synchronized void load(){
-    	try(InputStream is = DataLoader.load("ChestReward.json", false); InputStreamReader isr = new InputStreamReader(is)) {
+    	try(InputStream is = DataLoader.load("ChestReward.json"); InputStreamReader isr = new InputStreamReader(is)) {
             List<ChestReward> chestReward = Grasscutter.getGsonFactory().fromJson(
             		isr,
                     TypeToken.getParameterized(List.class, ChestReward.class).getType());

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -10,6 +10,7 @@ import emu.grasscutter.scripts.data.SceneRegion;
 import emu.grasscutter.server.packet.send.PacketCanUseSkillNotify;
 import emu.grasscutter.server.packet.send.PacketGadgetStateNotify;
 import emu.grasscutter.server.packet.send.PacketWorktopOptionNotify;
+import io.netty.util.concurrent.FastThreadLocal;
 import org.luaj.vm2.LuaTable;
 import org.luaj.vm2.LuaValue;
 import org.slf4j.Logger;
@@ -20,15 +21,24 @@ import java.util.Optional;
 
 public class ScriptLib {
 	public static final Logger logger = LoggerFactory.getLogger(ScriptLib.class);
-	private final SceneScriptManager sceneScriptManager;
-	
-	public ScriptLib(SceneScriptManager sceneScriptManager) {
-		this.sceneScriptManager = sceneScriptManager;
-		this.currentGroup = new ThreadLocal<>();
+	private final FastThreadLocal<SceneScriptManager> sceneScriptManager;
+	private final FastThreadLocal<SceneGroup> currentGroup;
+	public ScriptLib() {
+		this.sceneScriptManager = new FastThreadLocal<>();
+		this.currentGroup = new FastThreadLocal<>();
+	}
+
+	public void setSceneScriptManager(SceneScriptManager sceneScriptManager){
+		this.sceneScriptManager.set(sceneScriptManager);
+	}
+
+	public void removeSceneScriptManager(){
+		this.sceneScriptManager.remove();
 	}
 
 	public SceneScriptManager getSceneScriptManager() {
-		return sceneScriptManager;
+		// normally not null
+		return Optional.of(sceneScriptManager.get()).get();
 	}
 
 	private String printTable(LuaTable table){
@@ -40,13 +50,11 @@ public class ScriptLib {
 		sb.append("}");
 		return sb.toString();
 	}
-	private final ThreadLocal<SceneGroup> currentGroup;
 	public void setCurrentGroup(SceneGroup currentGroup){
-		logger.debug("current {}", currentGroup);
 		this.currentGroup.set(currentGroup);
 	}
 	public Optional<SceneGroup> getCurrentGroup(){
-		return Optional.ofNullable(this.currentGroup.get());
+		return Optional.of(this.currentGroup.get());
 	}
 	public void removeCurrentGroup(){
 		this.currentGroup.remove();

--- a/src/main/java/emu/grasscutter/scripts/ScriptLoader.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLoader.java
@@ -29,6 +29,8 @@ public class ScriptLoader {
 	private static ScriptEngineFactory factory;
 	private static String fileType;
 	private static Serializer serializer;
+	private static ScriptLib scriptLib;
+	private static LuaValue scriptLibLua;
 	/**
 	 * suggest GC to remove it if the memory is less
 	 */
@@ -68,6 +70,10 @@ public class ScriptLoader {
 		ctx.globals.set("EventType", CoerceJavaToLua.coerce(new EventType())); // TODO - make static class to avoid instantiating a new class every scene
 		ctx.globals.set("GadgetState", CoerceJavaToLua.coerce(new ScriptGadgetState()));
 		ctx.globals.set("RegionShape", CoerceJavaToLua.coerce(new ScriptRegionShape()));
+
+		scriptLib = new ScriptLib();
+		scriptLibLua = CoerceJavaToLua.coerce(scriptLib);
+		ctx.globals.set("ScriptLib", scriptLibLua);
 	}
 	
 	public static ScriptEngine getEngine() {
@@ -80,6 +86,14 @@ public class ScriptLoader {
 
 	public static Serializer getSerializer() {
 		return serializer;
+	}
+
+	public static ScriptLib getScriptLib() {
+		return scriptLib;
+	}
+
+	public static LuaValue getScriptLibLua() {
+		return scriptLibLua;
 	}
 
 	public static <T> Optional<T> tryGet(SoftReference<T> softReference){

--- a/src/main/java/emu/grasscutter/scripts/data/SceneGroup.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneGroup.java
@@ -10,12 +10,11 @@ import javax.script.Bindings;
 import javax.script.CompiledScript;
 import javax.script.ScriptException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static emu.grasscutter.Configuration.*;
+import static emu.grasscutter.Configuration.SCRIPT;
 
 @ToString
 @Setter
@@ -40,6 +39,7 @@ public class SceneGroup {
 
 	private transient boolean loaded; // Not an actual variable in the scripts either
 	private transient CompiledScript script;
+	private transient Bindings bindings;
 
 	public boolean isLoaded() {
 		return loaded;
@@ -65,12 +65,18 @@ public class SceneGroup {
 		return suites.get(index - 1);
 	}
 
-	public SceneGroup load(int sceneId, Bindings bindings){
+	public Bindings getBindings() {
+		return bindings;
+	}
+
+	public SceneGroup load(int sceneId){
 		if(loaded){
 			return this;
 		}
 		// Set flag here so if there is no script, we dont call this function over and over again.
 		setLoaded(true);
+
+		this.bindings = ScriptLoader.getEngine().createBindings();
 
 		CompiledScript cs = ScriptLoader.getScriptByPath(
 				SCRIPT("Scene/" + sceneId + "/scene" + sceneId + "_group" + id + "." + ScriptLoader.getScriptType()));

--- a/src/main/java/emu/grasscutter/scripts/serializer/LuaSerializer.java
+++ b/src/main/java/emu/grasscutter/scripts/serializer/LuaSerializer.java
@@ -87,6 +87,9 @@ public class LuaSerializer implements Serializer {
 
 			object = (T) constructorCache.get(type).newInstance();
 
+			if(table == null){
+				return object;
+			}
 			LuaValue[] keys = table.keys();
 			for (LuaValue k : keys) {
 				try {


### PR DESCRIPTION
## Description
Lua script are eval every time to get the scriptManager context in the scene groups, when the number of groups increases, it will have a performance issue.

Now I use ThreadLocal to give the context of scriptManager so that the script will not eval again and again, the FastThreadLocal can be even faster if it accessed by a Netty thread.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.