### PR TITLE
Implement persist energy

### DIFF
--- a/src/main/java/emu/grasscutter/game/avatar/Avatar.java
+++ b/src/main/java/emu/grasscutter/game/avatar/Avatar.java
@@ -81,6 +81,7 @@ public class Avatar {
 	private int satiation; // ?
 	private int satiationPenalty; // ?
 	private float currentHp;
+	private float currentEnergy;
 	
 	@Transient private final Int2ObjectMap<GameItem> equips;
 	@Transient private final Int2FloatOpenHashMap fightProp;
@@ -149,7 +150,7 @@ public class Avatar {
 		this.recalcStats();
 		this.currentHp = getFightProperty(FightProperty.FIGHT_PROP_MAX_HP);
 		setFightProperty(FightProperty.FIGHT_PROP_CUR_HP, this.currentHp);
-		
+		this.currentEnergy = 0f;
 		// Load handler
 		this.onLoad();
 	}
@@ -358,6 +359,30 @@ public class Avatar {
 		this.currentHp = currentHp;
 	}
 
+	public void setCurrentEnergy() {
+		this.setCurrentEnergy(this.currentEnergy);
+	}
+	
+	public void setCurrentEnergy(float currentEnergy) {
+		if (this.getSkillDepot() != null && this.getSkillDepot().getEnergySkillData() != null) {
+			ElementType element = this.getSkillDepot().getElementType();
+			this.setFightProperty(element.getMaxEnergyProp(), this.getSkillDepot().getEnergySkillData().getCostElemVal());
+			
+			if (GAME_OPTIONS.energyUsage) {
+				this.setFightProperty(element.getCurEnergyProp(), currentEnergy);
+			}
+			else {
+				this.setFightProperty(element.getCurEnergyProp(), this.getSkillDepot().getEnergySkillData().getCostElemVal());
+			}
+		}		
+	}
+
+	public void setCurrentEnergy(FightProperty curEnergyProp, float currentEnergy) {
+		this.setFightProperty(curEnergyProp, currentEnergy);
+		this.currentEnergy = currentEnergy;
+		this.save();
+	}
+
 	public Int2FloatOpenHashMap getFightProperties() {
 		return fightProp;
 	}
@@ -516,17 +541,7 @@ public class Avatar {
 		}
 		
 		// Set energy usage
-		if (this.getSkillDepot() != null && this.getSkillDepot().getEnergySkillData() != null) {
-			ElementType element = this.getSkillDepot().getElementType();
-			this.setFightProperty(element.getMaxEnergyProp(), this.getSkillDepot().getEnergySkillData().getCostElemVal());
-			
-			if (GAME_OPTIONS.energyUsage) {
-				this.setFightProperty(element.getCurEnergyProp(), currentEnergy);
-			}
-			else {
-				this.setFightProperty(element.getCurEnergyProp(), this.getSkillDepot().getEnergySkillData().getCostElemVal());
-			}
-		}
+		setCurrentEnergy(currentEnergy);
 		
 		// Artifacts
 		for (int slotId = 1; slotId <= 5; slotId++) {

--- a/src/main/java/emu/grasscutter/game/avatar/Avatar.java
+++ b/src/main/java/emu/grasscutter/game/avatar/Avatar.java
@@ -360,7 +360,9 @@ public class Avatar {
 	}
 
 	public void setCurrentEnergy() {
-		this.setCurrentEnergy(this.currentEnergy);
+		if (GAME_OPTIONS.energyUsage) {
+			this.setCurrentEnergy(this.currentEnergy);
+		}
 	}
 	
 	public void setCurrentEnergy(float currentEnergy) {
@@ -378,9 +380,11 @@ public class Avatar {
 	}
 
 	public void setCurrentEnergy(FightProperty curEnergyProp, float currentEnergy) {
-		this.setFightProperty(curEnergyProp, currentEnergy);
-		this.currentEnergy = currentEnergy;
-		this.save();
+		if (GAME_OPTIONS.energyUsage) {
+			this.setFightProperty(curEnergyProp, currentEnergy);
+			this.currentEnergy = currentEnergy;
+			this.save();
+		}
 	}
 
 	public Int2FloatOpenHashMap getFightProperties() {

--- a/src/main/java/emu/grasscutter/game/entity/EntityAvatar.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityAvatar.java
@@ -46,6 +46,7 @@ public class EntityAvatar extends GameEntity {
 	public EntityAvatar(Scene scene, Avatar avatar) {
 		super(scene);
 		this.avatar = avatar;
+		this.avatar.setCurrentEnergy();
 		this.id = getScene().getWorld().getNextEntityId(EntityIdType.AVATAR);
 		
 		GameItem weapon = this.getAvatar().getWeapon();
@@ -57,6 +58,7 @@ public class EntityAvatar extends GameEntity {
 	public EntityAvatar(Avatar avatar) {
 		super(null);
 		this.avatar = avatar;
+		this.avatar.setCurrentEnergy();
 	}
 
 	public Player getPlayer() {
@@ -128,7 +130,7 @@ public class EntityAvatar extends GameEntity {
 	
 	public void clearEnergy(PropChangeReason reason) {
 		FightProperty curEnergyProp = this.getAvatar().getSkillDepot().getElementType().getCurEnergyProp();
-		this.setFightProperty(curEnergyProp, 0);
+		this.avatar.setCurrentEnergy(curEnergyProp, 0);
 			
 		this.getScene().broadcastPacket(new PacketAvatarFightPropUpdateNotify(this.getAvatar(), curEnergyProp));
 		this.getScene().broadcastPacket(new PacketEntityFightPropChangeReasonNotify(this, curEnergyProp, 0f, reason));
@@ -158,7 +160,7 @@ public class EntityAvatar extends GameEntity {
 		
 		// Set energy and notify.
 		if (newEnergy != curEnergy) {
-			this.setFightProperty(curEnergyProp, newEnergy);
+			this.avatar.setCurrentEnergy(curEnergyProp, newEnergy);
 			
 			this.getScene().broadcastPacket(new PacketAvatarFightPropUpdateNotify(this.getAvatar(), curEnergyProp));
 			this.getScene().broadcastPacket(new PacketEntityFightPropChangeReasonNotify(this, curEnergyProp, newEnergy, reason));

--- a/src/main/java/emu/grasscutter/game/entity/EntityAvatar.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityAvatar.java
@@ -108,11 +108,13 @@ public class EntityAvatar extends GameEntity {
 	public void onDeath(int killerId) {
 		this.killedType = PlayerDieType.PLAYER_DIE_KILL_BY_MONSTER;
 		this.killedBy = killerId;
+		clearEnergy(PropChangeReason.PROP_CHANGE_STATUE_RECOVER);
 	}
 
 	public void onDeath(PlayerDieType dieType, int killerId) {
 		this.killedType = dieType;
 		this.killedBy = killerId;
+		clearEnergy(PropChangeReason.PROP_CHANGE_STATUE_RECOVER);
 	}
 	
 	@Override


### PR DESCRIPTION
## Description

Log off no longer clears energy, death does. (when energyUsage is true)

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.