### PR TITLE
Spawn default monsters with different levels

### DIFF
--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -465,7 +465,11 @@ public class Scene {
 					continue;
 				}
 				
-				EntityMonster entity = new EntityMonster(this, data, entry.getPos(), worldLevelOverride > 0 ? worldLevelOverride : entry.getLevel());
+				int level = worldLevelOverride > 0 ? worldLevelOverride + entry.getLevel() - 22 : entry.getLevel();
+				level = level >= 100 ? 100 : level;
+				level = level <= 0 ? 1 : level;
+				
+				EntityMonster entity = new EntityMonster(this, data, entry.getPos(), level);
 				entity.getRotation().set(entry.getRot());
 				entity.setGroupId(entry.getGroup().getGroupId());
 				entity.setPoseId(entry.getPoseId());


### PR DESCRIPTION
## Description

Spawn default monsters with different levels according to data/Spawns.json.

For example, in world with worldlevel 8, base monster level is 90 according to  resources/ExcelBinOutput/WorldLevelExcelConfigData.json,  monster level bias in data/Spawns.json belongs to [1,32], the default monster level would be [69, 100].

## Type of changes

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
