### PR TITLE
Implement element burst invincible time

### DIFF
--- a/src/main/java/emu/grasscutter/data/ResourceType.java
+++ b/src/main/java/emu/grasscutter/data/ResourceType.java
@@ -11,6 +11,9 @@ public @interface ResourceType {
 	
 	/** Load priority - dictates which order to load this resource, with "highest" being loaded first */
 	LoadPriority loadPriority() default LoadPriority.NORMAL;
+
+	/** use extend config json, which will merge into the current config, the extend json with the name of string append of original config json name and place in the data folder, eg: AvatarSkillExcelConfigData.json AvatarSkillExcelConfigDataEx.json */
+	boolean useExtendConfig() default false;
 	
 	public enum LoadPriority {
 		HIGHEST	(4), 

--- a/src/main/java/emu/grasscutter/data/excels/AvatarSkillData.java
+++ b/src/main/java/emu/grasscutter/data/excels/AvatarSkillData.java
@@ -7,7 +7,7 @@ import emu.grasscutter.data.ResourceType;
 import emu.grasscutter.data.ResourceType.LoadPriority;
 import emu.grasscutter.game.props.ElementType;
 
-@ResourceType(name = "AvatarSkillExcelConfigData.json", loadPriority = LoadPriority.HIGHEST)
+@ResourceType(name = "AvatarSkillExcelConfigData.json", loadPriority = LoadPriority.HIGHEST, useExtendConfig = true)
 public class AvatarSkillData extends GameResource {
 	private int id;
     private	float cdTime;
@@ -24,6 +24,8 @@ public class AvatarSkillData extends GameResource {
     private String abilityName;
     private String lockShape;
     private String globalValueKey;
+	
+	private int invincibleTime;
 
     @Override
 	public int getId(){
@@ -81,5 +83,9 @@ public class AvatarSkillData extends GameResource {
 	@Override
 	public void onLoad() {
 		
+	}
+
+	public int getInvincibleTime() {
+		return invincibleTime;
 	}
 }

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -151,6 +151,7 @@ public class Player {
 	@Transient private SceneLoadState sceneState;
 	@Transient private boolean hasSentAvatarDataNotify;
 	@Transient private long nextSendPlayerLocTime = 0;
+	@Transient private long playerElementBurstInvincibleEndTime = 0;
 
 	@Transient private final Int2ObjectMap<CoopRequest> coopRequests;
 	@Transient private final Queue<AttackResult> attackResults;
@@ -1389,6 +1390,14 @@ public class Player {
 		//Note: DON'T DELETE BY UID,BECAUSE THERE ARE MULTIPLE SAME UID PLAYERS WHEN DUPLICATED LOGIN!
 		//so I decide to delete by object rather than uid
 		getServer().getPlayers().values().removeIf(player1 -> player1 == this);
+	}
+
+	public long getPlayerElementBurstInvincibleEndTime() {
+		return playerElementBurstInvincibleEndTime;
+	}
+
+	public void setPlayerElementBurstInvincibleEndTime(long playerElementBurstInvincibleEndTime) {
+		this.playerElementBurstInvincibleEndTime = playerElementBurstInvincibleEndTime;
 	}
 
 	public enum SceneLoadState {

--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -33,6 +33,11 @@ public class GameSession implements GameSessionManager.KcpChannel {
 	private int clientTime;
 	private long lastPingTime;
 	private int lastClientSeq = 10;
+	
+	/**
+	 * time of latency 
+ 	 */
+	private int latency;
 
 	public GameSession(GameServer server) {
 		this.server = server;
@@ -174,6 +179,8 @@ public class GameSession implements GameSessionManager.KcpChannel {
 
 	@Override
 	public void handleReceive(byte[] bytes) {
+		// update session latency
+		this.latency = this.tunnel.getSrtt() / 2;
 		// Decrypt and turn back into a packet
 		Crypto.xor(bytes, useSecretKey() ? Crypto.ENCRYPT_KEY : Crypto.DISPATCH_KEY);
 		ByteBuf packet = Unpooled.wrappedBuffer(bytes);
@@ -256,6 +263,10 @@ public class GameSession implements GameSessionManager.KcpChannel {
 
 	public boolean isActive() {
 		return getState() == SessionState.ACTIVE;
+	}
+
+	public int getLatency() {
+		return latency;
 	}
 
 	public enum SessionState {

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtDoSkillSuccNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtDoSkillSuccNotify.java
@@ -1,10 +1,14 @@
 package emu.grasscutter.server.packet.recv;
 
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.excels.AvatarSkillData;
 import emu.grasscutter.net.packet.Opcodes;
 import emu.grasscutter.net.packet.PacketHandler;
 import emu.grasscutter.net.packet.PacketOpcodes;
 import emu.grasscutter.net.proto.EvtDoSkillSuccNotifyOuterClass.EvtDoSkillSuccNotify;
 import emu.grasscutter.server.game.GameSession;
+
+import java.util.concurrent.TimeUnit;
 
 @Opcodes(PacketOpcodes.EvtDoSkillSuccNotify)
 public class HandlerEvtDoSkillSuccNotify extends PacketHandler {
@@ -15,6 +19,10 @@ public class HandlerEvtDoSkillSuccNotify extends PacketHandler {
         int skillId = notify.getSkillId();
         int casterId = notify.getCasterId();
 
+        final AvatarSkillData avatarSkillData = GameData.getAvatarSkillDataMap().get(skillId);
+        if (avatarSkillData != null && avatarSkillData.getCostElemVal() > 0) {
+            session.getPlayer().setPlayerElementBurstInvincibleEndTime(TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - session.getLatency() + avatarSkillData.getInvincibleTime());
+        }
         session.getPlayer().getStaminaManager().handleEvtDoSkillSuccNotify(session, skillId, casterId);
         session.getPlayer().getEnergyManager().handleEvtDoSkillSuccNotify(session, skillId, casterId);
     }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketWorldPlayerRTTNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketWorldPlayerRTTNotify.java
@@ -18,7 +18,7 @@ public class PacketWorldPlayerRTTNotify extends BasePacket {
 			proto.addPlayerRttList(
 					PlayerRTTInfo.newBuilder()
 							.setUid(player.getUid())
-							.setRtt(10) // TODO - put player ping here
+							.setRtt(player.getSession().getLatency())
 			);
 		}
 		

--- a/src/main/resources/defaults/data/ExcelBinOutput/AvatarSkillExcelConfigDataEx.json
+++ b/src/main/resources/defaults/data/ExcelBinOutput/AvatarSkillExcelConfigDataEx.json
@@ -1,0 +1,238 @@
+[
+    {
+        "id": 10014,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10017,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10019,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10021,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10034,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10062,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10068,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10072,
+        "invincibleTime": 3500
+    },
+    {
+        "id": 10075,
+        "invincibleTime": 2500
+    },
+    {
+        "id": 10078,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10165,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10203,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10225,
+        "invincibleTime": 1570
+    },
+    {
+        "id": 10235,
+        "invincibleTime": 1570
+    },
+    {
+        "id": 10245,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10255,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10265,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10274,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10295,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10303,
+        "invincibleTime": 4500
+    },
+    {
+        "id": 10313,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10323,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10333,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10343,
+        "invincibleTime": 2200
+    },
+    {
+        "id": 10353,
+        "invincibleTime": 1570
+    },
+    {
+        "id": 10373,
+        "invincibleTime": 3500
+    },
+    {
+        "id": 11305,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10259,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10362,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 11373,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10385,
+        "invincibleTime": 2300
+    },
+    {
+        "id": 10388,
+        "invincibleTime": 4200
+    },
+    {
+        "id": 10395,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10403,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10415,
+        "invincibleTime": 2600
+    },
+    {
+        "id": 10425,
+        "invincibleTime": 4500
+    },
+    {
+        "id": 10435,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10443,
+        "invincibleTime": 1450
+    },
+    {
+        "id": 10453,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10463,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10475,
+        "invincibleTime": 2500
+    },
+    {
+        "id": 10485,
+        "invincibleTime": 1450
+    },
+    {
+        "id": 10495,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10505,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10515,
+        "invincibleTime": 2300
+    },
+    {
+        "id": 10525,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10535,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10545,
+        "invincibleTime": 1450
+    },
+    {
+        "id": 10555,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10565,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10575,
+        "invincibleTime": 2200
+    },
+    {
+        "id": 10585,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10605,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10610,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10635,
+        "invincibleTime": 1450
+    },
+    {
+        "id": 10625,
+        "invincibleTime": 4400
+    },
+    {
+        "id": 10643,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10655,
+        "invincibleTime": 2000
+    },
+    {
+        "id": 10665,
+        "invincibleTime": 2000
+    }
+]


### PR DESCRIPTION
## Description
simple implementation of element burst invincible time
1. when handling EvtDoSkillSuccNotify, calculate the time of element burst end (use fixed time, 2 seconds, since cannot find the config, counting the lag of kcp)
2. when handling CombatInvocationsNotify of EvtBeingHitInfo, judge the nano time is less than the time of element burst end

## Issues fixed by this PR
[https://github.com/Grasscutters/Grasscutter/issues/361]()
<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.