### PR TITLE
Fixed excessive memory usage of Spatial Index

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,8 +86,8 @@ dependencies {
 
     implementation group: 'org.luaj', name: 'luaj-jse', version: '3.0.1'
 
-    implementation group:  'ch.ethz.globis.phtree', name : 'phtree', version: '2.5.0'
     implementation group:  'com.esotericsoftware', name : 'reflectasm', version: '1.11.9'
+    implementation group:  'com.github.davidmoten', name : 'rtree-multi', version: '0.1'
 
     protobuf files('proto/')
 

--- a/src/main/java/emu/grasscutter/data/ResourceLoader.java
+++ b/src/main/java/emu/grasscutter/data/ResourceLoader.java
@@ -8,10 +8,9 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import ch.ethz.globis.phtree.PhTree;
-import ch.ethz.globis.phtree.v16.PhTree16;
 import com.google.gson.Gson;
 import emu.grasscutter.data.custom.*;
+import emu.grasscutter.scripts.SceneIndexManager;
 import emu.grasscutter.utils.Utils;
 import lombok.SneakyThrows;
 import org.reflections.Reflections;
@@ -428,15 +427,12 @@ public class ResourceLoader {
 				continue;
 			}
 
-			PhTree<SceneNpcBornEntry> index = new PhTree16<>(3);
-
 			var data = Grasscutter.getGsonFactory().fromJson(Files.readString(file), SceneNpcBornData.class);
 			if(data.getBornPosList() == null || data.getBornPosList().size() == 0){
 				continue;
 			}
-			data.getBornPosList().forEach(item -> index.put(item.getPos().toLongArray(), item));
 
-			data.setIndex(index);
+			data.setIndex(SceneIndexManager.buildIndex(3, data.getBornPosList(), item -> item.getPos().toPoint()));
 			GameData.getSceneNpcBornData().put(data.getSceneId(), data);
 		}
 

--- a/src/main/java/emu/grasscutter/data/custom/SceneNpcBornData.java
+++ b/src/main/java/emu/grasscutter/data/custom/SceneNpcBornData.java
@@ -1,6 +1,7 @@
 package emu.grasscutter.data.custom;
 
-import ch.ethz.globis.phtree.PhTree;
+import com.github.davidmoten.rtreemulti.RTree;
+import com.github.davidmoten.rtreemulti.geometry.Geometry;
 import emu.grasscutter.scripts.data.SceneGroup;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -19,7 +20,7 @@ public class SceneNpcBornData {
     /**
      * Spatial Index For NPC
      */
-    transient PhTree<SceneNpcBornEntry> index;
+    transient RTree<SceneNpcBornEntry, Geometry> index;
 
     /**
      * npc groups

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -498,11 +498,11 @@ public class Scene {
 			this.broadcastPacket(new PacketSceneEntityDisappearNotify(toRemove, VisionType.VISION_REMOVE));
 		}
 	}
-	public Set<SceneBlock> getPlayerActiveBlocks(Player player){
-		// TODO consider the borders of blocks
-		return getScriptManager().getBlocks().values().stream()
-				.filter(block -> block.contains(player.getPos()))
-				.collect(Collectors.toSet());
+
+	public List<SceneBlock> getPlayerActiveBlocks(Player player){
+		// consider the borders' entities of blocks, so we check if contains by index
+		return SceneIndexManager.queryNeighbors(getScriptManager().getBlocksIndex(),
+				player.getPos().toXZDoubleArray(), Grasscutter.getConfig().server.game.loadEntitiesForPlayerRange);
 	}
 	public void checkBlocks() {
 		Set<SceneBlock> visible = new HashSet<>();
@@ -542,9 +542,8 @@ public class Scene {
 
 	}
 	public List<SceneGroup> playerMeetGroups(Player player, SceneBlock block){
-		int RANGE = 100;
-
-		List<SceneGroup> sceneGroups = SceneIndexManager.queryNeighbors(block.sceneGroupIndex, player.getPos(), RANGE);
+		List<SceneGroup> sceneGroups = SceneIndexManager.queryNeighbors(block.sceneGroupIndex, player.getPos().toDoubleArray(),
+				Grasscutter.getConfig().server.game.loadEntitiesForPlayerRange);
 
 		List<SceneGroup> groups = sceneGroups.stream()
 				.filter(group -> !scriptManager.getLoadedGroupSetPerBlock().get(block.id).contains(group))
@@ -732,14 +731,14 @@ public class Scene {
 			return List.of();
 		}
 
-		int RANGE = 100;
 		var pos = player.getPos();
 		var data = GameData.getSceneNpcBornData().get(getId());
 		if(data == null){
 			return List.of();
 		}
 
-		var npcs = SceneIndexManager.queryNeighbors(data.getIndex(), pos.toLongArray(), RANGE);
+		var npcs = SceneIndexManager.queryNeighbors(data.getIndex(), pos.toDoubleArray(),
+				Grasscutter.getConfig().server.game.loadEntitiesForPlayerRange);
 		var entityNPCS = npcs.stream().map(item -> {
 					var group = data.getGroups().get(item.getGroupId());
 					if(group == null){

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -1,6 +1,7 @@
 package emu.grasscutter.scripts;
 
-import ch.ethz.globis.phtree.PhTree;
+import com.github.davidmoten.rtreemulti.RTree;
+import com.github.davidmoten.rtreemulti.geometry.Geometry;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.def.MonsterData;
@@ -420,7 +421,7 @@ public class SceneScriptManager {
 		getScene().addEntities(gameEntity);
 	}
 
-	public PhTree<SceneBlock> getBlocksIndex() {
+	public RTree<SceneBlock, Geometry> getBlocksIndex() {
 		return meta.sceneBlockIndex;
 	}
 	public void removeMonstersInGroup(SceneGroup group, SceneSuite suite) {

--- a/src/main/java/emu/grasscutter/scripts/data/SceneMeta.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneMeta.java
@@ -1,11 +1,10 @@
 package emu.grasscutter.scripts.data;
 
-import ch.ethz.globis.phtree.PhTree;
-import ch.ethz.globis.phtree.v16.PhTree16;
+import com.github.davidmoten.rtreemulti.RTree;
+import com.github.davidmoten.rtreemulti.geometry.Geometry;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.scripts.SceneIndexManager;
 import emu.grasscutter.scripts.ScriptLoader;
-import lombok.Data;
 import lombok.Setter;
 import lombok.ToString;
 
@@ -27,7 +26,7 @@ public class SceneMeta {
 
     public Bindings context;
 
-    public PhTree<SceneBlock> sceneBlockIndex = new PhTree16<>(2);
+    public RTree<SceneBlock, Geometry> sceneBlockIndex;
 
     public static SceneMeta of(int sceneId) {
         return new SceneMeta().load(sceneId);
@@ -64,8 +63,8 @@ public class SceneMeta {
             }
 
             this.blocks = blocks.stream().collect(Collectors.toMap(b -> b.id, b -> b));
-            SceneIndexManager.buildIndex(this.sceneBlockIndex, blocks, g -> g.min.toXZLongArray());
-            SceneIndexManager.buildIndex(this.sceneBlockIndex, blocks, g -> g.max.toXZLongArray());
+            this.sceneBlockIndex = SceneIndexManager.buildIndex(2, blocks, SceneBlock::toRectangle);
+
         } catch (ScriptException e) {
             Grasscutter.getLogger().error("Error running script", e);
             return null;

--- a/src/main/java/emu/grasscutter/utils/ConfigContainer.java
+++ b/src/main/java/emu/grasscutter/utils/ConfigContainer.java
@@ -135,7 +135,8 @@ public class ConfigContainer {
         public int bindPort = 22102;
         /* This is the port used in the default region. */
         public int accessPort = 0;
-        
+        /* Entities within a certain range will be loaded for the player */
+        public int loadEntitiesForPlayerRange = 100;
         public boolean enableScriptInBigWorld = false;
         public boolean enableConsole = true;
         public GameOptions gameOptions = new GameOptions();

--- a/src/main/java/emu/grasscutter/utils/Position.java
+++ b/src/main/java/emu/grasscutter/utils/Position.java
@@ -2,6 +2,7 @@ package emu.grasscutter.utils;
 
 import java.io.Serializable;
 
+import com.github.davidmoten.rtreemulti.geometry.Point;
 import dev.morphia.annotations.Entity;
 import emu.grasscutter.net.proto.VectorOuterClass.Vector;
 
@@ -155,10 +156,20 @@ public class Position implements Serializable {
 			.setZ(this.getZ())
 			.build();
 	}
-	public long[] toLongArray(){
-		return new long[]{(long) x, (long) y, (long) z};
+	public Point toPoint(){
+		return Point.create(x,y,z);
 	}
-	public long[] toXZLongArray(){
-		return new long[]{(long) x, (long) z};
+
+	/**
+	 * To XYZ array for Spatial Index
+	 */
+	public double[] toDoubleArray(){
+		return new double[]{ x, y, z};
+	}
+	/**
+	 * To XZ array for Spatial Index (Blocks)
+	 */
+	public double[] toXZDoubleArray(){
+		return new double[]{x, z};
 	}
 }


### PR DESCRIPTION
## Description

- The previously used spatial index PhTree has a problem of excessive memory usage, so I replace it with RTree
- Fixed entities disappearing at blocks boundaries

Before:
<img width="307" alt="1" src="https://user-images.githubusercontent.com/104902222/170193587-a79a5abc-9db5-4da1-9a2c-83585a3746f7.png">
Now:
<img width="395" alt="2" src="https://user-images.githubusercontent.com/104902222/170193735-8c1a0879-0725-48c7-b604-eeb84bbef197.png">




## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.