### PR TITLE
Fix default Shop.json (for Mondstadt General Goods)

### DIFF
--- a/src/main/resources/defaults/data/Shop.json
+++ b/src/main/resources/defaults/data/Shop.json
@@ -5,8 +5,8 @@
       {
         "goodsId": 1004202,
         "goodsItem": {
-          "Id": 202,
-          "Count": 1000000
+          "id": 202,
+          "count": 1000000
         },
         "scoin": 1,
         "buyLimit": 500,
@@ -16,17 +16,18 @@
         "maxLevel": 99,
         "costItemList": [
           {
-            "Id": 223,
-            "Count": 100
+            "id": 223,
+            "count": 100
           }
         ]
       },
       {
         "goodsId": 10048006,
         "goodsItem": {
-          "Id": 108006,
-          "Count": 20
+          "id": 108006,
+          "count": 20
         },
+        "costItemList": [],
         "scoin": 100,
         "hcoin": 100,
         "mcoin": 100,
@@ -39,9 +40,10 @@
       {
         "goodsId": 10048033,
         "goodsItem": {
-          "Id": 108033,
-          "Count": 20
+          "id": 108033,
+          "count": 20
         },
+        "costItemList": [],
         "scoin": 1,
         "buyLimit": 50000,
         "beginTime": 1575129600,


### PR DESCRIPTION
## Description

The additional items defined in default Shop.json for Mondstadt General Goods are not updated for 2.7 protos and are not working.
This PR fixes Shop.json for that.
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [X] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My pull request is unique and no other pull requests have been opened for these changes
- [X] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [X] I am responsible for any copyright issues with my code if it occurs in the future.