### PR TITLE
Energy: Make sure we only process energy drops for actual monsters.

### DIFF
--- a/src/main/java/emu/grasscutter/game/managers/EnergyManager/EnergyManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/EnergyManager/EnergyManager.java
@@ -303,6 +303,13 @@ public class EnergyManager {
 		}
 	}
 	public void handleMonsterEnergyDrop(EntityMonster monster, float hpBeforeDamage, float hpAfterDamage) {
+		// Make sure this is actually a monster.
+		// Note that some wildlife also has that type, like boars or birds.
+		String type = monster.getMonsterData().getType();
+		if (!type.equals("MONSTER_ORDINARY") && !type.equals("MONSTER_BOSS")) {
+			return;
+		}
+
 		// Calculate the HP tresholds for before and after the damage was taken.
 		float maxHp = monster.getFightProperty(FightProperty.FIGHT_PROP_MAX_HP);
 		float thresholdBefore = hpBeforeDamage / maxHp;

--- a/src/main/resources/defaults/data/EnergyDrop.json
+++ b/src/main/resources/defaults/data/EnergyDrop.json
@@ -156,5 +156,30 @@
 		"dropId": 22003100,
 		"dropList": [
 		]
+	},
+	{
+		"dropId": 22001000,
+		"dropList": [
+		]
+	},
+	{
+		"dropId": 22000100,
+		"dropList": [
+		]
+	},
+	{
+		"dropId": 22003000,
+		"dropList": [
+		]
+	},
+	{
+		"dropId": 22001100,
+		"dropList": [
+		]
+	},
+	{
+		"dropId": 22000000,
+		"dropList": [
+		]
 	}
 ]


### PR DESCRIPTION
## Description

Adds a check for energy drops to make sure we are dealing with actual monsters instead of other creatures. Note that some wildlife actually has type `MONSTER_ORDINARY` assigned, and uses the same drop logic for meat/fowl as energy particles do. I have set the drop IDs for those drops to empty in `EnergyDrop.json`, since I think this is something we should handle as ordinary drops.

## Issues fixed by this PR

#1071

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.