### PR TITLE
Incompletely implement about QuickUseWidgetReq

### DIFF
--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerQuickUseWidgetReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerQuickUseWidgetReq.java
@@ -1,0 +1,52 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.game.inventory.GameItem;
+import emu.grasscutter.game.inventory.Inventory;
+import emu.grasscutter.game.inventory.InventoryTab;
+import emu.grasscutter.game.inventory.ItemType;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.QuickUseWidgetRspOuterClass.QuickUseWidgetRsp;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketPullRecentChatRsp;
+
+@Opcodes(PacketOpcodes.QuickUseWidgetReq)
+public class HandlerQuickUseWidgetReq extends PacketHandler {
+    /*
+    * WARNING: with the consuming of material widget ( Example: bomb ),
+    * this is just a implement designed to the decreasing of count
+    *
+    * ### Known Bug: No effects after using item but decrease. ###
+    *
+    * If you know which Packet could make the effects, feel free to contribute!
+    * */
+    @Override
+    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+        QuickUseWidgetRsp.Builder proto = QuickUseWidgetRsp.newBuilder();
+        Player pl = session.getPlayer();
+        synchronized (pl) {
+            int materialId = pl.getWidgetId();
+            Inventory inventory = session.getPlayer().getInventory();
+            InventoryTab inventoryTab = inventory.getInventoryTab(ItemType.ITEM_MATERIAL);
+            GameItem item = inventoryTab.getItemById(materialId);
+            int remain = item.getCount();
+            if (remain > 0) {
+                remain--;
+                if (remain <= 0) {
+                    proto.setRetcode(1);
+                } else {
+                    proto.setRetcode(0);
+                }
+                proto.setMaterialId(materialId);
+                inventory.removeItem(item,1);// decrease count
+                BasePacket rsp = new BasePacket(PacketOpcodes.QuickUseWidgetRsp);
+                rsp.setData(proto);
+                session.send(rsp);
+                // but no effects in the game, feel free to implement it!
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
WARNING: with the consuming of material widget ( Example: bomb ),
this is just a implement designed to the decreasing of count

**Known Bug: No effects after using item but decreasing.** 

If you know which Packet could make the effects, feel free to contribute please! 

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.