### PR TITLE
Add energy generation probabilities to WeaponType.

### DIFF
--- a/src/main/java/emu/grasscutter/game/managers/EnergyManager/EnergyManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/EnergyManager/EnergyManager.java
@@ -256,7 +256,7 @@ public class EnergyManager {
 		//    - Does the probability for a character reset when switching them out?
 		//    - Does this really count every individual hit separately?
 
-		// Make sure the avatar's weapon type makes sense.
+		// Get the avatar's weapon type.
 		WeaponType weaponType = avatar.getAvatar().getAvatarData().getWeaponType();
 
 		// Check if we already have probability data for this avatar. If not, insert it.

--- a/src/main/java/emu/grasscutter/game/props/WeaponType.java
+++ b/src/main/java/emu/grasscutter/game/props/WeaponType.java
@@ -9,7 +9,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 public enum WeaponType {
 	WEAPON_NONE (0),
-	WEAPON_SWORD_ONE_HAND (1),
+	WEAPON_SWORD_ONE_HAND (1, 10, 5),
 	WEAPON_CROSSBOW (2),
 	WEAPON_STAFF (3),
 	WEAPON_DOUBLE_DAGGER (4),
@@ -18,10 +18,10 @@ public enum WeaponType {
 	WEAPON_STICK (7),
 	WEAPON_SPEAR (8),
 	WEAPON_SHIELD_SMALL (9),
-	WEAPON_CATALYST (10),
-	WEAPON_CLAYMORE (11),
-	WEAPON_BOW (12),
-	WEAPON_POLE (13);
+	WEAPON_CATALYST (10, 0, 10),
+	WEAPON_CLAYMORE (11, 0, 10),
+	WEAPON_BOW (12, 0, 5),
+	WEAPON_POLE (13, 0, 4);
 	
 	private final int value;
 	private int energyGainInitialProbability;


### PR DESCRIPTION
## Description

Add energy generation probabilities to WeaponType.

## Issues fixed by this PR

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.