### PR TITLE
Add skill particle generation info for Yelan and Kuki Shinobu

### DIFF
--- a/src/main/java/emu/grasscutter/data/excels/TowerFloorData.java
+++ b/src/main/java/emu/grasscutter/data/excels/TowerFloorData.java
@@ -8,7 +8,7 @@ public class TowerFloorData extends GameResource {
 
     private int floorId;
     private int floorIndex;
-    private int levelId;
+    private int levelGroupId;
     private int overrideMonsterLevel;
     private int teamNum;
     private int floorLevelConfigId;
@@ -31,8 +31,8 @@ public class TowerFloorData extends GameResource {
         return floorIndex;
     }
 
-    public int getLevelId() {
-        return levelId;
+    public int getLevelGroupId() {
+        return levelGroupId;
     }
 
     public int getOverrideMonsterLevel() {

--- a/src/main/java/emu/grasscutter/data/excels/TowerLevelData.java
+++ b/src/main/java/emu/grasscutter/data/excels/TowerLevelData.java
@@ -8,6 +8,7 @@ public class TowerLevelData extends GameResource {
 	
     private int levelId;
     private int levelIndex;
+    private int levelGroupId;
     private int dungeonId;
 
     @Override
@@ -17,6 +18,10 @@ public class TowerLevelData extends GameResource {
 
     public int getLevelId() {
         return levelId;
+    }
+
+    public int getLevelGroupId() {
+        return levelGroupId;
     }
 
     public int getLevelIndex() {

--- a/src/main/java/emu/grasscutter/game/tower/TowerManager.java
+++ b/src/main/java/emu/grasscutter/game/tower/TowerManager.java
@@ -71,7 +71,7 @@ public class TowerManager {
         this.currentFloorId = floorData.getFloorId();
         this.currentLevel = 0;
         this.currentLevelId = GameData.getTowerLevelDataMap().values().stream()
-                .filter(x -> x.getLevelId() == floorData.getLevelId() && x.getLevelIndex() == 1)
+                .filter(x -> x.getLevelGroupId() == floorData.getLevelGroupId() && x.getLevelIndex() == 1)
                 .findFirst()
                 .map(TowerLevelData::getId)
                 .orElse(0);

--- a/src/main/resources/defaults/data/SkillParticleGeneration.json
+++ b/src/main/resources/defaults/data/SkillParticleGeneration.json
@@ -510,6 +510,16 @@
 		]
 	},
 	{
+		"avatarId": 10000060,
+		"name": "Yelan",
+		"amountList": [
+			{
+				"value": 4,
+				"chance": 100
+			}
+		]
+	},
+	{
 		"avatarId": 10000062,
 		"name": "Aloy",
 		"amountList": [
@@ -535,6 +545,16 @@
 		"amountList": [
 			{
 				"value": 2,
+				"chance": 100
+			}
+		]
+	},
+	{
+		"avatarId": 10000065,
+		"name": "Kuki Shinobu",
+		"amountList": [
+			{
+				"value": 4,
 				"chance": 100
 			}
 		]


### PR DESCRIPTION
## Description
Add skill particle generation info for Yelan and Kuki Shinobu

## Issues fixed by this PR

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.