### PR TITLE
TeamManager avatar add refactor

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/GiveAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveAllCommand.java
@@ -57,7 +57,8 @@ public final class GiveAllCommand implements CommandHandler {
             }
             // This will handle stats and talents
             avatar.recalcStats();
-            player.addAvatar(avatar);
+            // Don't try to add each avatar to the current team
+            player.addAvatar(avatar, false);
         }
 
         //some test items

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -809,7 +809,7 @@ public class Player {
 		this.hasSentAvatarDataNotify = hasSentAvatarDataNotify;
 	}
 
-	public void addAvatar(Avatar avatar) {
+	public void addAvatar(Avatar avatar, boolean addToCurrentTeam) {
 		boolean result = getAvatars().addAvatar(avatar);
 
 		if (result) {
@@ -820,12 +820,20 @@ public class Player {
 			if (hasSentAvatarDataNotify()) {
 				// Recalc stats
 				avatar.recalcStats();
-				// Packet
-				sendPacket(new PacketAvatarAddNotify(avatar, false));
+				// Packet, show notice on left if the avatar will be added to the team
+				sendPacket(new PacketAvatarAddNotify(avatar, addToCurrentTeam && this.getTeamManager().canAddAvatarToCurrentTeam()));
+				if (addToCurrentTeam) {
+					// If space in team, add
+					this.getTeamManager().addAvatarToCurrentTeam(avatar);
+				}
 			}
 		} else {
 			// Failed adding avatar
 		}
+	}
+
+	public void addAvatar(Avatar avatar) {
+		addAvatar(avatar, true);
 	}
 
 	public void addFlycloak(int flycloakId) {

--- a/src/main/java/emu/grasscutter/game/player/TeamInfo.java
+++ b/src/main/java/emu/grasscutter/game/player/TeamInfo.java
@@ -44,7 +44,7 @@ public class TeamInfo {
 	}
 
 	public boolean addAvatar(Avatar avatar) {
-		if (size() >= GAME_OPTIONS.avatarLimits.singlePlayerTeam || contains(avatar)) {
+		if (contains(avatar)) {
 			return false;
 		}
 		

--- a/src/main/java/emu/grasscutter/game/player/TeamManager.java
+++ b/src/main/java/emu/grasscutter/game/player/TeamManager.java
@@ -104,6 +104,20 @@ public class TeamManager {
 		this.mpTeam = mpTeam;
 	}
 
+	/**
+	 * Search through all teams and if the team matches, return that index.
+	 * Otherwise, return -1.
+	 * No match could mean that the team does not currently belong to the player.
+	 */
+	public int getTeamId(TeamInfo team) {
+		for (int i = 1; i <= this.teams.size(); i++) {
+			if (this.teams.get(i).equals(team)) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
 	public int getCurrentTeamId() {
 		// Starts from 1
 		return currentTeamIndex;
@@ -185,7 +199,108 @@ public class TeamManager {
 	}
 	
 	// Methods
-	
+
+	/**
+	 * Returns true if there is space to add the number of avatars to the team.
+	 */
+	public boolean canAddAvatarsToTeam(TeamInfo team, int avatars) {
+		return team.size() + avatars <= getMaxTeamSize();
+	}
+
+	/**
+	 * Returns true if there is space to add to the team.
+	 */
+	public boolean canAddAvatarToTeam(TeamInfo team) {
+		return canAddAvatarsToTeam(team, 1);
+	}
+
+	/**
+	 * Returns true if there is space to add the number of avatars to the current team.
+	 * If the current team is temporary, returns false.
+	 */
+	public boolean canAddAvatarsToCurrentTeam(int avatars) {
+		if (this.useTemporarilyTeamIndex != -1){
+			return false;
+		}
+		return canAddAvatarsToTeam(this.getCurrentTeamInfo(), avatars);
+	}
+
+	/**
+	 * Returns true if there is space to add to the current team.
+	 * If the current team is temporary, returns false.
+	 */
+	public boolean canAddAvatarToCurrentTeam() {
+		return canAddAvatarsToCurrentTeam(1);
+	}
+
+	/**
+	 * Try to add the collection of avatars to the team.
+	 * Returns true if all were successfully added.
+	 * If some can not be added, returns false and does not add any.
+	 */
+	public boolean addAvatarsToTeam(TeamInfo team, Collection<Avatar> avatars) {
+		if (!canAddAvatarsToTeam(team, avatars.size())) {
+			return false;
+		}
+
+		// Convert avatars into a collection of avatar IDs, then add
+		team.getAvatars().addAll(avatars.stream().map(a -> a.getAvatarId()).toList());
+
+		// Update team
+		if (this.getPlayer().isInMultiplayer()) {
+			if (team.equals(this.getMpTeam())) {
+				// MP team Packet
+				this.updateTeamEntities(new PacketChangeMpTeamAvatarRsp(getPlayer(), team));
+			}
+		} else {
+			// SP team update packet
+			getPlayer().sendPacket(new PacketAvatarTeamUpdateNotify(getPlayer()));
+
+			int teamId = this.getTeamId(team);
+			if (teamId != -1) {
+				// This is one of the player's teams
+				// Update entites
+				if (teamId == this.getCurrentTeamId()) {
+					this.updateTeamEntities(new PacketSetUpAvatarTeamRsp(getPlayer(), teamId, team));
+				} else {
+					getPlayer().sendPacket(new PacketSetUpAvatarTeamRsp(getPlayer(), teamId, team));
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Try to add an avatar to a team.
+	 * Returns true if successful.
+	 */
+	public boolean addAvatarToTeam(TeamInfo team, Avatar avatar){
+		return addAvatarsToTeam(team, Collections.singleton(avatar));
+	}
+
+	/**
+	 * Try to add the collection of avatars to the current team.
+	 * Will not modify a temporary team.
+	 * Returns true if all were successfully added.
+	 * If some can not be added, returns false and does not add any.
+	 */
+	public boolean addAvatarsToCurrentTeam(Collection<Avatar> avatars) {
+		if (this.useTemporarilyTeamIndex != -1){
+			return false;
+		}
+		return addAvatarsToTeam(this.getCurrentTeamInfo(), avatars);
+	}
+
+	/**
+	 * Try to add an avatar to the current team.
+	 * Will not modify a temporary team.
+	 * Returns true if successful.
+	 */
+	public boolean addAvatarToCurrentTeam(Avatar avatar) {
+		return addAvatarsToCurrentTeam(Collections.singleton(avatar));
+	}
+
 	private void updateTeamResonances() {
 		Int2IntOpenHashMap map = new Int2IntOpenHashMap();
 		
@@ -315,19 +430,7 @@ public class TeamManager {
 		
 		// Clear current team info and add avatars from our new team
 		teamInfo.getAvatars().clear();
-		for (Avatar avatar : newTeam) {
-			teamInfo.addAvatar(avatar);
-		}
-		
-		// Update packet
-		getPlayer().sendPacket(new PacketAvatarTeamUpdateNotify(getPlayer()));
-		
-		// Update entites
-		if (teamId == this.getCurrentTeamId()) {
-			this.updateTeamEntities(new PacketSetUpAvatarTeamRsp(getPlayer(), teamId, teamInfo));
-		} else {
-			getPlayer().sendPacket(new PacketSetUpAvatarTeamRsp(getPlayer(), teamId, teamInfo));
-		}
+		this.addAvatarsToTeam(teamInfo, newTeam);
 	}
 	
 	public void setupMpTeam(List<Long> list) {
@@ -351,12 +454,7 @@ public class TeamManager {
 		
 		// Clear current team info and add avatars from our new team
 		teamInfo.getAvatars().clear();
-		for (Avatar avatar : newTeam) {
-			teamInfo.addAvatar(avatar);
-		}
-		
-		// Packet
-		this.updateTeamEntities(new PacketChangeMpTeamAvatarRsp(getPlayer(), teamInfo));
+		this.addAvatarsToTeam(teamInfo, newTeam);
 	}
 
 	public void setupTemporaryTeam(List<List<Long>> guidList) {

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerSetPlayerBornDataReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerSetPlayerBornDataReq.java
@@ -65,7 +65,8 @@ public class HandlerSetPlayerBornDataReq extends PacketHandler {
 			if (player.getAvatars().getAvatarCount() == 0) {
 				Avatar mainCharacter = new Avatar(avatarId);
 				mainCharacter.setSkillDepotData(GameData.getAvatarSkillDepotDataMap().get(startingSkillDepot));
-				player.addAvatar(mainCharacter);
+				// Manually handle adding to team
+				player.addAvatar(mainCharacter, false);
 				player.setMainCharacterId(avatarId);
 				player.setHeadImage(avatarId);
 				player.getTeamManager().getCurrentSinglePlayerTeamInfo().getAvatars().add(mainCharacter.getAvatarId());


### PR DESCRIPTION
## Description
TeamManager refactor
Added new addAvatar methods to the team manager to handle adding avatars.
Added new canAddAvatar methods to the team manager to check if an avatar can be added to a team.
Adding avatars through the new team manager methods to the players current team or the MP team will trigger entity updates.
Now by default, adding an avatar to the player will attempt to add it to the current team if there is space based on the appropriate configs.
This can be disabled with a new second param, some places use this(PlayerBorn, GiveAll).
If a newly accquired avatar is added to the team, a notice will display in the item/reward feed at the left.
Fixed adding avatars in multiplayer not using the MP team limit config

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.