### PR TITLE
Fix the bug that can't kill command-generated monsters

### DIFF
--- a/src/main/java/emu/grasscutter/game/entity/GameEntity.java
+++ b/src/main/java/emu/grasscutter/game/entity/GameEntity.java
@@ -216,7 +216,7 @@ public abstract class GameEntity {
 		
 		// Check if dead
 		if (isDead) {
-			getScene().killEntity(this, 0);
+			getScene().killEntity(this, killerId);
 		}
 	}
 }

--- a/src/main/java/emu/grasscutter/game/player/PlayerCodex.java
+++ b/src/main/java/emu/grasscutter/game/player/PlayerCodex.java
@@ -5,6 +5,7 @@ import dev.morphia.annotations.Transient;
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.def.CodexAnimalData;
 import emu.grasscutter.data.def.CodexReliquaryData;
+import emu.grasscutter.game.entity.EntityMonster;
 import emu.grasscutter.game.entity.GameEntity;
 import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.game.inventory.ItemType;
@@ -79,22 +80,21 @@ public class PlayerCodex {
     }
 
     public void checkAnimal(GameEntity target, CodexAnimalData.CodexAnimalUnlockCondition condition){
-        if(target.getEntityType() == 2){
-            var monsterId = target.getSpawnEntry().getMonsterId();
+        if(target instanceof EntityMonster){
+            var monsterId = ((EntityMonster)target).getMonsterData().getId();
             var codexAnimal = GameData.getCodexAnimalDataMap().get(monsterId);
 
             if(!getUnlockedAnimal().containsKey(monsterId)) {
                 if (codexAnimal != null) {
-                    if(codexAnimal.getUnlockCondition() == condition){
+                    if(codexAnimal.getUnlockCondition() == condition || codexAnimal.getUnlockCondition() == null){
                         getUnlockedAnimal().put(monsterId, 1);
-                        player.save();
-                        this.player.sendPacket(new PacketCodexDataUpdateNotify(3, monsterId));
                     }
                 }
             }else{
                 getUnlockedAnimal().put(monsterId, getUnlockedAnimal().get(monsterId) + 1);
-                player.save();
             }
+            player.save();
+            this.player.sendPacket(new PacketCodexDataUpdateNotify(3, monsterId));
         }
     }
 

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -29,7 +29,6 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.danilopianini.util.SpatialIndex;
-import org.quartz.Trigger;
 
 import java.util.*;
 

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -29,6 +29,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.danilopianini.util.SpatialIndex;
+import org.quartz.Trigger;
 
 import java.util.*;
 
@@ -386,9 +387,19 @@ public class Scene {
 	}
 	
 	public void killEntity(GameEntity target, int attackerId) {
-		for (Player player : this.getPlayers()) {
-			player.getCodex().checkAnimal(target, CodexAnimalData.CodexAnimalUnlockCondition.CODEX_COUNT_TYPE_KILL);
+		GameEntity attacker = getEntityById(attackerId);
+
+		//Check codex
+		if (attacker instanceof EntityClientGadget) {
+			var clientGadgetOwner = getEntityById(((EntityClientGadget) attacker).getOwnerEntityId());
+			if(clientGadgetOwner instanceof EntityAvatar) {
+				((EntityClientGadget) attacker).getOwner().getCodex().checkAnimal(target, CodexAnimalData.CodexAnimalUnlockCondition.CODEX_COUNT_TYPE_KILL);
+			}
 		}
+		else if (attacker instanceof EntityAvatar) {
+			((EntityAvatar) attacker).getPlayer().getCodex().checkAnimal(target, CodexAnimalData.CodexAnimalUnlockCondition.CODEX_COUNT_TYPE_KILL);
+		}
+
 		// Packet
 		this.broadcastPacket(new PacketLifeStateChangeNotify(attackerId, target, LifeState.LIFE_DEAD));
 


### PR DESCRIPTION
Command-generated monsters do not have spawnentry so we have to get data from getMonsterData

## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.