### PR TITLE
fix monster no melee attack and adjust skill particle amount

### DIFF
--- a/src/main/java/emu/grasscutter/server/packet/send/PacketEntityAiSyncNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketEntityAiSyncNotify.java
@@ -13,7 +13,7 @@ public class PacketEntityAiSyncNotify extends BasePacket {
 		EntityAiSyncNotify.Builder proto = EntityAiSyncNotify.newBuilder();
 		
 		for (int monsterId : notify.getLocalAvatarAlertedMonsterListList()) {
-			proto.addInfoList(AiSyncInfo.newBuilder().setEntityId(monsterId));
+			proto.addInfoList(AiSyncInfo.newBuilder().setEntityId(monsterId).setHasPathToTarget(true));
 		}
 		
 		this.setData(proto);

--- a/src/main/resources/defaults/data/SkillParticleGeneration.json
+++ b/src/main/resources/defaults/data/SkillParticleGeneration.json
@@ -202,12 +202,8 @@
 		"name": "Zhongli",
 		"amountList": [
 			{
-				"value": 0,
-				"chance": 50
-			},
-			{
 				"value": 1,
-				"chance": 50
+				"chance": 100
 			}
 		]
 	},
@@ -216,12 +212,8 @@
 		"name": "Fischl",
 		"amountList": [
 			{
-				"value": 0,
-				"chance": 33
-			},
-			{
 				"value": 1,
-				"chance": 67
+				"chance": 100
 			}
 		]
 	},
@@ -294,12 +286,8 @@
 		"name": "Albedo",
 		"amountList": [
 			{
-				"value": 0,
-				"chance": 33
-			},
-			{
 				"value": 1,
-				"chance": 67
+				"chance": 100
 			}
 		]
 	},
@@ -308,12 +296,8 @@
 		"name": "Diona",
 		"amountList": [
 			{
-				"value": 0,
-				"chance": 20
-			},
-			{
 				"value": 1,
-				"chance": 80
+				"chance": 100
 			}
 		]
 	},
@@ -456,12 +440,8 @@
 		"name": "Raiden Shogun",
 		"amountList": [
 			{
-				"value": 0,
-				"chance": 50
-			},
-			{
 				"value": 1,
-				"chance": 50
+				"chance": 100
 			}
 		]
 	},
@@ -480,12 +460,8 @@
 		"name": "Sangonomiya Kokomi",
 		"amountList": [
 			{
-				"value": 0,
-				"chance": 33
-			},
-			{
 				"value": 1,
-				"chance": 67
+				"chance": 100
 			}
 		]
 	},


### PR DESCRIPTION
## Description

Fix monsters don't do melee attack issue - half line of code
Adjust skill particle JSON file to not do 0 particle generation. The logic is already handled by client.

## Issues fixed by this PR

[1062](https://github.com/Grasscutters/Grasscutter/issues/1062)
[762](https://github.com/Grasscutters/Grasscutter/issues/762)

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.