### PR TITLE
Implement Resin

### DIFF
--- a/src/main/java/emu/grasscutter/data/excels/DungeonData.java
+++ b/src/main/java/emu/grasscutter/data/excels/DungeonData.java
@@ -15,6 +15,9 @@ public class DungeonData extends GameResource {
 	private String involveType; // TODO enum
 	
 	private RewardPreviewData previewData;
+
+	private int statueCostID;
+	private int statueCostCount;
 	    
 	@Override
 	public int getId() {
@@ -31,6 +34,14 @@ public class DungeonData extends GameResource {
 
 	public RewardPreviewData getRewardPreview() {
 		return previewData;
+	}
+
+	public int getStatueCostID() {
+		return statueCostID;
+	}
+
+	public int getStatueCostCount() {
+		return statueCostCount;
 	}
 
 	@Override

--- a/src/main/java/emu/grasscutter/game/combine/CombineManger.java
+++ b/src/main/java/emu/grasscutter/game/combine/CombineManger.java
@@ -3,10 +3,12 @@ package emu.grasscutter.game.combine;
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.common.ItemParamData;
 import emu.grasscutter.data.excels.CombineData;
+import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.game.inventory.ItemType;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.net.proto.RetcodeOuterClass;
 import emu.grasscutter.server.game.GameServer;
+import emu.grasscutter.server.packet.send.PacketCombineFormulaDataNotify;
 import emu.grasscutter.server.packet.send.PacketCombineRsp;
 import it.unimi.dsi.fastutil.Pair;
 
@@ -22,6 +24,27 @@ public class CombineManger {
     public CombineManger(GameServer gameServer) {
         this.gameServer = gameServer;
     }
+
+    public boolean unlockCombineDiagram(Player player, GameItem diagramItem) {
+		// Make sure this is actually a diagram.
+		if (!diagramItem.getItemData().getItemUse().get(0).getUseOp().equals("ITEM_USE_UNLOCK_COMBINE")) {
+			return false;
+		}
+
+		// Determine the combine item we should unlock.
+		int combineId = Integer.parseInt(diagramItem.getItemData().getItemUse().get(0).getUseParam().get(0));
+
+		// Remove the diagram from the player's inventory.
+		// We need to do this here, before sending CombineFormulaDataNotify, or the the combine UI won't correctly
+		// update when unlocking the diagram.
+		player.getInventory().removeItem(diagramItem, 1);
+
+		// Tell the client that this diagram is now unlocked and add the unlocked item to the player.
+		player.getUnlockedCombines().add(combineId);
+		player.sendPacket(new PacketCombineFormulaDataNotify(combineId));
+
+		return true;
+	}
 
     public CombineResult combineItem(Player player, int cid, int count){
         // check config exist

--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonChallenge.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonChallenge.java
@@ -167,6 +167,8 @@ public class DungeonChallenge {
 
 	public void getStatueDrops(Player player, GadgetInteractReq request) {
 		DungeonData dungeonData = getScene().getDungeonData();
+		int resinCost = dungeonData.getStatueCostCount() != 0 ? dungeonData.getStatueCostCount() : 20;
+
 		if (!isSuccess() || dungeonData == null || dungeonData.getRewardPreview() == null || dungeonData.getRewardPreview().getPreviewItems().length == 0) {
 			return;
 		}
@@ -180,6 +182,13 @@ public class DungeonChallenge {
 		List<GameItem> rewards = new ArrayList<>();
 
 		if (request.getIsUseCondenseResin()) {
+			// Check if condensed resin is usable here.
+			// For this, we use the following logic for now:
+			// The normal resin cost of the dungeon has to be 20.
+			if (resinCost != 20) {
+				return;
+			}
+
 			// Make sure the player has condensed resin.
 			GameItem condensedResin = player.getInventory().getInventoryTab(ItemType.ITEM_MATERIAL).getItemById(220007);
 			if (condensedResin == null || condensedResin.getCount() <= 0) {
@@ -196,7 +205,7 @@ public class DungeonChallenge {
 		else {
 			// If the player used regular resin, try to deduct.
 			// Stop if insufficient resin.
-			boolean success = player.getResinManager().useResin(20);
+			boolean success = player.getResinManager().useResin(resinCost);
 			if (!success) {
 				return;
 			}

--- a/src/main/java/emu/grasscutter/game/inventory/Inventory.java
+++ b/src/main/java/emu/grasscutter/game/inventory/Inventory.java
@@ -258,6 +258,8 @@ public class Inventory implements Iterable<GameItem> {
 					getPlayer().addExpDirectly(count);
 			case 105 -> // Companionship exp
 					getPlayer().getServer().getInventoryManager().upgradeAvatarFetterLevel(player, getPlayer().getTeamManager().getCurrentAvatarEntity().getAvatar(), count);
+			case 106 -> // Resin
+					getPlayer().getResinManager().addResin(count);
 			case 201 -> // Primogem
 					getPlayer().setPrimogems(player.getPrimogems() + count);
 			case 202 -> // Mora

--- a/src/main/java/emu/grasscutter/game/inventory/Inventory.java
+++ b/src/main/java/emu/grasscutter/game/inventory/Inventory.java
@@ -17,6 +17,7 @@ import emu.grasscutter.game.avatar.AvatarStorage;
 import emu.grasscutter.game.avatar.Avatar;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.ActionReason;
+import emu.grasscutter.game.props.PlayerProperty;
 import emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam;
 import emu.grasscutter.server.packet.send.PacketAvatarEquipChangeNotify;
 import emu.grasscutter.server.packet.send.PacketItemAddHintNotify;
@@ -277,6 +278,8 @@ public class Inventory implements Iterable<GameItem> {
 				return player.getMora();
 			case 203:  // Genesis Crystals
 				return player.getCrystals();
+			case 106:  // Resin
+				return player.getProperty(PlayerProperty.PROP_PLAYER_RESIN);
 			default:
 				GameItem item = getInventoryTab(ItemType.ITEM_MATERIAL).getItemById(itemId);  // What if we ever want to operate on weapons/relics/furniture? :S
 				return (item == null) ? 0 : item.getCount();
@@ -315,6 +318,8 @@ public class Inventory implements Iterable<GameItem> {
 					player.setMora(player.getMora() - (cost.getCount() * quantity));
 				case 203 ->  // Genesis Crystals
 					player.setCrystals(player.getCrystals() - (cost.getCount() * quantity));
+				case 106 ->  // Resin
+					player.getResinManager().useResin(cost.getCount() * quantity);
 				default ->
 					removeItem(getInventoryTab(ItemType.ITEM_MATERIAL).getItemById(cost.getId()), cost.getCount() * quantity);
 			}

--- a/src/main/java/emu/grasscutter/game/managers/ForgingManager/ForgingManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/ForgingManager/ForgingManager.java
@@ -157,39 +157,7 @@ public class ForgingManager {
 		if (!success) {
 			this.player.sendPacket(new PacketForgeStartRsp(Retcode.RET_FORGE_POINT_NOT_ENOUGH)); //ToDo: Probably the wrong return code.
 		}
-		
-		// Check if we have enough of each material.
-		/* for (var material : forgeData.getMaterialItems()) {
-			if (material.getItemId() == 0) {
-				continue;
-			}
 
-			int currentCount = this.player.getInventory().getInventoryTab(ItemType.ITEM_MATERIAL).getItemById(material.getItemId()).getCount();
-
-			if (currentCount < material.getCount() * req.getForgeCount()) {
-				this.player.sendPacket(new PacketForgeStartRsp(Retcode.RET_FORGE_POINT_NOT_ENOUGH)); //ToDo: Probably the wrong return code.
-				return;
-			}
-		}
-
-		// Check if we have enough Mora.
-		if (this.player.getMora() < forgeData.getScoinCost() * req.getForgeCount()) {
-			this.player.sendPacket(new PacketForgeStartRsp(Retcode.RET_FORGE_POINT_NOT_ENOUGH)); //ToDo: Probably the wrong return code.
-			return;
-		}
-
-		// Consume material and Mora.
-		for (var material : forgeData.getMaterialItems()) {
-			if (material.getItemId() == 0) {
-				continue;
-			}
-
-			GameItem item = this.player.getInventory().getInventoryTab(ItemType.ITEM_MATERIAL).getItemById(material.getItemId());
-			this.player.getInventory().removeItem(item, material.getCount() * req.getForgeCount());
-		}
-
-		this.player.setMora(this.player.getMora() - forgeData.getScoinCost() * req.getForgeCount());
-		*/
 		// Create and add active forge.
 		ActiveForgeData activeForge = new ActiveForgeData();
 		activeForge.setForgeId(req.getForgeId());

--- a/src/main/java/emu/grasscutter/game/managers/InventoryManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/InventoryManager.java
@@ -857,6 +857,22 @@ public class InventoryManager {
 					useSuccess = player.getForgingManager().unlockForgingBlueprint(useItem);
 				}
 				break;
+			case MATERIAL_CONSUME_BATCH_USE:
+				// Make sure we have usage data for this material.
+				if (useItem.getItemData().getItemUse() == null) {
+					break;
+				}
+
+				// Handle fragile/transient resin.
+				if (useItem.getItemId() == 107009 || useItem.getItemId() == 107012){				
+					// Add resin to the inventory.
+					ItemData resinItemData = GameData.getItemDataMap().get(106);
+					player.getInventory().addItem(new GameItem(resinItemData, 60 * count), ActionReason.PlayerUseItem);
+
+					// Set used amount.
+					used = count;
+				}
+				break;
 			case MATERIAL_CHEST:
 				List<ShopChestTable> shopChestTableList = player.getServer().getShopManager().getShopChestData();
 				List<GameItem> rewardItemList = new ArrayList<>();

--- a/src/main/java/emu/grasscutter/game/managers/InventoryManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/InventoryManager.java
@@ -856,6 +856,11 @@ public class InventoryManager {
 					// Unlock.
 					useSuccess = player.getForgingManager().unlockForgingBlueprint(useItem);
 				}
+				// Handle combine diagrams.
+				if (useItem.getItemData().getItemUse().get(0).getUseOp().equals("ITEM_USE_UNLOCK_COMBINE")) {
+					// Unlock.
+					useSuccess = player.getServer().getCombineManger().unlockCombineDiagram(player, useItem);
+				}
 				break;
 			case MATERIAL_CONSUME_BATCH_USE:
 				// Make sure we have usage data for this material.

--- a/src/main/java/emu/grasscutter/game/managers/ResinManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/ResinManager.java
@@ -37,7 +37,7 @@ public class ResinManager {
 
         // Check if this has taken the player under the recharge cap,
         // starting the recharging process.
-        if (newResin < GAME_OPTIONS.resinOptions.cap) {
+        if (this.player.getNextResinRefresh() == 0 && newResin < GAME_OPTIONS.resinOptions.cap) {
 		    int currentTime = Utils.getCurrentSeconds();
             this.player.setNextResinRefresh(currentTime + GAME_OPTIONS.resinOptions.rechargeTime);
         }

--- a/src/main/java/emu/grasscutter/game/managers/ResinManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/ResinManager.java
@@ -1,0 +1,99 @@
+package emu.grasscutter.game.managers;
+
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.props.PlayerProperty;
+import emu.grasscutter.server.packet.send.PacketPlayerPropNotify;
+import emu.grasscutter.server.packet.send.PacketResinChangeNotify;
+import emu.grasscutter.utils.Utils;
+
+import static emu.grasscutter.Configuration.GAME_OPTIONS;
+
+public class ResinManager {
+    private final Player player;
+
+    public ResinManager(Player player) {
+        this.player = player;
+    }
+
+    /********************
+     * Use resin.
+     ********************/
+    public synchronized boolean useResin(int amount) {
+        int currentResin = this.player.getProperty(PlayerProperty.PROP_PLAYER_RESIN);
+        
+        // Check if the player has sufficient resin.
+        if (currentResin < amount) {
+            return false;
+        }
+
+        // Deduct the resin from the player.
+        int newResin = currentResin - amount;
+        this.player.setProperty(PlayerProperty.PROP_PLAYER_RESIN, newResin);
+
+        // Check if this has taken the player under the recharge cap,
+        // starting the recharging process.
+        if (newResin < GAME_OPTIONS.resinOptions.cap) {
+		    int currentTime = Utils.getCurrentSeconds();
+            this.player.setNextResinRefresh(currentTime);
+        }
+
+        // Send packets.
+        this.player.sendPacket(new PacketResinChangeNotify(this.player));
+        this.player.sendPacket(new PacketPlayerPropNotify(this.player, PlayerProperty.PROP_PLAYER_RESIN));
+
+        return true;
+    }
+
+    /********************
+     * Recharge resin.
+     ********************/
+    public synchronized void rechargeResin() {
+        int currentResin = this.player.getProperty(PlayerProperty.PROP_PLAYER_RESIN);
+        int currentTime = Utils.getCurrentSeconds();
+
+        // In case server administrators change the resin cap while players are capped,
+        // we need to restart recharging here.
+        if (currentResin < GAME_OPTIONS.resinOptions.cap && this.player.getNextResinRefresh() == 0) {
+            this.player.setNextResinRefresh(currentTime + GAME_OPTIONS.resinOptions.rechargeTime);
+
+            this.player.sendPacket(new PacketPlayerPropNotify(this.player, PlayerProperty.PROP_PLAYER_RESIN));
+            this.player.sendPacket(new PacketResinChangeNotify(this.player));
+
+            return;
+        }
+
+        // Make sure we are currently in "recharging mode".
+        // This is denoted by Player.nextResinRefresh being greater than 0.
+        if (this.player.getNextResinRefresh() <= 0) {
+            return;
+        }
+
+        // Determine if we actually need to recharge yet.
+        if (currentTime < this.player.getNextResinRefresh()) {
+            return;
+        }
+
+        // Calculate how much resin we need to refill and update player.
+        // Note that this can be more than one in case the player
+        // logged off with uncapped resin and is now logging in again.
+        int recharge = 1 + (int)((currentTime - this.player.getNextResinRefresh()) / GAME_OPTIONS.resinOptions.rechargeTime);
+        int newResin = Math.min(GAME_OPTIONS.resinOptions.cap, currentResin + recharge);
+        int resinChange = newResin - currentResin;
+
+        this.player.setProperty(PlayerProperty.PROP_PLAYER_RESIN, newResin);
+
+        // Calculate next recharge time.
+        // Set to zero to disable recharge (because on/over cap.)
+        if (newResin >= GAME_OPTIONS.resinOptions.cap) {
+            this.player.setNextResinRefresh(0);
+        }
+        else {
+            int nextRecharge = this.player.getNextResinRefresh() + resinChange * GAME_OPTIONS.resinOptions.rechargeTime;
+            this.player.setNextResinRefresh(nextRecharge);
+        }
+
+        // Send packets.
+        this.player.sendPacket(new PacketPlayerPropNotify(this.player, PlayerProperty.PROP_PLAYER_RESIN));
+        this.player.sendPacket(new PacketResinChangeNotify(this.player));
+    }
+}

--- a/src/main/java/emu/grasscutter/game/managers/ResinManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/ResinManager.java
@@ -1,5 +1,7 @@
 package emu.grasscutter.game.managers;
 
+import emu.grasscutter.game.inventory.GameItem;
+import emu.grasscutter.game.inventory.ItemType;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.PlayerProperty;
 import emu.grasscutter.server.packet.send.PacketPlayerPropNotify;
@@ -7,6 +9,8 @@ import emu.grasscutter.server.packet.send.PacketResinChangeNotify;
 import emu.grasscutter.utils.Utils;
 
 import static emu.grasscutter.Configuration.GAME_OPTIONS;
+
+import emu.grasscutter.Grasscutter;
 
 public class ResinManager {
     private final Player player;
@@ -39,12 +43,12 @@ public class ResinManager {
         // starting the recharging process.
         if (newResin < GAME_OPTIONS.resinOptions.cap) {
 		    int currentTime = Utils.getCurrentSeconds();
-            this.player.setNextResinRefresh(currentTime);
+            this.player.setNextResinRefresh(currentTime + GAME_OPTIONS.resinOptions.rechargeTime);
         }
 
         // Send packets.
-        this.player.sendPacket(new PacketResinChangeNotify(this.player));
         this.player.sendPacket(new PacketPlayerPropNotify(this.player, PlayerProperty.PROP_PLAYER_RESIN));
+        this.player.sendPacket(new PacketResinChangeNotify(this.player));
 
         return true;
     }
@@ -100,6 +104,9 @@ public class ResinManager {
      * Player login.
      ********************/
     public synchronized void onPlayerLogin() {
+		GameItem condensedResin = player.getInventory().getInventoryTab(ItemType.ITEM_MATERIAL).getItemById(220007);
+        Grasscutter.getLogger().info("Condensed resin count: {}", condensedResin.getCount());
+
         // If resin usage is disabled, set resin to cap.
         if (!GAME_OPTIONS.resinOptions.resinUsage) {
             this.player.setProperty(PlayerProperty.PROP_PLAYER_RESIN, GAME_OPTIONS.resinOptions.cap);

--- a/src/main/java/emu/grasscutter/game/managers/ResinManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/ResinManager.java
@@ -50,6 +50,11 @@ public class ResinManager {
     }
 
     public synchronized void addResin(int amount) {
+        // Check if resin enabled.
+        if (!GAME_OPTIONS.resinOptions.resinUsage) {
+            return;
+        }
+
         // Add resin.
         int currentResin = this.player.getProperty(PlayerProperty.PROP_PLAYER_RESIN);
         int newResin = currentResin + amount;

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -1312,9 +1312,7 @@ public class Player {
 		session.send(new PacketPlayerHomeCompInfoNotify(this));
 		session.send(new PacketHomeComfortInfoNotify(this));
 		this.forgingManager.sendForgeDataNotify();
-
-		this.sendPacket(new PacketResinChangeNotify(this));
-		this.resinManager.rechargeResin();
+		this.resinManager.onPlayerLogin();
 
 		getTodayMoonCard(); // The timer works at 0:0, some users log in after that, use this method to check if they have received a reward today or not. If not, send the reward.
 

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -96,6 +96,7 @@ public class Player {
 	private Set<Integer> flyCloakList;
 	private Set<Integer> costumeList;
 	private Set<Integer> unlockedForgingBlueprints;
+	private Set<Integer> unlockedCombines;
 	private List<ActiveForgeData> activeForges;
 
 	private Integer widgetId;
@@ -197,6 +198,7 @@ public class Player {
 		this.costumeList = new HashSet<>();
 		this.towerData = new TowerData();
 		this.unlockedForgingBlueprints = new HashSet<>();
+		this.unlockedCombines = new HashSet<>();
 		this.activeForges = new ArrayList<>();
 
 		this.setSceneId(3);
@@ -544,6 +546,10 @@ public class Player {
 
 	public Set<Integer> getUnlockedForgingBlueprints() {
 		return this.unlockedForgingBlueprints;
+	}
+
+	public Set<Integer> getUnlockedCombines() {
+		return this.unlockedCombines;
 	}
 
 	public List<ActiveForgeData> getActiveForges() {
@@ -1312,6 +1318,7 @@ public class Player {
 		session.send(new PacketWidgetGadgetAllDataNotify());
 		session.send(new PacketPlayerHomeCompInfoNotify(this));
 		session.send(new PacketHomeComfortInfoNotify(this));
+		session.send(new PacketCombineDataNotify(this.unlockedCombines));
 		this.forgingManager.sendForgeDataNotify();
 		this.resinManager.onPlayerLogin();
 

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -49,6 +49,7 @@ import emu.grasscutter.net.proto.*;
 import emu.grasscutter.net.proto.AbilityInvokeEntryOuterClass.AbilityInvokeEntry;
 import emu.grasscutter.net.proto.AttackResultOuterClass.AttackResult;
 import emu.grasscutter.net.proto.CombatInvokeEntryOuterClass.CombatInvokeEntry;
+import emu.grasscutter.net.proto.GadgetInteractReqOuterClass.GadgetInteractReq;
 import emu.grasscutter.net.proto.InteractTypeOuterClass.InteractType;
 import emu.grasscutter.net.proto.MpSettingTypeOuterClass.MpSettingType;
 import emu.grasscutter.net.proto.OnlinePlayerInfoOuterClass.OnlinePlayerInfo;
@@ -953,7 +954,7 @@ public class Player {
 		return this.getMailHandler().replaceMailByIndex(index, message);
 	}
 	
-	public void interactWith(int gadgetEntityId) {
+	public void interactWith(int gadgetEntityId, GadgetInteractReq request) {
 		GameEntity entity = getScene().getEntityById(gadgetEntityId);
 		if (entity == null) {
 			return;
@@ -983,7 +984,7 @@ public class Player {
 		} else if (entity instanceof EntityGadget gadget) {
 			if (gadget.getGadgetData().getType() == EntityType.RewardStatue) {
 				if (scene.getChallenge() != null) {
-					scene.getChallenge().getStatueDrops(this);
+					scene.getChallenge().getStatueDrops(this, request);
 				}
 				this.sendPacket(new PacketGadgetInteractRsp(gadget, InteractType.INTERACT_TYPE_OPEN_STATUE));
 			}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerGadgetInteractReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerGadgetInteractReq.java
@@ -13,7 +13,7 @@ public class HandlerGadgetInteractReq extends PacketHandler {
 	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
 		GadgetInteractReq req = GadgetInteractReq.parseFrom(payload);
 		
-		session.getPlayer().interactWith(req.getGadgetEntityId());
+		session.getPlayer().interactWith(req.getGadgetEntityId(), req);
 	}
 
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketCombineDataNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketCombineDataNotify.java
@@ -1,0 +1,18 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.CombineDataNotifyOuterClass.CombineDataNotify;
+
+public class PacketCombineDataNotify extends BasePacket {
+	
+	public PacketCombineDataNotify(Iterable<Integer> unlockedCombines) {
+		super(PacketOpcodes.CombineDataNotify);
+		
+		CombineDataNotify proto = CombineDataNotify.newBuilder()
+				.addAllCombineIdList(unlockedCombines)
+				.build();
+		
+		this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketCombineFormulaDataNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketCombineFormulaDataNotify.java
@@ -1,0 +1,19 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.CombineFormulaDataNotifyOuterClass.CombineFormulaDataNotify;
+
+public class PacketCombineFormulaDataNotify extends BasePacket {
+	
+	public PacketCombineFormulaDataNotify(int combineId) {
+		super(PacketOpcodes.CombineFormulaDataNotify);
+		
+		CombineFormulaDataNotify proto = CombineFormulaDataNotify.newBuilder()
+				.setCombineId(combineId)
+				.setIsLocked(false)
+				.build();
+		
+		this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketResinChangeNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketResinChangeNotify.java
@@ -1,0 +1,23 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.props.PlayerProperty;
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.ResinChangeNotifyOuterClass.ResinChangeNotify;
+
+public class PacketResinChangeNotify extends BasePacket {
+	
+	public PacketResinChangeNotify(Player player) {
+		super(PacketOpcodes.ResinChangeNotify);
+		
+		ResinChangeNotify proto = ResinChangeNotify.newBuilder()
+				.setCurValue(player.getProperty(PlayerProperty.PROP_PLAYER_RESIN))
+				.setNextAddTimestamp(player.getNextResinRefresh())
+				.build();
+
+		// ToDo: Add ability to buy resin with primogems, has to be included here.
+		
+		this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/utils/ConfigContainer.java
+++ b/src/main/java/emu/grasscutter/utils/ConfigContainer.java
@@ -177,6 +177,7 @@ public class ConfigContainer {
         public boolean enableShopItems = true;
         public boolean staminaUsage = true;
         public boolean energyUsage = false;
+        public ResinOptions resinOptions = new ResinOptions();
         public Rates rates = new Rates();
 
         public static class InventoryLimits {
@@ -196,6 +197,12 @@ public class ConfigContainer {
             public float adventureExp = 1.0f;
             public float mora = 1.0f;
             public float leyLines = 1.0f;
+        }
+
+        public static class ResinOptions {
+            public boolean resinUsage = false;
+            public int cap = 160;
+            public int rechargeTime = 480;
         }
     }
 


### PR DESCRIPTION
## Description

This PR implements the resin system and enhances/expands some related functionality. This includes:
- Recharging resin over time.
- Consuming resin when claiming dungeon rewards.
    * Handling for condensed resin was also added, but reward statues did not let me chose whether to use normal or condensed resin, so this is not tested.
- Enable using fragile and transient resin to refill.
- Crafting condensed resin.
    * The ability to unlock crafting diagrams was also added for this.

Resin-related behavior is configurable via a new config section under `server.game.gameOptions.resinOptions`, which has the following three values:
- `resinUsage` (default value: `false`): Controls whether resin is used or not. If not, resin is always set to full, and no resin is consumed/added.
- `cap` (default value: `160`): Controls the resin cap, i.e. the point until resin automatically recharges.
- `rechargeTime` (default value: `480`): Controls how long it takes for one resin to recharge. This is given in seconds.

Note: The resin cap as well as the recharge time displayed for "Fully replenished" seems to be hardcoded in the client - or at least I was not able to find a way to change it. This means that cap and full recharge time will show incorrectly if other values than the default are used for `cap` and `rechargeTime`. Recharging works as expected, however.

Missing:
- Recharging resin using primogems is not implemented. I will probably add that with a later PR, if no one else does it in the meantime.

## Issues fixed by this PR

## Type of changes

- [ ] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.