### PR TITLE
Account: Make sure we don't reserve a UID that is already taken by another Player

### DIFF
--- a/src/main/java/emu/grasscutter/database/DatabaseHelper.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseHelper.java
@@ -38,8 +38,16 @@ public final class DatabaseHelper {
 			if (reservedId == GameConstants.SERVER_CONSOLE_UID) {
 				return null;
 			}
+
+			// Make sure not other accounts has that id as its reservedPlayerId
 			exists = DatabaseHelper.getAccountByPlayerId(reservedId);
 			if (exists != null) {
+				return null;
+			}
+
+			// Make sure no existing player already has this id.
+			Player existsPlayer = DatabaseHelper.getPlayerByUid(reservedId);
+			if (existsPlayer != null) {
 				return null;
 			}
 		}

--- a/src/main/resources/languages/en-US.json
+++ b/src/main/resources/languages/en-US.json
@@ -103,7 +103,7 @@
     "account": {
       "modify": "Modify user accounts",
       "invalid": "Invalid UID.",
-      "exists": "Account already exists.",
+      "exists": "An account with this username and/or UID already exists.",
       "create": "Account created with UID %s.",
       "delete": "Account deleted.",
       "no_account": "Account not found.",


### PR DESCRIPTION
## Description

The current implementation of account creation only checks the UID specified for `/account create` against the reserved IDs in `accounts`. This can lead to a situation where there already is an existing player with a given UID X, but the user can still create an account with `/account create <name> X`. The actual `players` entry of this account will then get a different UID from the one that was specified via `/account create`.

This PR fixes this issue by making sure that no existing player has the UID that the user attempts to reserve.

## Issues fixed by this PR

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.