### PR TITLE
Partial revert of #1245

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/PermissionCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/PermissionCommand.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "permission", usage = "permission <add|remove> <permission>", permission = "server.permission", description = "commands.permission.description", targetRequirement = Command.TargetRequirement.NONE)
+@Command(label = "permission", usage = "permission <add|remove> <permission>", permission = "permission", description = "commands.permission.description")
 public final class PermissionCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/PositionCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/PositionCommand.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "position", usage = "position", aliases = {"pos"}, description = "commands.position.description", targetRequirement = Command.TargetRequirement.NONE)
+@Command(label = "position", usage = "position", aliases = {"pos"}, description = "commands.position.description")
 public final class PositionCommand implements CommandHandler {
 
     @Override


### PR DESCRIPTION
## Description
Reverts incorrect usage of `Command.TargetRequirement.NONE`.
Also reverts changing `permission`'s permission to `server.permission` as collateral damage.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.