### PR TITLE
fix: Error when checking files

### DIFF
--- a/src/main/java/emu/grasscutter/utils/FileUtils.java
+++ b/src/main/java/emu/grasscutter/utils/FileUtils.java
@@ -97,7 +97,7 @@ public final class FileUtils {
 			}
 		} catch (Exception e) {
 			// Eclipse puts resources in its bin folder
-			File f = new File(jarPath + "defaults/data/");
+			File f = new File(System.getProperty("user.dir") + folder);
 			
 			if (!f.exists() || f.listFiles().length == 0) {
 				return null;


### PR DESCRIPTION
fix: Error when checking files & always checking "/default/data" instead of folder

## Description

Error was caused because jarPath points to the jar file, not the folder the program is currently running in.
When your folder contains " ", "[","]" or some thing else, code at line 92 will cause an error, and code at line 100 cannot get the corrct path. This makes getPathsFromResource() returns null and finally caused this error.
Also, the path was pointed to "/default/data" permenately, not the one in folder.
## Issues fixed by this PR

[Bug] Android 安卓客户端登录界面文字成代码了 #982
(I don't have an Android phone, so I don't know whether this works, but some one was telling me that this issue is reated to this error. Can anyone help me to test this?)
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.