### PR TITLE
Java not found in start.cmd if you don't installed java 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ EN | [中文](README_zh-CN.md)
     
 2. Set network proxy to `127.0.0.1:8080` or the proxy port you specified.
 
-**you can also use `start.cmd` to start servers and proxy daemons automatically**
+**you can also use `start.cmd` to start servers and proxy daemons automatically, but you have to set up JAVA_HOME enviroment**
 
 ### Building
 

--- a/start.cmd
+++ b/start.cmd
@@ -28,6 +28,10 @@ if exist "%CUR_PATH%%CONFIG%.cmd" (
 )
 
 if not "%JAVA_PATH%" == "DO_NOT_CHECK_PATH" (
+	if "%JAVA_PATH%" == "\bin\" (
+		call :LOG [ERROR] JAVA_HOME not found, please setup your windows enviroment for installed java.
+		goto :EXIT
+	)
 	if not exist "%JAVA_PATH%java.exe" (
 		call :LOG [ERROR] Java not found.
 		goto :EXIT

--- a/start_config.cmd
+++ b/start_config.cmd
@@ -12,7 +12,7 @@ set CUR_PATH=%~dp0
 @rem Executable Path
 @rem Note: Fill DO_NOT_CHECK_PATH if you need to run it from PATH
 @rem without detecting whether the executable file exists
-set JAVA_PATH=C:\Program Files\Java\jdk1.8.0_202\bin\
+set JAVA_PATH=%JAVA_HOME%\bin\
 set MITMDUMP_PATH=%CUR_PATH%
 set MONGODB_PATH=%CUR_PATH%
 


### PR DESCRIPTION
## Description
Fixes java searching in starts.cmd script

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [x] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.