### PR TITLE
Fix unable to save game data occasionally

### DIFF
--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
@@ -8,6 +8,7 @@ import emu.grasscutter.data.excels.DungeonData;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.SceneType;
 import emu.grasscutter.game.quest.enums.QuestTrigger;
+import emu.grasscutter.game.world.Scene;
 import emu.grasscutter.net.packet.BasePacket;
 import emu.grasscutter.net.packet.PacketOpcodes;
 import emu.grasscutter.server.game.GameServer;
@@ -80,19 +81,21 @@ public class DungeonManager {
 	}
 
 	public void exitDungeon(Player player) {
-		if (player.getScene().getSceneType() != SceneType.SCENE_DUNGEON) {
+		Scene scene = player.getScene();
+		
+		if (scene==null || scene.getSceneType() != SceneType.SCENE_DUNGEON) {
 			return;
 		}
 		
 		// Get previous scene
-		int prevScene = player.getScene().getPrevScene() > 0 ? player.getScene().getPrevScene() : 3;
+		int prevScene = scene.getPrevScene() > 0 ? scene.getPrevScene() : 3;
 		
 		// Get previous position
-		DungeonData dungeonData = player.getScene().getDungeonData();
+		DungeonData dungeonData = scene.getDungeonData();
 		Position prevPos = new Position(GameConstants.START_POSITION);
 		
 		if (dungeonData != null) {
-			ScenePointEntry entry = GameData.getScenePointEntryById(prevScene, player.getScene().getPrevScenePoint());
+			ScenePointEntry entry = GameData.getScenePointEntryById(prevScene, scene.getPrevScenePoint());
 			
 			if (entry != null) {
 				prevPos.set(entry.getPointData().getTranPos());

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -1219,11 +1219,15 @@ public class Player {
 		GameServer server = this.getServer();
 		synchronized (server) {
 			exists = server.getPlayerByUid(uid);
+
 		}
 		if (exists != null) {
 			exists.save();//must save immediately , or the below will get old data
-			exists.getSession().close();
-			Grasscutter.getLogger().warn("Player (UID {}) was kicked due to duplicated login", uid);
+			GameSession existsSession = exists.getSession();
+			if(existsSession!=getSession()) {// No self-kicking
+				existsSession.close();
+				Grasscutter.getLogger().warn("Player (UID {}) was kicked due to duplicated login", uid);
+			}
 		}
 
 		// Load from db

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -1212,20 +1212,6 @@ public class Player {
 			this.getProfile().syncWithCharacter(this);
 		}
 
-		// Check if player object exists in server
-		// TODO - optimize
-		int uid = getUid();
-		GameServer server = this.getServer();
-		Player exists = server.getPlayerByUid(uid);
-		if (exists != null) {
-			GameSession existsSession = exists.getSession();
-			if(existsSession!=getSession()) {// No self-kicking
-				exists.onLogout();//must save immediately , or the below will load old data
-				existsSession.close();
-				Grasscutter.getLogger().warn("Player (UID {}) was kicked due to duplicated login", uid);
-			}
-		}
-
 		// Load from db
 		this.getAvatars().loadFromDatabase();
 		this.getInventory().loadFromDatabase();
@@ -1234,12 +1220,13 @@ public class Player {
 		this.getFriendsList().loadFromDatabase();
 		this.getMailHandler().loadFromDatabase();
 		this.getQuestManager().loadFromDatabase();
-		
+
 		// Add to gameserver (Always handle last)
 		if (getSession().isActive()) {
 			getServer().registerPlayer(this);
 			getProfile().setPlayer(this); // Set online
 		}
+
 	}
 
 	public void onLogin() {
@@ -1327,6 +1314,7 @@ public class Player {
 
 			//reset wood
 			getDeforestationManager().resetWood();
+
 		}catch (Throwable e){
 			e.printStackTrace();
 			Grasscutter.getLogger().warn("Player (UID {}) save failure", getUid());

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -2,6 +2,7 @@ package emu.grasscutter.game.player;
 
 import dev.morphia.annotations.*;
 import emu.grasscutter.GameConstants;
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.excels.PlayerLevelData;
 import emu.grasscutter.database.DatabaseHelper;
@@ -1213,9 +1214,16 @@ public class Player {
 
 		// Check if player object exists in server
 		// TODO - optimize
-		Player exists = this.getServer().getPlayerByUid(getUid());
+		int uid = getUid();
+		Player exists;
+		GameServer server = this.getServer();
+		synchronized (server) {
+			exists = server.getPlayerByUid(uid);
+		}
 		if (exists != null) {
+			exists.save();//must save immediately , or the below will get old data
 			exists.getSession().close();
+			Grasscutter.getLogger().warn("Player (UID {}) was kicked due to duplicated login", uid);
 		}
 
 		// Load from db

--- a/src/main/java/emu/grasscutter/server/game/GameServerInitializer.java
+++ b/src/main/java/emu/grasscutter/server/game/GameServerInitializer.java
@@ -13,6 +13,10 @@ public class GameServerInitializer extends KcpServerInitializer {
 	
     @Override
     protected void initChannel(UkcpChannel ch) throws Exception {
-        new GameSession(server,ch.pipeline());
+        ChannelPipeline pipeline=null;
+        if(ch!=null){
+            pipeline = ch.pipeline();
+        }
+        new GameSession(server,pipeline);
     }
 }

--- a/src/main/java/emu/grasscutter/server/game/GameServerInitializer.java
+++ b/src/main/java/emu/grasscutter/server/game/GameServerInitializer.java
@@ -13,8 +13,6 @@ public class GameServerInitializer extends KcpServerInitializer {
 	
     @Override
     protected void initChannel(UkcpChannel ch) throws Exception {
-        ChannelPipeline pipeline = ch.pipeline();
-        GameSession session = new GameSession(server);
-        pipeline.addLast(session);
+        new GameSession(server,ch.pipeline());
     }
 }

--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -102,8 +102,12 @@ public class GameSession extends KcpChannel {
 		return state;
 	}
 
-	public void setState(SessionState state) {
+	public boolean setState(SessionState state) {
+		if(this.state == state){
+			return false;
+		}
 		this.state = state;
+		return true;
 	}
 
 	public boolean isLoggedIn() {
@@ -141,18 +145,18 @@ public class GameSession extends KcpChannel {
 		Grasscutter.getLogger().info(translate("messages.game.disconnect", this.getAddress().getHostString().toLowerCase()));
 
 		// Set state so no more packets can be handled
-		this.setState(SessionState.INACTIVE);
-		
-		// Save after disconnecting
-		if (this.isLoggedIn()) {
-			Player player = getPlayer();
-			// Call logout event.
-			player.onLogout();
-		}
-		try{
-			pipeline.remove(this);
-		}catch (Throwable ignore){
+		if(this.setState(SessionState.INACTIVE)) {
+			// Save after disconnecting
+			if (this.isLoggedIn()) {
+				Player player = getPlayer();
+				// Call logout event.
+				player.onLogout();
+			}
+			try {
+				pipeline.remove(this);
+			} catch (Throwable ignore) {
 
+			}
 		}
 	}
 	

--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -151,12 +151,10 @@ public class GameSession extends KcpChannel {
 			// Call logout event.
 			player.onLogout();
 		}
-		if(pipeline!=null) {
-			try {
-				pipeline.remove(this);
-			} catch (Throwable ignore) {
+		try {
+			pipeline.remove(this);
+		} catch (Throwable ignore) {
 
-			}
 		}
 	}
 	

--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -3,6 +3,8 @@ package emu.grasscutter.server.game;
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 import emu.grasscutter.Grasscutter;
@@ -17,9 +19,11 @@ import emu.grasscutter.server.event.game.SendPacketEvent;
 import emu.grasscutter.utils.Crypto;
 import emu.grasscutter.utils.FileUtils;
 import emu.grasscutter.utils.Utils;
+import io.jpower.kcp.netty.UkcpChannel;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
 
 import static emu.grasscutter.utils.Language.translate;
 import static emu.grasscutter.Configuration.*;
@@ -36,11 +40,25 @@ public class GameSession extends KcpChannel {
 	private int clientTime;
 	private long lastPingTime;
 	private int lastClientSeq = 10;
-	
-	public GameSession(GameServer server) {
+
+	private final ChannelPipeline pipeline;
+	@Override
+	public void close() {
+		setState(SessionState.INACTIVE);
+		//send disconnection pack in case of reconnection
+		try {
+			send(new BasePacket(PacketOpcodes.ServerDisconnectClientNotify));
+		}catch (Throwable ignore){
+
+		}
+		super.close();
+	}
+	public GameSession(GameServer server, ChannelPipeline pipeline) {
 		this.server = server;
 		this.state = SessionState.WAITING_FOR_TOKEN;
 		this.lastPingTime = System.currentTimeMillis();
+		this.pipeline = pipeline;
+		pipeline.addLast(this);
 	}
 	
 	public GameServer getServer() {
@@ -131,6 +149,11 @@ public class GameSession extends KcpChannel {
 			getPlayer().onLogout();
 			// Remove from server.
 			getServer().getPlayers().remove(getPlayer().getUid());
+		}
+		try{
+			pipeline.remove(this);
+		}catch (Throwable ignore){
+
 		}
 	}
 	

--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -58,7 +58,9 @@ public class GameSession extends KcpChannel {
 		this.state = SessionState.WAITING_FOR_TOKEN;
 		this.lastPingTime = System.currentTimeMillis();
 		this.pipeline = pipeline;
-		pipeline.addLast(this);
+		if(pipeline!=null) {
+			pipeline.addLast(this);
+		}
 	}
 	
 	public GameServer getServer() {
@@ -142,17 +144,19 @@ public class GameSession extends KcpChannel {
 
 		// Set state so no more packets can be handled
 		this.setState(SessionState.INACTIVE);
-		
+
 		// Save after disconnecting
 		if (this.isLoggedIn()) {
 			Player player = getPlayer();
 			// Call logout event.
 			player.onLogout();
 		}
-		try{
-			pipeline.remove(this);
-		}catch (Throwable ignore){
+		if(pipeline!=null) {
+			try {
+				pipeline.remove(this);
+			} catch (Throwable ignore) {
 
+			}
 		}
 	}
 	

--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -145,10 +145,9 @@ public class GameSession extends KcpChannel {
 		
 		// Save after disconnecting
 		if (this.isLoggedIn()) {
+			Player player = getPlayer();
 			// Call logout event.
-			getPlayer().onLogout();
-			// Remove from server.
-			getServer().getPlayers().remove(getPlayer().getUid());
+			player.onLogout();
 		}
 		try{
 			pipeline.remove(this);

--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -102,12 +102,8 @@ public class GameSession extends KcpChannel {
 		return state;
 	}
 
-	public boolean setState(SessionState state) {
-		if(this.state == state){
-			return false;
-		}
+	public void setState(SessionState state) {
 		this.state = state;
-		return true;
 	}
 
 	public boolean isLoggedIn() {
@@ -145,18 +141,18 @@ public class GameSession extends KcpChannel {
 		Grasscutter.getLogger().info(translate("messages.game.disconnect", this.getAddress().getHostString().toLowerCase()));
 
 		// Set state so no more packets can be handled
-		if(this.setState(SessionState.INACTIVE)) {
-			// Save after disconnecting
-			if (this.isLoggedIn()) {
-				Player player = getPlayer();
-				// Call logout event.
-				player.onLogout();
-			}
-			try {
-				pipeline.remove(this);
-			} catch (Throwable ignore) {
+		this.setState(SessionState.INACTIVE);
+		
+		// Save after disconnecting
+		if (this.isLoggedIn()) {
+			Player player = getPlayer();
+			// Call logout event.
+			player.onLogout();
+		}
+		try{
+			pipeline.remove(this);
+		}catch (Throwable ignore){
 
-			}
 		}
 	}
 	

--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -53,6 +53,9 @@ public class GameSession extends KcpChannel {
 		}
 		super.close();
 	}
+	public GameSession(GameServer server) {
+		this(server,null);
+	}
 	public GameSession(GameServer server, ChannelPipeline pipeline) {
 		this.server = server;
 		this.state = SessionState.WAITING_FOR_TOKEN;

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerTokenReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerTokenReq.java
@@ -25,8 +25,8 @@ public class HandlerGetPlayerTokenReq extends PacketHandler {
 		GetPlayerTokenReq req = GetPlayerTokenReq.parseFrom(payload);
 		
 		// Authenticate
-		Account account = DatabaseHelper.getAccountByToken(req.getAccountToken());
-		if (account == null) {
+		Account account = DatabaseHelper.getAccountById(req.getAccountUid());
+		if (account == null || !account.getToken().equals(req.getAccountToken())) {
 			return;
 		}
 		

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerTokenReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerTokenReq.java
@@ -20,6 +20,8 @@ public class HandlerGetPlayerTokenReq extends PacketHandler {
 	
 	@Override
 	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+
+		// TODO: If there are 5 online players, max count of player is 5, a new client want to login by kicking one of them , I think it should be allowed
 		// Max players limit
 		if (ACCOUNT.maxPlayer > -1 && Grasscutter.getGameServer().getPlayers().size() >= ACCOUNT.maxPlayer) {
 			session.close();
@@ -29,13 +31,8 @@ public class HandlerGetPlayerTokenReq extends PacketHandler {
 		GetPlayerTokenReq req = GetPlayerTokenReq.parseFrom(payload);
 		
 		// Authenticate
-		Account account = DatabaseHelper.getAccountById(req.getAccountUid());
+		Account account = DatabaseHelper.getAccountByToken(req.getAccountToken());
 		if (account == null) {
-			return;
-		}
-		
-		// Check token
-		if (!account.getToken().equals(req.getAccountToken())) {
 			return;
 		}
 		

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerQuickUseWidgetReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerQuickUseWidgetReq.java
@@ -1,5 +1,6 @@
 package emu.grasscutter.server.packet.recv;
 
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.game.inventory.Inventory;
 import emu.grasscutter.game.inventory.InventoryTab;
@@ -45,6 +46,7 @@ public class HandlerQuickUseWidgetReq extends PacketHandler {
                 BasePacket rsp = new BasePacket(PacketOpcodes.QuickUseWidgetRsp);
                 rsp.setData(proto);
                 session.send(rsp);
+                Grasscutter.getLogger().warn("class has no effects in the game, feel free to implement it");
                 // but no effects in the game, feel free to implement it!
             }
         }


### PR DESCRIPTION
## Fix bugs:

**1. Max players limit**

If there are 5 online players, max count of player is 5,
a new client ( who has one of their account) want to login by kicking one of them ,
I think it should be allowed

**2. Check whether user exists, if exists, kick it and save data( save immediately! )**

Checking must situated here (before `getPlayerByUID`)! 
because to save firstly ,to load secondly !!!
or the `getPlayerByUID` will load old data


**3.Remove offline player from server**

Don't delete by uid,because there are multiple same uid players when duplicated login!
so I decide to delete by object rather than uid

**4.`exitDungeon` added a sanity check in case of null error**


**5.Fix data lost**
Fix when player exit game or kicked by others login, client quickly login again will lost recently record.


I am sorry but too many problem with this project, I can't edit simply, if you have any question ,feel free to ask me!


## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.