### PR TITLE
Add support for installing on arch linux systems to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,6 @@ valid_ip() {
 # Checks for supported installer(s) (only apt-get for now :(, might add pacman in the future)
 if is_command apt-get ; then
         echo -e "Supported package manager found\n"
-elif is_command pacman
 else
         echo "No supported package manager found"
         exit

--- a/install.sh
+++ b/install.sh
@@ -38,10 +38,26 @@ valid_ip() {
 # Checks for supported installer(s) (only apt-get for now :(, might add pacman in the future)
 if is_command apt-get ; then
         echo -e "Supported package manager found\n"
+elif is_command pacman
 else
         echo "No supported package manager found"
         exit
 fi
+
+BRANCH="stable" # Stable by default
+# Allows choice between stable and dev branch
+echo "Please select the branch you wish to install"
+echo -e "!!NOTE!!: stable is the recommended brach.\ndevelopment is not guaranteed to work.\nUnless you have a reason to use development, pick stable"
+select branch in "stable" "development" ; do
+	case $branch in
+		stable )
+			BRANCH="stable"
+			break;;
+		development )
+			BRANCH="development"
+			break;;
+	esac
+done
 
 INSTALLER_DEPS="curl wget openssl unzip git"
 GC_DEPS="mongodb openjdk-17-jre"
@@ -74,7 +90,7 @@ echo "Done"
 echo "Getting grasscutter..."
 
 # Download and rename jar
-wget -q --show-progress https://nightly.link/Grasscutters/Grasscutter/workflows/build/stable/Grasscutter.zip
+wget -q --show-progress "https://nightly.link/Grasscutters/Grasscutter/workflows/build/$BRANCH/Grasscutter.zip"
 unzip -qq Grasscutter.zip
 mv $(find -name "grasscutter*.jar" -type f) grasscutter.jar
 


### PR DESCRIPTION
## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

Steps in the installer that this PR adds:
- Determines if system is debian-based or arch-based by checking for `apt-get` and `pacman`
- Sets a different package list for apt-get and pacman due to name differences in the repositories
- Adds the respective pacman commands for updating package cache and installing grasscutter and installer dependencies
- Prompts user if they want to install mongodb from the Arch User Repository, allowing the user to also skip or exit
- Installs mongodb from AUR
  - Creates temporary account without sudo to bypass `makepgs`'s restriction of erroring if run as root
  - git clones the mongdb-bin (avoids other AUR dependencies) repository from AUR
  - Builds tarball
  - Copies tarball to original install directory
  - Installs tarball and enables service
  - Deletes temporary account
- Proceeds as normal (further commands are not distro-specific)

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.