### PR TITLE
Implement the Home System (Serenitea Pot)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ dependencies {
 
     implementation group: 'org.reflections', name: 'reflections', version: '0.10.2'
 
-    implementation group: 'dev.morphia.morphia', name: 'morphia-core', version: '2.2.6'
+    implementation group: 'dev.morphia.morphia', name: 'morphia-core', version: '2.2.7'
 
     implementation group: 'org.greenrobot', name: 'eventbus-java', version: '3.3.1'
     implementation group: 'org.danilopianini', name: 'java-quadtree', version: '0.1.9'

--- a/proto/FurnitureCurModuleArrangeCountNotify.proto
+++ b/proto/FurnitureCurModuleArrangeCountNotify.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "Uint32Pair.proto";
+
+// CmdId: 4681
+// EnetChannelId: 0
+// EnetIsReliable: true
+message FurnitureCurModuleArrangeCountNotify {
+	repeated Uint32Pair furniture_arrange_count_list = 9;
+}

--- a/proto/FurnitureMakeBeHelpedData.proto
+++ b/proto/FurnitureMakeBeHelpedData.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "ProfilePicture.proto";
+
+message FurnitureMakeBeHelpedData {
+	string player_name = 1;
+	uint32 time = 2;
+	uint32 uid = 3;
+	uint32 icon = 4;
+	ProfilePicture profile_picture = 5;
+}

--- a/proto/FurnitureMakeData.proto
+++ b/proto/FurnitureMakeData.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+message FurnitureMakeData {
+	uint32 index = 1;
+	uint32 make_id = 2;
+	uint32 begin_time = 3;
+	uint32 dur_time = 4;
+	uint32 accelerate_time = 5;
+	uint32 avatar_id = 6;
+}

--- a/proto/FurnitureMakeHelpData.proto
+++ b/proto/FurnitureMakeHelpData.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+message FurnitureMakeHelpData {
+	uint32 uid = 1;
+	uint32 times = 2;
+}

--- a/proto/FurnitureMakeMakeInfo.proto
+++ b/proto/FurnitureMakeMakeInfo.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+message FurnitureMakeMakeInfo {
+	uint32 furniture_id = 1;
+	uint32 make_count = 2;
+}

--- a/proto/FurnitureMakeReq.proto
+++ b/proto/FurnitureMakeReq.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4551
+// EnetChannelId: 0
+// EnetIsReliable: true
+// IsAllowClient: true
+message FurnitureMakeReq {
+}

--- a/proto/FurnitureMakeRsp.proto
+++ b/proto/FurnitureMakeRsp.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "FurnitureMakeBeHelpedData.proto";
+import "FurnitureMakeHelpData.proto";
+import "FurnitureMakeMakeInfo.proto";
+import "FurnitureMakeSlot.proto";
+
+// CmdId: 4530
+// EnetChannelId: 0
+// EnetIsReliable: true
+message FurnitureMakeRsp {
+	int32 retcode = 6;
+	FurnitureMakeSlot furniture_make_slot = 10;
+	repeated FurnitureMakeHelpData help_data_list = 13;
+	repeated FurnitureMakeBeHelpedData helped_data_list = 12;
+	repeated FurnitureMakeMakeInfo make_info_list = 11;
+}

--- a/proto/FurnitureMakeSlot.proto
+++ b/proto/FurnitureMakeSlot.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "FurnitureMakeData.proto";
+
+message FurnitureMakeSlot {
+	repeated FurnitureMakeData furniture_make_data_list = 1;
+}

--- a/proto/FurnitureMakeStartReq.proto
+++ b/proto/FurnitureMakeStartReq.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4582
+// EnetChannelId: 0
+// EnetIsReliable: true
+// IsAllowClient: true
+message FurnitureMakeStartReq {
+	uint32 make_id = 1;
+	uint32 avatar_id = 14;
+}

--- a/proto/FurnitureMakeStartRsp.proto
+++ b/proto/FurnitureMakeStartRsp.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "FurnitureMakeSlot.proto";
+
+// CmdId: 4463
+// EnetChannelId: 0
+// EnetIsReliable: true
+message FurnitureMakeStartRsp {
+	int32 retcode = 8;
+	FurnitureMakeSlot furniture_make_slot = 10;
+}

--- a/proto/GetFurnitureCurModuleArrangeCountReq.proto
+++ b/proto/GetFurnitureCurModuleArrangeCountReq.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4603
+// EnetChannelId: 0
+// EnetIsReliable: true
+// IsAllowClient: true
+message GetFurnitureCurModuleArrangeCountReq {
+}

--- a/proto/GetPlayerHomeCompInfoReq.proto
+++ b/proto/GetPlayerHomeCompInfoReq.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4845
+// EnetChannelId: 0
+// EnetIsReliable: true
+// IsAllowClient: true
+message GetPlayerHomeCompInfoReq {
+}

--- a/proto/HomeAnimalData.proto
+++ b/proto/HomeAnimalData.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "Vector.proto";
+
+message HomeAnimalData {
+	uint32 furniture_id = 1;
+	Vector spawn_pos = 2;
+	Vector spawn_rot = 3;
+}

--- a/proto/HomeBasicInfo.proto
+++ b/proto/HomeBasicInfo.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "HomeLimitedShopInfo.proto";
+
+message HomeBasicInfo {
+	uint32 cur_module_id = 1;
+	uint32 cur_room_scene_id = 2;
+	bool is_in_edit_mode = 3;
+	uint64 exp = 4;
+	uint32 level = 5;
+	uint32 home_owner_uid = 6;
+	HomeLimitedShopInfo limited_shop_info = 7;
+	string owner_nick_name = 8;
+}

--- a/proto/HomeBasicInfoNotify.proto
+++ b/proto/HomeBasicInfoNotify.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "HomeBasicInfo.proto";
+
+// CmdId: 4872
+// EnetChannelId: 0
+// EnetIsReliable: true
+message HomeBasicInfoNotify {
+	HomeBasicInfo basic_info = 9;
+}

--- a/proto/HomeBlockArrangementInfo.proto
+++ b/proto/HomeBlockArrangementInfo.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+//import "BIEMCDLIFOD.proto";
+//import "GOHMLAFNBGF.proto";
+import "HomeAnimalData.proto";
+import "HomeBlockDotPattern.proto";
+import "HomeBlockFieldData.proto";
+import "HomeFurnitureData.proto";
+import "HomeFurnitureSuiteData.proto";
+import "HomeNpcData.proto";
+//import "WeekendDjinnInfo.proto";
+
+message HomeBlockArrangementInfo {
+	uint32 block_id = 1;
+	repeated HomeFurnitureData persistent_furniture_list = 2;
+	repeated HomeFurnitureData deploy_furniure_list = 3;
+	repeated HomeNpcData deploy_npc_list = 4;
+	repeated HomeFurnitureSuiteData furniture_suite_list = 5;
+	repeated HomeAnimalData deploy_animal_list = 6;
+	bool is_unlocked = 7;
+	uint32 comfort_value = 8;
+	//repeated WeekendDjinnInfo weekend_djinn_info_list = 9;
+	repeated HomeBlockDotPattern dot_pattern_list = 10;
+	repeated HomeBlockFieldData field_list = 11;
+//	repeated GOHMLAFNBGF BOCBLHLEKNJ = 12;
+//	repeated BIEMCDLIFOD CONIAKDJHAN = 13;
+}

--- a/proto/HomeBlockDotPattern.proto
+++ b/proto/HomeBlockDotPattern.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+message HomeBlockDotPattern {
+	uint32 height = 1;
+	uint32 width = 2;
+	bytes data = 3;
+}

--- a/proto/HomeBlockFieldData.proto
+++ b/proto/HomeBlockFieldData.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "HomeBlockSubFieldData.proto";
+import "Vector.proto";
+
+message HomeBlockFieldData {
+	uint32 guid = 1;
+	uint32 furniture_id = 2;
+	Vector pos = 3;
+	Vector rot = 4;
+	repeated HomeBlockSubFieldData sub_field_list = 5;
+}

--- a/proto/HomeBlockNotify.proto
+++ b/proto/HomeBlockNotify.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4542
+// EnetChannelId: 0
+// EnetIsReliable: true
+message HomeBlockNotify {
+	uint32 end_time = 7;
+}

--- a/proto/HomeBlockSubFieldData.proto
+++ b/proto/HomeBlockSubFieldData.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "Vector.proto";
+
+message HomeBlockSubFieldData {
+	Vector pos = 1;
+	Vector rot = 2;
+}

--- a/proto/HomeChangeEditModeReq.proto
+++ b/proto/HomeChangeEditModeReq.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4625
+// EnetChannelId: 0
+// EnetIsReliable: true
+// IsAllowClient: true
+message HomeChangeEditModeReq {
+	bool is_enter_edit_mode = 5;
+}

--- a/proto/HomeChangeEditModeRsp.proto
+++ b/proto/HomeChangeEditModeRsp.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4885
+// EnetChannelId: 0
+// EnetIsReliable: true
+message HomeChangeEditModeRsp {
+	int32 retcode = 11;
+	bool is_enter_edit_mode = 5;
+}

--- a/proto/HomeFurnitureData.proto
+++ b/proto/HomeFurnitureData.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "Vector.proto";
+
+message HomeFurnitureData {
+	uint32 furniture_id = 1;
+	Vector spawn_pos = 3;
+	Vector spawn_rot = 4;
+	int32 parent_furniture_index = 7;
+	uint32 guid = 8;
+	uint32 version = 9;
+}

--- a/proto/HomeFurnitureSuiteData.proto
+++ b/proto/HomeFurnitureSuiteData.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "Vector.proto";
+
+message HomeFurnitureSuiteData {
+	uint32 suite_id = 1;
+	Vector spawn_pos = 2;
+	repeated int32 included_furniture_index_list = 3;
+	uint32 guid = 5;
+	bool is_allow_summon = 6;
+}

--- a/proto/HomeGetArrangementInfoReq.proto
+++ b/proto/HomeGetArrangementInfoReq.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4848
+// EnetChannelId: 0
+// EnetIsReliable: true
+// IsAllowClient: true
+message HomeGetArrangementInfoReq {
+	repeated uint32 scene_id_list = 6;
+}

--- a/proto/HomeGetArrangementInfoRsp.proto
+++ b/proto/HomeGetArrangementInfoRsp.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "HomeSceneArrangementInfo.proto";
+
+// CmdId: 4456
+// EnetChannelId: 0
+// EnetIsReliable: true
+message HomeGetArrangementInfoRsp {
+	int32 retcode = 1;
+	repeated HomeSceneArrangementInfo scene_arrangement_info_list = 12;
+}

--- a/proto/HomeGetBasicInfoReq.proto
+++ b/proto/HomeGetBasicInfoReq.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4535
+// EnetChannelId: 0
+// EnetIsReliable: true
+// IsAllowClient: true
+message HomeGetBasicInfoReq {
+}

--- a/proto/HomeLimitedShopInfo.proto
+++ b/proto/HomeLimitedShopInfo.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "Vector.proto";
+
+message HomeLimitedShopInfo {
+	uint32 uid = 1;
+	uint32 next_open_time = 3;
+	uint32 next_guest_open_time = 4;
+	uint32 next_close_time = 5;
+	Vector djinn_pos = 6;
+	Vector djinn_rot = 7;
+}

--- a/proto/HomeMarkPointFurnitureData.proto
+++ b/proto/HomeMarkPointFurnitureData.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "HomeMarkPointNPCData.proto";
+import "HomeMarkPointSuiteData.proto";
+import "Vector.proto";
+
+message HomeMarkPointFurnitureData {
+	uint32 guid = 1;
+	uint32 furniture_id = 2;
+	uint32 furniture_type = 3;
+	Vector pos = 4;
+	oneof extra {
+		HomeMarkPointNPCData npc_data = 6;
+		HomeMarkPointSuiteData suite_data = 7;
+	}
+}

--- a/proto/HomeMarkPointNPCData.proto
+++ b/proto/HomeMarkPointNPCData.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+message HomeMarkPointNPCData {
+	uint32 avatar_id = 1;
+	uint32 costume_id = 2;
+}

--- a/proto/HomeMarkPointNotify.proto
+++ b/proto/HomeMarkPointNotify.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "HomeMarkPointSceneData.proto";
+
+// CmdId: 4746
+// EnetChannelId: 0
+// EnetIsReliable: true
+message HomeMarkPointNotify {
+	repeated HomeMarkPointSceneData mark_point_data_list = 13;
+}

--- a/proto/HomeMarkPointSceneData.proto
+++ b/proto/HomeMarkPointSceneData.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "HomeMarkPointFurnitureData.proto";
+import "Vector.proto";
+
+message HomeMarkPointSceneData {
+	uint32 module_id = 1;
+	uint32 scene_id = 2;
+	repeated HomeMarkPointFurnitureData furniture_list = 3;
+	Vector teapot_spirit_pos = 4;
+}

--- a/proto/HomeMarkPointSuiteData.proto
+++ b/proto/HomeMarkPointSuiteData.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+message HomeMarkPointSuiteData {
+	uint32 suite_id = 1;
+}

--- a/proto/HomeNpcData.proto
+++ b/proto/HomeNpcData.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "Vector.proto";
+
+message HomeNpcData {
+	uint32 avatar_id = 1;
+	Vector spawn_pos = 2;
+	Vector spawn_rot = 3;
+	uint32 costume_id = 4;
+}

--- a/proto/HomeSceneArrangementInfo.proto
+++ b/proto/HomeSceneArrangementInfo.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "HomeBlockArrangementInfo.proto";
+import "HomeFurnitureData.proto";
+import "Vector.proto";
+
+message HomeSceneArrangementInfo {
+	uint32 scene_id = 1;
+	repeated HomeBlockArrangementInfo block_arrangement_info_list = 2;
+	bool is_set_born_pos = 3;
+	Vector born_pos = 4;
+	Vector born_rot = 5;
+	repeated HomeFurnitureData door_list = 7;
+	repeated HomeFurnitureData stair_list = 8;
+	HomeFurnitureData main_house = 9;
+	uint32 comfort_value = 10;
+	Vector djinn_pos = 11;
+	uint32 tmp_version = 12;
+	uint32 CNLMNOEGKME = 13;
+}

--- a/proto/HomeSceneInitFinishReq.proto
+++ b/proto/HomeSceneInitFinishReq.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4552
+// EnetChannelId: 0
+// EnetIsReliable: true
+// IsAllowClient: true
+message HomeSceneInitFinishReq {
+}

--- a/proto/HomeSceneInitFinishRsp.proto
+++ b/proto/HomeSceneInitFinishRsp.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4592
+// EnetChannelId: 0
+// EnetIsReliable: true
+message HomeSceneInitFinishRsp {
+	int32 retcode = 7;
+}

--- a/proto/HomeSceneJumpReq.proto
+++ b/proto/HomeSceneJumpReq.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4659
+// EnetChannelId: 0
+// EnetIsReliable: true
+// IsAllowClient: true
+message HomeSceneJumpReq {
+	bool is_enter_room_scene = 12;
+}

--- a/proto/HomeSceneJumpRsp.proto
+++ b/proto/HomeSceneJumpRsp.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4570
+// EnetChannelId: 0
+// EnetIsReliable: true
+message HomeSceneJumpRsp {
+	int32 retcode = 10;
+	bool is_enter_room_scene = 8;
+}

--- a/proto/HomeUnknown1Notify.proto
+++ b/proto/HomeUnknown1Notify.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+message HomeUnknown1Notify {
+  bool is_enter_edit_mode = 12;
+}

--- a/proto/HomeUpdateArrangementInfoReq.proto
+++ b/proto/HomeUpdateArrangementInfoReq.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "HomeSceneArrangementInfo.proto";
+
+// CmdId: 4472
+// EnetChannelId: 0
+// EnetIsReliable: true
+// IsAllowClient: true
+message HomeUpdateArrangementInfoReq {
+	HomeSceneArrangementInfo scene_arrangement_info = 12;
+}

--- a/proto/HomeUpdateArrangementInfoRsp.proto
+++ b/proto/HomeUpdateArrangementInfoRsp.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4822
+// EnetChannelId: 0
+// EnetIsReliable: true
+message HomeUpdateArrangementInfoRsp {
+	int32 retcode = 1;
+}

--- a/proto/TakeFurnitureMakeReq.proto
+++ b/proto/TakeFurnitureMakeReq.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4768
+// EnetChannelId: 0
+// EnetIsReliable: true
+// IsAllowClient: true
+message TakeFurnitureMakeReq {
+	uint32 index = 9;
+	uint32 make_id = 4;
+	bool is_fast_finish = 2;
+}

--- a/proto/TakeFurnitureMakeRsp.proto
+++ b/proto/TakeFurnitureMakeRsp.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+import "FurnitureMakeSlot.proto";
+import "ItemParam.proto";
+
+// CmdId: 4599
+// EnetChannelId: 0
+// EnetIsReliable: true
+message TakeFurnitureMakeRsp {
+	int32 retcode = 9;
+	uint32 make_id = 2;
+	FurnitureMakeSlot furniture_make_slot = 15;
+	repeated ItemParam output_item_list = 10;
+	repeated ItemParam return_item_list = 5;
+}

--- a/proto/UnlockedFurnitureFormulaDataNotify.proto
+++ b/proto/UnlockedFurnitureFormulaDataNotify.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4680
+// EnetChannelId: 0
+// EnetIsReliable: true
+message UnlockedFurnitureFormulaDataNotify {
+	bool is_all = 14;
+	repeated uint32 furniture_id_list = 7;
+}

--- a/proto/UnlockedFurnitureSuiteDataNotify.proto
+++ b/proto/UnlockedFurnitureSuiteDataNotify.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 4717
+// EnetChannelId: 0
+// EnetIsReliable: true
+message UnlockedFurnitureSuiteDataNotify {
+	bool is_all = 10;
+	repeated uint32 furniture_suite_id_list = 15;
+}

--- a/src/main/java/emu/grasscutter/data/GameData.java
+++ b/src/main/java/emu/grasscutter/data/GameData.java
@@ -7,12 +7,8 @@ import java.util.List;
 import java.util.Map;
 
 import emu.grasscutter.Grasscutter;
+import emu.grasscutter.data.binout.*;
 import emu.grasscutter.utils.Utils;
-import emu.grasscutter.data.binout.AbilityEmbryoEntry;
-import emu.grasscutter.data.binout.AbilityModifierEntry;
-import emu.grasscutter.data.binout.MainQuestData;
-import emu.grasscutter.data.binout.OpenConfigEntry;
-import emu.grasscutter.data.binout.ScenePointEntry;
 import emu.grasscutter.data.excels.*;
 import it.unimi.dsi.fastutil.ints.Int2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -28,7 +24,9 @@ public class GameData {
 	private static final Map<String, OpenConfigEntry> openConfigEntries = new HashMap<>();
 	private static final Map<String, ScenePointEntry> scenePointEntries = new HashMap<>();
 	private static final Int2ObjectMap<MainQuestData> mainQuestData = new Int2ObjectOpenHashMap<>();
-	
+
+	private static final Int2ObjectMap<HomeworldDefaultSaveData> homeworldDefaultSaveData = new Int2ObjectOpenHashMap<>();
+
 	// ExcelConfigs
 	private static final Int2ObjectMap<PlayerLevelData> playerLevelDataMap = new Int2ObjectOpenHashMap<>();
 	
@@ -140,7 +138,9 @@ public class GameData {
 	public static Int2ObjectMap<MainQuestData> getMainQuestDataMap() {
 		return mainQuestData;
 	}
-
+	public static Int2ObjectMap<HomeworldDefaultSaveData> getHomeworldDefaultSaveData() {
+		return homeworldDefaultSaveData;
+	}
 	public static Int2ObjectMap<AvatarData> getAvatarDataMap() {
 		return avatarDataMap;
 	}

--- a/src/main/java/emu/grasscutter/data/GameData.java
+++ b/src/main/java/emu/grasscutter/data/GameData.java
@@ -87,6 +87,8 @@ public class GameData {
 	private static final Int2ObjectMap<TowerLevelData> towerLevelDataMap = new Int2ObjectOpenHashMap<>();
 	private static final Int2ObjectMap<TowerScheduleData> towerScheduleDataMap = new Int2ObjectOpenHashMap<>();
 	private static final Int2ObjectMap<ForgeData> forgeDataMap = new Int2ObjectOpenHashMap<>();
+	private static final Int2ObjectMap<HomeWorldLevelData> homeWorldLevelDataMap = new Int2ObjectOpenHashMap<>();
+	private static final Int2ObjectMap<FurnitureMakeConfigData> furnitureMakeConfigDataMap = new Int2ObjectOpenHashMap<>();
 
 	// Cache
 	private static Map<Integer, List<Integer>> fetters = new HashMap<>();
@@ -376,5 +378,11 @@ public class GameData {
 
 	public static Int2ObjectMap<ForgeData> getForgeDataMap() {
 		return forgeDataMap;
+	}
+	public static Int2ObjectMap<HomeWorldLevelData> getHomeWorldLevelDataMap() {
+		return homeWorldLevelDataMap;
+	}
+	public static Int2ObjectMap<FurnitureMakeConfigData> getFurnitureMakeConfigDataMap() {
+		return furnitureMakeConfigDataMap;
 	}
 }

--- a/src/main/java/emu/grasscutter/data/ResourceLoader.java
+++ b/src/main/java/emu/grasscutter/data/ResourceLoader.java
@@ -67,37 +67,7 @@ public class ResourceLoader {
 
 		// Load default home layout
 		loadHomeworldDefaultSaveData();
-		// Custom - TODO move this somewhere else
-		try {
-			GameData.getAvatarSkillDepotDataMap().get(504).setAbilities(
-				new AbilityEmbryoEntry(
-					"", 
-					new String[] {
-						"Avatar_PlayerBoy_ExtraAttack_Wind",
-						"Avatar_Player_UziExplode_Mix",
-						"Avatar_Player_UziExplode",
-						"Avatar_Player_UziExplode_Strike_01",
-						"Avatar_Player_UziExplode_Strike_02",
-						"Avatar_Player_WindBreathe",
-						"Avatar_Player_WindBreathe_CameraController"
-					}
-			));
-			GameData.getAvatarSkillDepotDataMap().get(704).setAbilities(
-				new AbilityEmbryoEntry(
-					"", 
-					new String[] {
-						"Avatar_PlayerGirl_ExtraAttack_Wind",
-						"Avatar_Player_UziExplode_Mix",
-						"Avatar_Player_UziExplode",
-						"Avatar_Player_UziExplode_Strike_01",
-						"Avatar_Player_UziExplode_Strike_02",
-						"Avatar_Player_WindBreathe",
-						"Avatar_Player_WindBreathe_CameraController"
-					}
-			));
-		} catch (Exception e) {
-			Grasscutter.getLogger().error("Error loading abilities", e);
-		}
+
 	}
 
 	public static void loadResources() {

--- a/src/main/java/emu/grasscutter/data/ResourceLoader.java
+++ b/src/main/java/emu/grasscutter/data/ResourceLoader.java
@@ -1,13 +1,17 @@
 package emu.grasscutter.data;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.gson.Gson;
+import emu.grasscutter.data.binout.*;
 import emu.grasscutter.utils.Utils;
+import lombok.SneakyThrows;
 import org.reflections.Reflections;
 
 import com.google.gson.JsonElement;
@@ -15,12 +19,6 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 
 import emu.grasscutter.Grasscutter;
-import emu.grasscutter.data.binout.AbilityEmbryoEntry;
-import emu.grasscutter.data.binout.AbilityModifier;
-import emu.grasscutter.data.binout.AbilityModifierEntry;
-import emu.grasscutter.data.binout.MainQuestData;
-import emu.grasscutter.data.binout.OpenConfigEntry;
-import emu.grasscutter.data.binout.ScenePointEntry;
 import emu.grasscutter.data.binout.AbilityModifier.AbilityConfigData;
 import emu.grasscutter.data.binout.AbilityModifier.AbilityModifierAction;
 import emu.grasscutter.data.binout.AbilityModifier.AbilityModifierActionType;
@@ -66,6 +64,40 @@ public class ResourceLoader {
 		loadQuests();
 		// Load scene points - must be done AFTER resources are loaded
 		loadScenePoints();
+
+		// Load default home layout
+		loadHomeworldDefaultSaveData();
+		// Custom - TODO move this somewhere else
+		try {
+			GameData.getAvatarSkillDepotDataMap().get(504).setAbilities(
+				new AbilityEmbryoEntry(
+					"", 
+					new String[] {
+						"Avatar_PlayerBoy_ExtraAttack_Wind",
+						"Avatar_Player_UziExplode_Mix",
+						"Avatar_Player_UziExplode",
+						"Avatar_Player_UziExplode_Strike_01",
+						"Avatar_Player_UziExplode_Strike_02",
+						"Avatar_Player_WindBreathe",
+						"Avatar_Player_WindBreathe_CameraController"
+					}
+			));
+			GameData.getAvatarSkillDepotDataMap().get(704).setAbilities(
+				new AbilityEmbryoEntry(
+					"", 
+					new String[] {
+						"Avatar_PlayerGirl_ExtraAttack_Wind",
+						"Avatar_Player_UziExplode_Mix",
+						"Avatar_Player_UziExplode",
+						"Avatar_Player_UziExplode_Strike_01",
+						"Avatar_Player_UziExplode_Strike_02",
+						"Avatar_Player_WindBreathe",
+						"Avatar_Player_WindBreathe_CameraController"
+					}
+			));
+		} catch (Exception e) {
+			Grasscutter.getLogger().error("Error loading abilities", e);
+		}
 	}
 
 	public static void loadResources() {
@@ -392,6 +424,26 @@ public class ResourceLoader {
 		}
 		
 		Grasscutter.getLogger().info("Loaded " + GameData.getMainQuestDataMap().size() + " MainQuestDatas.");
+	}
+
+	@SneakyThrows
+	private static void loadHomeworldDefaultSaveData(){
+		var folder = Files.list(Path.of(RESOURCE("BinOutput/HomeworldDefaultSave"))).toList();
+		var pattern = Pattern.compile("scene(.*)_home_config.json");
+
+		for(var file : folder){
+			var matcher = pattern.matcher(file.getFileName().toString());
+			if(!matcher.find()){
+				continue;
+			}
+			var sceneId = matcher.group(1);
+
+			var data = Grasscutter.getGsonFactory().fromJson(Files.readString(file), HomeworldDefaultSaveData.class);
+
+			GameData.getHomeworldDefaultSaveData().put(Integer.parseInt(sceneId), data);
+		}
+
+		Grasscutter.getLogger().info("Loaded " + GameData.getHomeworldDefaultSaveData().size() + " HomeworldDefaultSaveDatas.");
 	}
 
 	// BinOutput configs

--- a/src/main/java/emu/grasscutter/data/binout/HomeworldDefaultSaveData.java
+++ b/src/main/java/emu/grasscutter/data/binout/HomeworldDefaultSaveData.java
@@ -1,0 +1,52 @@
+package emu.grasscutter.data.binout;
+
+import com.google.gson.annotations.SerializedName;
+import emu.grasscutter.utils.Position;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class HomeworldDefaultSaveData {
+
+    @SerializedName(value = "KFHBFNPDJBE", alternate = "PKACPHDGGEI")
+    List<HomeBlock> homeBlockLists;
+    @SerializedName(value = "IJNPADKGNKE", alternate = "MINCKHBNING")
+    Position bornPos;
+    @SerializedName("IPIIGEMFLHK")
+    Position bornRot;
+    @SerializedName("HHOLBNPIHEM")
+    Position djinPos;
+    @SerializedName("KNHCJKHCOAN")
+    HomeFurniture mainhouse;
+
+    @SerializedName("NIHOJFEKFPG")
+    List<HomeFurniture> doorLists;
+    @SerializedName("EPGELGEFJFK")
+    List<HomeFurniture> stairLists;
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public static class HomeBlock{
+
+        @SerializedName(value = "FGIJCELCGFI", alternate = "PGDPDIDJEEL")
+        int blockId;
+
+        @SerializedName(value = "BEAPOFELABD", alternate = "MLIODLGDFHJ")
+        List<HomeFurniture> furnitures;
+    }
+
+    @Data
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public static class HomeFurniture{
+
+        @SerializedName(value = "ENHNGKJBJAB", alternate = "KMAAJJHPNBA")
+        int id;
+        @SerializedName(value = "NGIEEIOLPPO", alternate = "JFKAHNCPDME")
+        Position pos;
+        //@SerializedName(value = "HEOCEHKEBFM", alternate = "LKCKOOGFDBM")
+        Position rot;
+    }
+}

--- a/src/main/java/emu/grasscutter/data/excels/FurnitureMakeConfigData.java
+++ b/src/main/java/emu/grasscutter/data/excels/FurnitureMakeConfigData.java
@@ -1,0 +1,37 @@
+package emu.grasscutter.data.excels;
+
+import emu.grasscutter.data.GameResource;
+import emu.grasscutter.data.ResourceType;
+import emu.grasscutter.data.common.ItemParamData;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Getter
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@ResourceType(name = {"FurnitureMakeExcelConfigData.json"})
+public class FurnitureMakeConfigData extends GameResource {
+
+    int configID;
+    int furnitureItemID;
+    int count;
+    int exp;
+    List<ItemParamData> materialItems;
+    int makeTime;
+    int maxAccelerateTime;
+    int quickFetchMaterialNum;
+
+    @Override
+    public int getId() {
+        return configID;
+    }
+
+    @Override
+    public void onLoad() {
+        this.materialItems = materialItems.stream()
+                .filter(x -> x.getId() > 0)
+                .toList();
+    }
+}

--- a/src/main/java/emu/grasscutter/data/excels/HomeWorldLevelData.java
+++ b/src/main/java/emu/grasscutter/data/excels/HomeWorldLevelData.java
@@ -1,0 +1,37 @@
+package emu.grasscutter.data.excels;
+
+import emu.grasscutter.data.GameResource;
+import emu.grasscutter.data.ResourceType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Getter
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@ResourceType(name = {"HomeworldLevelExcelConfigData.json"})
+public class HomeWorldLevelData extends GameResource {
+
+    int level;
+    int exp;
+    int homeCoinStoreLimit;
+    int homeFetterExpStoreLimit;
+    int rewardId;
+    int furnitureMakeSlotCount;
+    int outdoorUnlockBlockCount;
+    int freeUnlockModuleCount;
+    int deployNpcCount;
+    int limitShopGoodsCount;
+    List<String> levelFuncs;
+
+    @Override
+    public int getId() {
+        return level;
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+    }
+}

--- a/src/main/java/emu/grasscutter/data/excels/ItemData.java
+++ b/src/main/java/emu/grasscutter/data/excels/ItemData.java
@@ -2,14 +2,20 @@ package emu.grasscutter.data.excels;
 
 import java.util.List;
 
+import com.google.gson.annotations.SerializedName;
 import emu.grasscutter.data.GameResource;
 import emu.grasscutter.data.ResourceType;
 import emu.grasscutter.data.common.ItemUseData;
+import emu.grasscutter.game.inventory.*;
 import emu.grasscutter.game.props.FightProperty;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 
-@ResourceType(name = {"MaterialExcelConfigData.json", "WeaponExcelConfigData.json", "ReliquaryExcelConfigData.json"})
+@ResourceType(name = {"MaterialExcelConfigData.json",
+        "WeaponExcelConfigData.json",
+        "ReliquaryExcelConfigData.json",
+        "HomeWorldFurnitureExcelConfigData.json"
+})
 public class ItemData extends GameResource {
 	
 	private int id;
@@ -63,12 +69,19 @@ public class ItemData extends GameResource {
     private long nameTextMapHash;
     
     // Post load
-    private transient emu.grasscutter.game.inventory.MaterialType materialEnumType;
-    private transient emu.grasscutter.game.inventory.ItemType itemEnumType;
-    private transient emu.grasscutter.game.inventory.EquipType equipEnumType;
+    private transient MaterialType materialEnumType;
+    private transient ItemType itemEnumType;
+    private transient EquipType equipEnumType;
     
     private IntSet addPropLevelSet;
-    
+
+    // Furniture
+    private int comfort;
+    private List<Integer> furnType;
+    private List<Integer> furnitureGadgetID;
+    @SerializedName("JFDLJGDFIGL")
+    private int roomSceneId;
+
     @Override
 	public int getId(){
         return this.id;
@@ -193,41 +206,57 @@ public class ItemData extends GameResource {
 	public int getMaxLevel() {
 		return maxLevel;
 	}
-	
-	public emu.grasscutter.game.inventory.ItemType getItemType() {
+
+    public int getComfort() {
+        return comfort;
+    }
+
+    public List<Integer> getFurnType() {
+        return furnType;
+    }
+
+    public List<Integer> getFurnitureGadgetID() {
+        return furnitureGadgetID;
+    }
+
+    public int getRoomSceneId() {
+        return roomSceneId;
+    }
+
+    public ItemType getItemType() {
     	return this.itemEnumType;
     }
     
-    public emu.grasscutter.game.inventory.MaterialType getMaterialType() {
+    public MaterialType getMaterialType() {
     	return this.materialEnumType;
     }
     
-    public emu.grasscutter.game.inventory.EquipType getEquipType() {
+    public EquipType getEquipType() {
     	return this.equipEnumType;
     }
     
     public boolean canAddRelicProp(int level) {
-    	return this.addPropLevelSet != null & this.addPropLevelSet.contains(level);
+    	return this.addPropLevelSet != null && this.addPropLevelSet.contains(level);
     }
     
 	public boolean isEquip() {
-		return this.itemEnumType == emu.grasscutter.game.inventory.ItemType.ITEM_RELIQUARY || this.itemEnumType == emu.grasscutter.game.inventory.ItemType.ITEM_WEAPON;
+		return this.itemEnumType == ItemType.ITEM_RELIQUARY || this.itemEnumType == ItemType.ITEM_WEAPON;
 	}
     
     @Override
 	public void onLoad() {
-    	this.itemEnumType = emu.grasscutter.game.inventory.ItemType.getTypeByName(getItemTypeString());
-    	this.materialEnumType = emu.grasscutter.game.inventory.MaterialType.getTypeByName(getMaterialTypeString());
+    	this.itemEnumType = ItemType.getTypeByName(getItemTypeString());
+    	this.materialEnumType = MaterialType.getTypeByName(getMaterialTypeString());
 
-		if (this.itemEnumType == emu.grasscutter.game.inventory.ItemType.ITEM_RELIQUARY) {
-			this.equipEnumType = emu.grasscutter.game.inventory.EquipType.getTypeByName(this.equipType);
+		if (this.itemEnumType == ItemType.ITEM_RELIQUARY) {
+			this.equipEnumType = EquipType.getTypeByName(this.equipType);
 			if (this.addPropLevels != null && this.addPropLevels.length > 0) {
 				this.addPropLevelSet = new IntOpenHashSet(this.addPropLevels);
 			}
-		} else if (this.itemEnumType == emu.grasscutter.game.inventory.ItemType.ITEM_WEAPON) {
-			this.equipEnumType = emu.grasscutter.game.inventory.EquipType.EQUIP_WEAPON;
+		} else if (this.itemEnumType == ItemType.ITEM_WEAPON) {
+			this.equipEnumType = EquipType.EQUIP_WEAPON;
 		} else {
-			this.equipEnumType = emu.grasscutter.game.inventory.EquipType.EQUIP_NONE;
+			this.equipEnumType = EquipType.EQUIP_NONE;
 		}
 		
 		if (this.getWeaponProperties() != null) {
@@ -235,6 +264,13 @@ public class ItemData extends GameResource {
 				weaponProperty.onLoad();
 			}
 		}
+
+        if(this.getFurnType() != null){
+            this.furnType = this.furnType.stream().filter(x -> x > 0).toList();
+        }
+        if(this.getFurnitureGadgetID() != null){
+            this.furnitureGadgetID = this.furnitureGadgetID.stream().filter(x -> x > 0).toList();
+        }
     }
     
     public static class WeaponProperty {

--- a/src/main/java/emu/grasscutter/database/DatabaseHelper.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseHelper.java
@@ -13,6 +13,7 @@ import emu.grasscutter.game.Account;
 import emu.grasscutter.game.avatar.Avatar;
 import emu.grasscutter.game.friends.Friendship;
 import emu.grasscutter.game.gacha.GachaRecord;
+import emu.grasscutter.game.home.GameHome;
 import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.game.mail.Mail;
 import emu.grasscutter.game.player.Player;
@@ -294,5 +295,11 @@ public final class DatabaseHelper {
 	
 	public static boolean deleteQuest(GameMainQuest quest) {
 		return DatabaseManager.getGameDatastore().delete(quest).wasAcknowledged();
+	}
+	public static GameHome getHomeByUid(int id) {
+		return DatabaseManager.getGameDatastore().find(GameHome.class).filter(Filters.eq("ownerUid", id)).first();
+	}
+	public static void saveHome(GameHome gameHome) {
+		DatabaseManager.getGameDatastore().save(gameHome);
 	}
 }

--- a/src/main/java/emu/grasscutter/database/DatabaseManager.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseManager.java
@@ -16,6 +16,7 @@ import emu.grasscutter.game.Account;
 import emu.grasscutter.game.avatar.Avatar;
 import emu.grasscutter.game.friends.Friendship;
 import emu.grasscutter.game.gacha.GachaRecord;
+import emu.grasscutter.game.home.GameHome;
 import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.game.mail.Mail;
 import emu.grasscutter.game.player.Player;
@@ -30,7 +31,7 @@ public final class DatabaseManager {
 	
 	private static final Class<?>[] mappedClasses = new Class<?>[] {
 		DatabaseCounter.class, Account.class, Player.class, Avatar.class, GameItem.class, Friendship.class, 
-		GachaRecord.class, Mail.class, GameMainQuest.class
+		GachaRecord.class, Mail.class, GameMainQuest.class, GameHome.class
 	};
     
     public static Datastore getGameDatastore() {

--- a/src/main/java/emu/grasscutter/game/home/FurnitureMakeSlotItem.java
+++ b/src/main/java/emu/grasscutter/game/home/FurnitureMakeSlotItem.java
@@ -1,0 +1,33 @@
+package emu.grasscutter.game.home;
+
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import emu.grasscutter.net.proto.FurnitureMakeDataOuterClass;
+import emu.grasscutter.net.proto.FurnitureMakeSlotOuterClass;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Entity
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Builder(builderMethodName = "of")
+public class FurnitureMakeSlotItem {
+    @Id
+    int index;
+    int makeId;
+    int avatarId;
+    int beginTime;
+    int durTime;
+
+    public FurnitureMakeDataOuterClass.FurnitureMakeData toProto() {
+        return FurnitureMakeDataOuterClass.FurnitureMakeData.newBuilder()
+                .setIndex(index)
+                .setAvatarId(avatarId)
+                .setMakeId(makeId)
+                .setBeginTime(beginTime)
+                .setDurTime(durTime)
+                .build();
+    }
+}

--- a/src/main/java/emu/grasscutter/game/home/GameHome.java
+++ b/src/main/java/emu/grasscutter/game/home/GameHome.java
@@ -1,0 +1,70 @@
+package emu.grasscutter.game.home;
+
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import dev.morphia.annotations.IndexOptions;
+import dev.morphia.annotations.Indexed;
+import emu.grasscutter.Grasscutter;
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.database.DatabaseHelper;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.server.packet.send.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Entity(value = "homes", useDiscriminator = false)
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Builder(builderMethodName = "of")
+public class GameHome {
+
+    @Id
+    String id;
+
+    @Indexed(options = @IndexOptions(unique = true))
+    long ownerUid;
+
+    ConcurrentHashMap<Integer, HomeSceneItem> sceneMap;
+
+    public void save(){
+        DatabaseHelper.saveHome(this);
+    }
+
+    public static GameHome getByUid(Integer uid){
+        var home = DatabaseHelper.getHomeByUid(uid);
+        if (home == null) {
+            home = GameHome.create(uid);
+        }
+        return home;
+    }
+
+    public static GameHome create(Integer uid){
+        return GameHome.of()
+                .ownerUid(uid)
+                .sceneMap(new ConcurrentHashMap<>())
+                .build();
+    }
+
+    public HomeSceneItem getHomeSceneItem(int sceneId) {
+        return sceneMap.computeIfAbsent(sceneId, e -> {
+            var defaultItem = GameData.getHomeworldDefaultSaveData().get(sceneId);
+            if (defaultItem != null){
+                Grasscutter.getLogger().info("Set player {} home {} to initial setting", ownerUid, sceneId);
+                return HomeSceneItem.parseFrom(defaultItem, sceneId);
+            }
+            return null;
+        });
+    }
+
+    public void onOwnerLogin(Player player) {
+        player.getSession().send(new PacketHomeBasicInfoNotify(player, false));
+        player.getSession().send(new PacketPlayerHomeCompInfoNotify(player));
+        player.getSession().send(new PacketHomeComfortInfoNotify(player));
+        player.getSession().send(new PacketFurnitureCurModuleArrangeCountNotify());
+        player.getSession().send(new PacketUnlockedFurnitureFormulaDataNotify());
+    }
+}

--- a/src/main/java/emu/grasscutter/game/home/GameHome.java
+++ b/src/main/java/emu/grasscutter/game/home/GameHome.java
@@ -65,6 +65,6 @@ public class GameHome {
         player.getSession().send(new PacketPlayerHomeCompInfoNotify(player));
         player.getSession().send(new PacketHomeComfortInfoNotify(player));
         player.getSession().send(new PacketFurnitureCurModuleArrangeCountNotify());
-        player.getSession().send(new PacketUnlockedFurnitureFormulaDataNotify());
+        player.getSession().send(new PacketHomeMarkPointNotify(player, this));
     }
 }

--- a/src/main/java/emu/grasscutter/game/home/GameHome.java
+++ b/src/main/java/emu/grasscutter/game/home/GameHome.java
@@ -6,6 +6,7 @@ import dev.morphia.annotations.IndexOptions;
 import dev.morphia.annotations.Indexed;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.excels.HomeWorldLevelData;
 import emu.grasscutter.database.DatabaseHelper;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.server.packet.send.*;
@@ -14,6 +15,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.experimental.FieldDefaults;
 
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Entity(value = "homes", useDiscriminator = false)
@@ -28,6 +30,9 @@ public class GameHome {
     @Indexed(options = @IndexOptions(unique = true))
     long ownerUid;
 
+    int level;
+    int exp;
+    List<FurnitureMakeSlotItem> furnitureMakeSlotItemList;
     ConcurrentHashMap<Integer, HomeSceneItem> sceneMap;
 
     public void save(){
@@ -45,6 +50,7 @@ public class GameHome {
     public static GameHome create(Integer uid){
         return GameHome.of()
                 .ownerUid(uid)
+                .level(1)
                 .sceneMap(new ConcurrentHashMap<>())
                 .build();
     }
@@ -65,6 +71,10 @@ public class GameHome {
         player.getSession().send(new PacketPlayerHomeCompInfoNotify(player));
         player.getSession().send(new PacketHomeComfortInfoNotify(player));
         player.getSession().send(new PacketFurnitureCurModuleArrangeCountNotify());
-        player.getSession().send(new PacketHomeMarkPointNotify(player, this));
+        player.getSession().send(new PacketHomeMarkPointNotify(player));
+    }
+
+    public HomeWorldLevelData getLevelData(){
+        return GameData.getHomeWorldLevelDataMap().get(level);
     }
 }

--- a/src/main/java/emu/grasscutter/game/home/HomeAnimalItem.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeAnimalItem.java
@@ -1,0 +1,37 @@
+package emu.grasscutter.game.home;
+
+import dev.morphia.annotations.Entity;
+import emu.grasscutter.net.proto.HomeAnimalDataOuterClass;
+import emu.grasscutter.net.proto.HomeFurnitureDataOuterClass;
+import emu.grasscutter.utils.Position;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Entity
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Builder(builderMethodName = "of")
+public class HomeAnimalItem {
+    int furnitureId;
+    Position spawnPos;
+    Position spawnRot;
+
+    public HomeAnimalDataOuterClass.HomeAnimalData toProto(){
+        return HomeAnimalDataOuterClass.HomeAnimalData.newBuilder()
+                .setFurnitureId(furnitureId)
+                .setSpawnPos(spawnPos.toProto())
+                .setSpawnRot(spawnRot.toProto())
+                .build();
+    }
+
+    public static HomeAnimalItem parseFrom(HomeAnimalDataOuterClass.HomeAnimalData homeAnimalData) {
+        return HomeAnimalItem.of()
+                .furnitureId(homeAnimalData.getFurnitureId())
+                .spawnPos(new Position(homeAnimalData.getSpawnPos()))
+                .spawnRot(new Position(homeAnimalData.getSpawnRot()))
+                .build();
+    }
+
+}

--- a/src/main/java/emu/grasscutter/game/home/HomeBlockItem.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeBlockItem.java
@@ -1,0 +1,64 @@
+package emu.grasscutter.game.home;
+
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import emu.grasscutter.data.binout.HomeworldDefaultSaveData;
+import emu.grasscutter.net.proto.HomeBlockArrangementInfoOuterClass.HomeBlockArrangementInfo;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Entity
+@Data
+@Builder(builderMethodName = "of")
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class HomeBlockItem {
+
+    @Id
+    int blockId;
+    boolean unlocked;
+
+    List<HomeFurnitureItem> deployFurnitureList;
+
+
+    public void update(HomeBlockArrangementInfo homeBlockArrangementInfo) {
+        this.blockId = homeBlockArrangementInfo.getBlockId();
+
+        this.deployFurnitureList = homeBlockArrangementInfo.getDeployFurniureListList().stream()
+                .map(HomeFurnitureItem::parseFrom)
+                .toList();
+    }
+
+    public int calComfort(){
+        return this.deployFurnitureList.stream()
+                .mapToInt(HomeFurnitureItem::getComfort)
+                .sum();
+    }
+
+    public HomeBlockArrangementInfo toProto() {
+        var proto = HomeBlockArrangementInfo.newBuilder()
+                .setBlockId(blockId)
+                .setIsUnlocked(unlocked)
+                .setComfortValue(calComfort());
+
+        this.deployFurnitureList.forEach(f -> proto.addDeployFurniureList(f.toProto()));
+
+        return proto.build();
+    }
+
+    public static HomeBlockItem parseFrom(HomeworldDefaultSaveData.HomeBlock homeBlock) {
+
+        return HomeBlockItem.of()
+                .blockId(homeBlock.getBlockId())
+                .unlocked(homeBlock.getFurnitures() != null)
+                .deployFurnitureList(
+                        homeBlock.getFurnitures() == null ? List.of() :
+                                homeBlock.getFurnitures().stream()
+                                        .map(HomeFurnitureItem::parseFrom)
+                                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/emu/grasscutter/game/home/HomeBlockItem.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeBlockItem.java
@@ -16,19 +16,26 @@ import java.util.List;
 @Builder(builderMethodName = "of")
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class HomeBlockItem {
-
     @Id
     int blockId;
     boolean unlocked;
-
     List<HomeFurnitureItem> deployFurnitureList;
-
+    List<HomeAnimalItem> deployAnimalList;
+    List<HomeNPCItem> deployNPCList;
 
     public void update(HomeBlockArrangementInfo homeBlockArrangementInfo) {
         this.blockId = homeBlockArrangementInfo.getBlockId();
 
         this.deployFurnitureList = homeBlockArrangementInfo.getDeployFurniureListList().stream()
                 .map(HomeFurnitureItem::parseFrom)
+                .toList();
+
+        this.deployAnimalList = homeBlockArrangementInfo.getDeployAnimalListList().stream()
+                .map(HomeAnimalItem::parseFrom)
+                .toList();
+
+        this.deployNPCList = homeBlockArrangementInfo.getDeployNpcListList().stream()
+                .map(HomeNPCItem::parseFrom)
                 .toList();
     }
 
@@ -45,6 +52,8 @@ public class HomeBlockItem {
                 .setComfortValue(calComfort());
 
         this.deployFurnitureList.forEach(f -> proto.addDeployFurniureList(f.toProto()));
+        this.deployAnimalList.forEach(f -> proto.addDeployAnimalList(f.toProto()));
+        this.deployNPCList.forEach(f -> proto.addDeployNpcList(f.toProto()));
 
         return proto.build();
     }
@@ -59,6 +68,8 @@ public class HomeBlockItem {
                                 homeBlock.getFurnitures().stream()
                                         .map(HomeFurnitureItem::parseFrom)
                                         .toList())
+                .deployAnimalList(List.of())
+                .deployNPCList(List.of())
                 .build();
     }
 }

--- a/src/main/java/emu/grasscutter/game/home/HomeBlockItem.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeBlockItem.java
@@ -4,6 +4,7 @@ import dev.morphia.annotations.Entity;
 import dev.morphia.annotations.Id;
 import emu.grasscutter.data.binout.HomeworldDefaultSaveData;
 import emu.grasscutter.net.proto.HomeBlockArrangementInfoOuterClass.HomeBlockArrangementInfo;
+import emu.grasscutter.utils.Position;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
@@ -20,6 +21,7 @@ public class HomeBlockItem {
     int blockId;
     boolean unlocked;
     List<HomeFurnitureItem> deployFurnitureList;
+    List<HomeFurnitureItem> persistentFurnitureList;
     List<HomeAnimalItem> deployAnimalList;
     List<HomeNPCItem> deployNPCList;
 
@@ -27,6 +29,10 @@ public class HomeBlockItem {
         this.blockId = homeBlockArrangementInfo.getBlockId();
 
         this.deployFurnitureList = homeBlockArrangementInfo.getDeployFurniureListList().stream()
+                .map(HomeFurnitureItem::parseFrom)
+                .toList();
+
+        this.persistentFurnitureList = homeBlockArrangementInfo.getPersistentFurnitureListList().stream()
                 .map(HomeFurnitureItem::parseFrom)
                 .toList();
 
@@ -52,6 +58,7 @@ public class HomeBlockItem {
                 .setComfortValue(calComfort());
 
         this.deployFurnitureList.forEach(f -> proto.addDeployFurniureList(f.toProto()));
+        this.persistentFurnitureList.forEach(f -> proto.addDeployFurniureList(f.toProto()));
         this.deployAnimalList.forEach(f -> proto.addDeployAnimalList(f.toProto()));
         this.deployNPCList.forEach(f -> proto.addDeployNpcList(f.toProto()));
 
@@ -59,7 +66,7 @@ public class HomeBlockItem {
     }
 
     public static HomeBlockItem parseFrom(HomeworldDefaultSaveData.HomeBlock homeBlock) {
-
+        // create from default setting
         return HomeBlockItem.of()
                 .blockId(homeBlock.getBlockId())
                 .unlocked(homeBlock.getFurnitures() != null)
@@ -70,6 +77,7 @@ public class HomeBlockItem {
                                         .toList())
                 .deployAnimalList(List.of())
                 .deployNPCList(List.of())
+                .persistentFurnitureList(List.of())
                 .build();
     }
 }

--- a/src/main/java/emu/grasscutter/game/home/HomeBlockItem.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeBlockItem.java
@@ -58,7 +58,7 @@ public class HomeBlockItem {
                 .setComfortValue(calComfort());
 
         this.deployFurnitureList.forEach(f -> proto.addDeployFurniureList(f.toProto()));
-        this.persistentFurnitureList.forEach(f -> proto.addDeployFurniureList(f.toProto()));
+        this.persistentFurnitureList.forEach(f -> proto.addPersistentFurnitureList(f.toProto()));
         this.deployAnimalList.forEach(f -> proto.addDeployAnimalList(f.toProto()));
         this.deployNPCList.forEach(f -> proto.addDeployNpcList(f.toProto()));
 

--- a/src/main/java/emu/grasscutter/game/home/HomeFurnitureItem.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeFurnitureItem.java
@@ -5,6 +5,7 @@ import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.binout.HomeworldDefaultSaveData;
 import emu.grasscutter.data.excels.ItemData;
 import emu.grasscutter.net.proto.HomeFurnitureDataOuterClass;
+import emu.grasscutter.net.proto.HomeMarkPointFurnitureDataOuterClass;
 import emu.grasscutter.utils.Position;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -29,6 +30,16 @@ public class HomeFurnitureItem {
                 .setParentFurnitureIndex(parentFurnitureIndex)
                 .setSpawnPos(spawnPos.toProto())
                 .setSpawnRot(spawnRot.toProto())
+                .build();
+    }
+
+    public HomeMarkPointFurnitureDataOuterClass.HomeMarkPointFurnitureData toMarkPointProto(int type){
+        return HomeMarkPointFurnitureDataOuterClass.HomeMarkPointFurnitureData.newBuilder()
+                .setFurnitureId(furnitureId)
+                .setGuid(guid)
+                .setFurnitureType(type)
+                .setPos(spawnPos.toProto())
+                // TODO NPC and farm
                 .build();
     }
 

--- a/src/main/java/emu/grasscutter/game/home/HomeFurnitureItem.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeFurnitureItem.java
@@ -1,0 +1,66 @@
+package emu.grasscutter.game.home;
+
+import dev.morphia.annotations.Entity;
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.binout.HomeworldDefaultSaveData;
+import emu.grasscutter.data.excels.ItemData;
+import emu.grasscutter.net.proto.HomeFurnitureDataOuterClass;
+import emu.grasscutter.utils.Position;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Entity
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Builder(builderMethodName = "of")
+public class HomeFurnitureItem {
+    int furnitureId;
+    int guid;
+    int parentFurnitureIndex;
+    Position spawnPos;
+    Position spawnRot;
+
+    public HomeFurnitureDataOuterClass.HomeFurnitureData toProto(){
+        return HomeFurnitureDataOuterClass.HomeFurnitureData.newBuilder()
+                .setFurnitureId(furnitureId)
+                .setGuid(guid)
+                .setParentFurnitureIndex(parentFurnitureIndex)
+                .setSpawnPos(spawnPos.toProto())
+                .setSpawnRot(spawnRot.toProto())
+                .build();
+    }
+
+    public static HomeFurnitureItem parseFrom(HomeFurnitureDataOuterClass.HomeFurnitureData homeFurnitureData) {
+        return HomeFurnitureItem.of()
+                .furnitureId(homeFurnitureData.getFurnitureId())
+                .guid(homeFurnitureData.getGuid())
+                .parentFurnitureIndex(homeFurnitureData.getParentFurnitureIndex())
+                .spawnPos(new Position(homeFurnitureData.getSpawnPos()))
+                .spawnRot(new Position(homeFurnitureData.getSpawnRot()))
+                .build();
+    }
+
+    public static HomeFurnitureItem parseFrom(HomeworldDefaultSaveData.HomeFurniture homeFurniture) {
+        return HomeFurnitureItem.of()
+                .furnitureId(homeFurniture.getId())
+                .parentFurnitureIndex(1)
+                .spawnPos(homeFurniture.getPos() == null ? new Position() : homeFurniture.getPos())
+                .spawnRot(homeFurniture.getRot() == null ? new Position() : homeFurniture.getRot())
+                .build();
+    }
+
+    public ItemData getAsItem() {
+        return GameData.getItemDataMap().get(this.furnitureId);
+    }
+
+    public int getComfort() {
+        var item = getAsItem();
+
+        if (item == null){
+            return 0;
+        }
+        return item.getComfort();
+    }
+}

--- a/src/main/java/emu/grasscutter/game/home/HomeFurnitureItem.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeFurnitureItem.java
@@ -6,6 +6,7 @@ import emu.grasscutter.data.binout.HomeworldDefaultSaveData;
 import emu.grasscutter.data.excels.ItemData;
 import emu.grasscutter.net.proto.HomeFurnitureDataOuterClass;
 import emu.grasscutter.net.proto.HomeMarkPointFurnitureDataOuterClass;
+import emu.grasscutter.net.proto.VectorOuterClass;
 import emu.grasscutter.utils.Position;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,7 +23,7 @@ public class HomeFurnitureItem {
     int parentFurnitureIndex;
     Position spawnPos;
     Position spawnRot;
-
+    int version;
     public HomeFurnitureDataOuterClass.HomeFurnitureData toProto(){
         return HomeFurnitureDataOuterClass.HomeFurnitureData.newBuilder()
                 .setFurnitureId(furnitureId)
@@ -30,6 +31,7 @@ public class HomeFurnitureItem {
                 .setParentFurnitureIndex(parentFurnitureIndex)
                 .setSpawnPos(spawnPos.toProto())
                 .setSpawnRot(spawnRot.toProto())
+                .setVersion(version)
                 .build();
     }
 
@@ -50,6 +52,7 @@ public class HomeFurnitureItem {
                 .parentFurnitureIndex(homeFurnitureData.getParentFurnitureIndex())
                 .spawnPos(new Position(homeFurnitureData.getSpawnPos()))
                 .spawnRot(new Position(homeFurnitureData.getSpawnRot()))
+                .version(homeFurnitureData.getVersion())
                 .build();
     }
 

--- a/src/main/java/emu/grasscutter/game/home/HomeNPCItem.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeNPCItem.java
@@ -1,0 +1,39 @@
+package emu.grasscutter.game.home;
+
+import dev.morphia.annotations.Entity;
+import emu.grasscutter.net.proto.HomeAnimalDataOuterClass;
+import emu.grasscutter.net.proto.HomeNpcDataOuterClass;
+import emu.grasscutter.utils.Position;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Entity
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Builder(builderMethodName = "of")
+public class HomeNPCItem {
+    int avatarId;
+    Position spawnPos;
+    Position spawnRot;
+    int costumeId;
+
+    public HomeNpcDataOuterClass.HomeNpcData toProto(){
+        return HomeNpcDataOuterClass.HomeNpcData.newBuilder()
+                .setAvatarId(avatarId)
+                .setSpawnPos(spawnPos.toProto())
+                .setSpawnRot(spawnRot.toProto())
+                .setCostumeId(costumeId)
+                .build();
+    }
+
+    public static HomeNPCItem parseFrom(HomeNpcDataOuterClass.HomeNpcData homeNpcData) {
+        return HomeNPCItem.of()
+                .avatarId(homeNpcData.getAvatarId())
+                .spawnPos(new Position(homeNpcData.getSpawnPos()))
+                .spawnRot(new Position(homeNpcData.getSpawnRot()))
+                .costumeId(homeNpcData.getCostumeId())
+                .build();
+    }
+}

--- a/src/main/java/emu/grasscutter/game/home/HomeSceneItem.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeSceneItem.java
@@ -1,0 +1,91 @@
+package emu.grasscutter.game.home;
+
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Id;
+import emu.grasscutter.data.binout.HomeworldDefaultSaveData;
+import emu.grasscutter.net.proto.HomeBasicInfoOuterClass.HomeBasicInfo;
+import emu.grasscutter.net.proto.HomeSceneArrangementInfoOuterClass.HomeSceneArrangementInfo;
+import emu.grasscutter.utils.Position;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Entity
+@Data
+@Builder(builderMethodName = "of")
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class HomeSceneItem {
+    @Id
+    int sceneId;
+    Map<Integer, HomeBlockItem> blockItems;
+    Position bornPos;
+    Position bornRot;
+    Position djinnPos;
+    HomeFurnitureItem mainHouse;
+
+    public static HomeSceneItem parseFrom(HomeworldDefaultSaveData defaultItem, int sceneId) {
+        return HomeSceneItem.of()
+                .sceneId(sceneId)
+                .blockItems(defaultItem.getHomeBlockLists().stream()
+                        .map(HomeBlockItem::parseFrom)
+                        .collect(Collectors.toMap(HomeBlockItem::getBlockId, y -> y)))
+                .bornPos(defaultItem.getBornPos())
+                .bornRot(defaultItem.getBornRot() == null ? new Position() : defaultItem.getBornRot())
+                .djinnPos(defaultItem.getDjinPos() == null ? new Position() : defaultItem.getDjinPos())
+                .mainHouse(defaultItem.getMainhouse() == null ? null :
+                        HomeFurnitureItem.parseFrom(defaultItem.getMainhouse()))
+                .build();
+    }
+
+    public void update(HomeSceneArrangementInfo arrangementInfo){
+        for(var blockItem : arrangementInfo.getBlockArrangementInfoListList()){
+            var block = this.blockItems.get(blockItem.getBlockId());
+            if(block == null){
+                System.out.println(111);
+                continue;
+            }
+            block.update(blockItem);
+            this.blockItems.put(blockItem.getBlockId(), block);
+        }
+
+        this.bornPos = new Position(arrangementInfo.getBornPos());
+        this.bornRot = new Position(arrangementInfo.getBornRot());
+        this.djinnPos = new Position(arrangementInfo.getDjinnPos());
+        this.mainHouse = HomeFurnitureItem.parseFrom(arrangementInfo.getMainHouse());
+    }
+
+    public int getRoomSceneId(){
+        if(mainHouse == null || mainHouse.getAsItem() == null){
+            return 0;
+        }
+        return mainHouse.getAsItem().getRoomSceneId();
+    }
+
+    public int calComfort(){
+        return this.blockItems.values().stream()
+                .mapToInt(HomeBlockItem::calComfort)
+                .sum();
+    }
+
+    public HomeSceneArrangementInfo toProto(){
+        var proto = HomeSceneArrangementInfo.newBuilder();
+        blockItems.values().forEach(b -> proto.addBlockArrangementInfoList(b.toProto()));
+
+        proto.setComfortValue(calComfort())
+                .setBornPos(bornPos.toProto())
+                .setBornRot(bornRot.toProto())
+                .setDjinnPos(djinnPos.toProto())
+                .setSceneId(sceneId)
+                .setTmpVersion(1);
+
+        if(mainHouse != null){
+            proto.setMainHouse(mainHouse.toProto());
+        }
+        return proto.build();
+    }
+
+}

--- a/src/main/java/emu/grasscutter/game/home/HomeSceneItem.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeSceneItem.java
@@ -2,6 +2,7 @@ package emu.grasscutter.game.home;
 
 import dev.morphia.annotations.Entity;
 import dev.morphia.annotations.Id;
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.binout.HomeworldDefaultSaveData;
 import emu.grasscutter.net.proto.HomeBasicInfoOuterClass.HomeBasicInfo;
 import emu.grasscutter.net.proto.HomeSceneArrangementInfoOuterClass.HomeSceneArrangementInfo;
@@ -45,7 +46,7 @@ public class HomeSceneItem {
         for(var blockItem : arrangementInfo.getBlockArrangementInfoListList()){
             var block = this.blockItems.get(blockItem.getBlockId());
             if(block == null){
-                System.out.println(111);
+                Grasscutter.getLogger().warn("Could not found the Home Block {}", blockItem.getBlockId());
                 continue;
             }
             block.update(blockItem);
@@ -79,6 +80,7 @@ public class HomeSceneItem {
                 .setBornPos(bornPos.toProto())
                 .setBornRot(bornRot.toProto())
                 .setDjinnPos(djinnPos.toProto())
+                .setIsSetBornPos(true)
                 .setSceneId(sceneId)
                 .setTmpVersion(1);
 

--- a/src/main/java/emu/grasscutter/game/home/HomeSceneItem.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeSceneItem.java
@@ -26,7 +26,7 @@ public class HomeSceneItem {
     Position bornRot;
     Position djinnPos;
     HomeFurnitureItem mainHouse;
-
+    int tmpVersion;
     public static HomeSceneItem parseFrom(HomeworldDefaultSaveData defaultItem, int sceneId) {
         return HomeSceneItem.of()
                 .sceneId(sceneId)
@@ -56,6 +56,7 @@ public class HomeSceneItem {
         this.bornRot = new Position(arrangementInfo.getBornRot());
         this.djinnPos = new Position(arrangementInfo.getDjinnPos());
         this.mainHouse = HomeFurnitureItem.parseFrom(arrangementInfo.getMainHouse());
+        this.tmpVersion = arrangementInfo.getTmpVersion();
     }
 
     public int getRoomSceneId(){
@@ -81,7 +82,7 @@ public class HomeSceneItem {
                 .setDjinnPos(djinnPos.toProto())
                 .setIsSetBornPos(true)
                 .setSceneId(sceneId)
-                .setTmpVersion(1);
+                .setTmpVersion(tmpVersion);
 
         if(mainHouse != null){
             proto.setMainHouse(mainHouse.toProto());

--- a/src/main/java/emu/grasscutter/game/home/HomeSceneItem.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeSceneItem.java
@@ -4,7 +4,6 @@ import dev.morphia.annotations.Entity;
 import dev.morphia.annotations.Id;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.binout.HomeworldDefaultSaveData;
-import emu.grasscutter.net.proto.HomeBasicInfoOuterClass.HomeBasicInfo;
 import emu.grasscutter.net.proto.HomeSceneArrangementInfoOuterClass.HomeSceneArrangementInfo;
 import emu.grasscutter.utils.Position;
 import lombok.AccessLevel;

--- a/src/main/java/emu/grasscutter/game/inventory/Inventory.java
+++ b/src/main/java/emu/grasscutter/game/inventory/Inventory.java
@@ -267,6 +267,8 @@ public class Inventory implements Iterable<GameItem> {
 					getPlayer().setMora(player.getMora() + count);
 			case 203 -> // Genesis Crystals
 					getPlayer().setCrystals(player.getCrystals() + count);
+			case 204 -> // Home Coin
+					getPlayer().setHomeCoin(player.getHomeCoin() + count);
 		}
 	}
 
@@ -280,6 +282,8 @@ public class Inventory implements Iterable<GameItem> {
 				return player.getCrystals();
 			case 106:  // Resin
 				return player.getProperty(PlayerProperty.PROP_PLAYER_RESIN);
+			case 204:  // Home Coin
+				return player.getHomeCoin();
 			default:
 				GameItem item = getInventoryTab(ItemType.ITEM_MATERIAL).getItemById(itemId);  // What if we ever want to operate on weapons/relics/furniture? :S
 				return (item == null) ? 0 : item.getCount();
@@ -320,6 +324,8 @@ public class Inventory implements Iterable<GameItem> {
 					player.setCrystals(player.getCrystals() - (cost.getCount() * quantity));
 				case 106 ->  // Resin
 					player.getResinManager().useResin(cost.getCount() * quantity);
+				case 204 ->  // Home Coin
+						player.setHomeCoin(player.getHomeCoin() - (cost.getCount() * quantity));
 				default ->
 					removeItem(getInventoryTab(ItemType.ITEM_MATERIAL).getItemById(cost.getId()), cost.getCount() * quantity);
 			}

--- a/src/main/java/emu/grasscutter/game/managers/FurnitureManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/FurnitureManager.java
@@ -124,10 +124,10 @@ public class FurnitureManager {
         }
 
         // check if player can take
-        if(slotItem.get().getBeginTime() + slotItem.get().getDurTime() >= Utils.getCurrentSeconds() && !isFastFinish){
-            player.getSession().send(new PacketTakeFurnitureMakeRsp(Retcode.RET_FURNITURE_MAKE_UNFINISH_VALUE, makeId, null, null));
-            return;
-        }
+//        if(slotItem.get().getBeginTime() + slotItem.get().getDurTime() >= Utils.getCurrentSeconds() && !isFastFinish){
+//            player.getSession().send(new PacketTakeFurnitureMakeRsp(Retcode.RET_FURNITURE_MAKE_UNFINISH_VALUE, makeId, null, null));
+//            return;
+//        }
 
         player.getInventory().addItem(makeData.getFurnitureItemID(), makeData.getCount());
         player.getHome().getFurnitureMakeSlotItemList().remove(slotItem.get());

--- a/src/main/java/emu/grasscutter/game/managers/FurnitureManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/FurnitureManager.java
@@ -1,0 +1,146 @@
+package emu.grasscutter.game.managers;
+
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.common.ItemParamData;
+import emu.grasscutter.game.home.FurnitureMakeSlotItem;
+import emu.grasscutter.game.inventory.GameItem;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.net.proto.ItemParamOuterClass;
+import emu.grasscutter.net.proto.RetcodeOuterClass.Retcode;
+import emu.grasscutter.server.packet.send.*;
+import emu.grasscutter.utils.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FurnitureManager {
+    private final Player player;
+
+    public FurnitureManager(Player player) {
+        this.player = player;
+    }
+
+    public void onLogin(){
+        notifyUnlockFurniture();
+        notifyUnlockFurnitureSuite();
+    }
+
+    public void notifyUnlockFurniture(){
+        player.getSession().send(new PacketUnlockedFurnitureFormulaDataNotify(player.getUnlockedFurniture()));
+    }
+
+    public void notifyUnlockFurnitureSuite(){
+        player.getSession().send(new PacketUnlockedFurnitureSuiteDataNotify(player.getUnlockedFurnitureSuite()));
+    }
+
+    public synchronized boolean unlockFurnitureOrSuite(GameItem useItem){
+        // Check
+        if (!List.of("ITEM_USE_UNLOCK_FURNITURE_FORMULA", "ITEM_USE_UNLOCK_FURNITURE_SUITE")
+                .contains(useItem.getItemData().getItemUse().get(0).getUseOp())) {
+            return false;
+        }
+
+        int furnitureIdOrSuiteId = Integer.parseInt(useItem.getItemData().getItemUse().get(0).getUseParam().get(0));
+
+        // Remove first
+        player.getInventory().removeItem(useItem, 1);
+
+        if("ITEM_USE_UNLOCK_FURNITURE_FORMULA".equals(useItem.getItemData().getItemUse().get(0).getUseOp())){
+            player.getUnlockedFurniture().add(furnitureIdOrSuiteId);
+            notifyUnlockFurniture();
+        }else{
+            player.getUnlockedFurnitureSuite().add(furnitureIdOrSuiteId);
+            notifyUnlockFurnitureSuite();
+        }
+        return true;
+    }
+
+    public void startMake(int makeId, int avatarId) {
+        var makeData = GameData.getFurnitureMakeConfigDataMap().get(makeId);
+        if(makeData == null){
+            player.getSession().send(new PacketFurnitureMakeStartRsp(Retcode.RET_FURNITURE_MAKE_CONFIG_ERROR_VALUE, null));
+            return;
+        }
+
+        // check slot count
+        if (player.getHome().getLevelData().getFurnitureMakeSlotCount() <= player.getHome().getFurnitureMakeSlotItemList().size()){
+            player.getSession().send(new PacketFurnitureMakeStartRsp(Retcode.RET_FURNITURE_MAKE_SLOT_FULL_VALUE, null));
+            return;
+        }
+
+        // pay items first
+        if(!player.getInventory().payItems(makeData.getMaterialItems().toArray(new ItemParamData[0]))){
+            player.getSession().send(new PacketFurnitureMakeStartRsp(Retcode.RET_HOME_FURNITURE_COUNT_NOT_ENOUGH_VALUE, null));
+            return;
+        }
+
+        var furnitureSlot = FurnitureMakeSlotItem.of()
+                .avatarId(avatarId)
+                .makeId(makeId)
+                .beginTime(Utils.getCurrentSeconds())
+                .durTime(makeData.getMakeTime())
+                .build();
+
+        // add furniture make task
+        player.getHome().getFurnitureMakeSlotItemList().add(furnitureSlot);
+        player.getSession().send(new PacketFurnitureMakeStartRsp(Retcode.RET_SUCC_VALUE,
+                player.getHome().getFurnitureMakeSlotItemList().stream()
+                        .map(FurnitureMakeSlotItem::toProto)
+                        .toList()
+        ));
+
+        player.getHome().save();
+    }
+
+    public void queryStatus() {
+        if (player.getHome().getFurnitureMakeSlotItemList() == null){
+            player.getHome().setFurnitureMakeSlotItemList(new ArrayList<>());
+        }
+
+        player.sendPacket(new PacketFurnitureMakeRsp(player.getHome()));
+    }
+
+
+    public void take(int index, int makeId, boolean isFastFinish) {
+        var makeData = GameData.getFurnitureMakeConfigDataMap().get(makeId);
+        if(makeData == null){
+            player.getSession().send(new PacketTakeFurnitureMakeRsp(Retcode.RET_FURNITURE_MAKE_CONFIG_ERROR_VALUE, makeId, null, null));
+            return;
+        }
+
+        var slotItem = player.getHome().getFurnitureMakeSlotItemList().stream()
+                .filter(x -> x.getIndex() == index && x.getMakeId() == makeId)
+                .findFirst();
+
+        if(slotItem.isEmpty()){
+            player.getSession().send(new PacketTakeFurnitureMakeRsp(Retcode.RET_FURNITURE_MAKE_NO_MAKE_DATA_VALUE, makeId, null, null));
+            return;
+        }
+
+        // pay the speedup item
+        if(isFastFinish && !player.getInventory().payItem(107013,1)){
+            player.getSession().send(new PacketTakeFurnitureMakeRsp(Retcode.RET_FURNITURE_MAKE_UNFINISH_VALUE, makeId, null, null));
+            return;
+        }
+
+        // check if player can take
+        if(slotItem.get().getBeginTime() + slotItem.get().getDurTime() >= Utils.getCurrentSeconds() && !isFastFinish){
+            player.getSession().send(new PacketTakeFurnitureMakeRsp(Retcode.RET_FURNITURE_MAKE_UNFINISH_VALUE, makeId, null, null));
+            return;
+        }
+
+        player.getInventory().addItem(makeData.getFurnitureItemID(), makeData.getCount());
+        player.getHome().getFurnitureMakeSlotItemList().remove(slotItem.get());
+
+        player.getSession().send(new PacketTakeFurnitureMakeRsp(Retcode.RET_SUCC_VALUE, makeId,
+                List.of(ItemParamOuterClass.ItemParam.newBuilder()
+                                .setItemId(makeData.getFurnitureItemID())
+                                .setCount(makeData.getCount())
+                        .build()),
+                player.getHome().getFurnitureMakeSlotItemList().stream()
+                        .map(FurnitureMakeSlotItem::toProto)
+                        .toList()
+                ));
+        player.getHome().save();
+    }
+}

--- a/src/main/java/emu/grasscutter/game/managers/InventoryManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/InventoryManager.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.binout.OpenConfigEntry;
 import emu.grasscutter.data.binout.OpenConfigEntry.SkillPointModifier;
@@ -22,14 +21,12 @@ import emu.grasscutter.data.excels.AvatarSkillDepotData.InherentProudSkillOpens;
 import emu.grasscutter.game.avatar.Avatar;
 import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.game.inventory.ItemType;
-import emu.grasscutter.game.inventory.MaterialType;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.ActionReason;
 import emu.grasscutter.game.shop.ShopChestBatchUseTable;
 import emu.grasscutter.game.shop.ShopChestTable;
 import emu.grasscutter.net.proto.ItemParamOuterClass.ItemParam;
 import emu.grasscutter.net.proto.MaterialInfoOuterClass.MaterialInfo;
-import emu.grasscutter.server.packet.send.PacketForgeFormulaDataNotify;
 import emu.grasscutter.server.game.GameServer;
 import emu.grasscutter.server.packet.send.*;
 import emu.grasscutter.utils.Utils;
@@ -861,6 +858,14 @@ public class InventoryManager {
 					// Unlock.
 					useSuccess = player.getServer().getCombineManger().unlockCombineDiagram(player, useItem);
 				}
+				break;
+			case MATERIAL_FURNITURE_FORMULA:
+			case MATERIAL_FURNITURE_SUITE_FORMULA:
+				if (useItem.getItemData().getItemUse() == null) {
+					break;
+				}
+				useSuccess = player.getFurnitureManager().unlockFurnitureOrSuite(useItem);
+
 				break;
 			case MATERIAL_CONSUME_BATCH_USE:
 				// Make sure we have usage data for this material.

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -27,6 +27,7 @@ import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.game.inventory.Inventory;
 import emu.grasscutter.game.mail.Mail;
 import emu.grasscutter.game.mail.MailHandler;
+import emu.grasscutter.game.managers.FurnitureManager;
 import emu.grasscutter.game.managers.InsectCaptureManager;
 import emu.grasscutter.game.managers.ResinManager;
 import emu.grasscutter.game.managers.deforestation.DeforestationManager;
@@ -99,6 +100,8 @@ public class Player {
 	private Set<Integer> costumeList;
 	private Set<Integer> unlockedForgingBlueprints;
 	private Set<Integer> unlockedCombines;
+	private Set<Integer> unlockedFurniture;
+	private Set<Integer> unlockedFurnitureSuite;
 	private List<ActiveForgeData> activeForges;
 
 	private Integer widgetId;
@@ -167,6 +170,7 @@ public class Player {
 	@Transient private ForgingManager forgingManager;
 	@Transient private DeforestationManager deforestationManager;
 	@Transient private GameHome home;
+	@Transient private FurnitureManager furnitureManager;
 
 	private long springLastUsed;
 	private HashMap<String, MapMark> mapMarks;
@@ -202,6 +206,8 @@ public class Player {
 		this.towerData = new TowerData();
 		this.unlockedForgingBlueprints = new HashSet<>();
 		this.unlockedCombines = new HashSet<>();
+		this.unlockedFurniture = new HashSet<>();
+		this.unlockedFurnitureSuite = new HashSet<>();
 		this.activeForges = new ArrayList<>();
 
 		this.setSceneId(3);
@@ -228,6 +234,7 @@ public class Player {
 		this.energyManager = new EnergyManager(this);
 		this.resinManager = new ResinManager(this);
 		this.forgingManager = new ForgingManager(this);
+		this.furnitureManager = new FurnitureManager(this);
 	}
 
 	// On player creation
@@ -261,6 +268,7 @@ public class Player {
 		this.resinManager = new ResinManager(this);
 		this.deforestationManager = new DeforestationManager(this);
 		this.forgingManager = new ForgingManager(this);
+		this.furnitureManager = new FurnitureManager(this);
 	}
 
 	public int getUid() {
@@ -563,6 +571,14 @@ public class Player {
 
 	public Set<Integer> getUnlockedCombines() {
 		return this.unlockedCombines;
+	}
+
+	public Set<Integer> getUnlockedFurniture() {
+		return unlockedFurniture;
+	}
+
+	public Set<Integer> getUnlockedFurnitureSuite() {
+		return unlockedFurnitureSuite;
 	}
 
 	public List<ActiveForgeData> getActiveForges() {
@@ -1183,6 +1199,10 @@ public class Player {
 		return this.forgingManager;
 	}
 
+	public FurnitureManager getFurnitureManager() {
+		return furnitureManager;
+	}
+
 	public AbilityManager getAbilityManager() {
 		return abilityManager;
 	}
@@ -1335,6 +1355,7 @@ public class Player {
 
 		getTodayMoonCard(); // The timer works at 0:0, some users log in after that, use this method to check if they have received a reward today or not. If not, send the reward.
 
+		this.furnitureManager.onLogin();
 		// Home
 		home = GameHome.getByUid(getUid());
 		home.onOwnerLogin(this);

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -15,7 +15,6 @@ import emu.grasscutter.game.avatar.AvatarStorage;
 import emu.grasscutter.game.entity.EntityMonster;
 import emu.grasscutter.game.entity.EntityVehicle;
 import emu.grasscutter.game.home.GameHome;
-import emu.grasscutter.game.managers.DeforestationManager.DeforestationManager;
 import emu.grasscutter.game.entity.EntityGadget;
 import emu.grasscutter.game.entity.EntityItem;
 import emu.grasscutter.game.entity.GameEntity;

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -414,6 +414,10 @@ public class Scene {
 	}
 	
 	public void onTick() {
+		// disable script for home
+		if (this.getSceneType() == SceneType.SCENE_HOME_WORLD || this.getSceneType() == SceneType.SCENE_HOME_ROOM){
+			return;
+		}
 		if (this.getScriptManager().isInit()) {
 			this.checkBlocks();
 		} else {

--- a/src/main/java/emu/grasscutter/game/world/World.java
+++ b/src/main/java/emu/grasscutter/game/world/World.java
@@ -270,7 +270,9 @@ public class World implements Iterable<Player> {
 			enterType = EnterType.ENTER_TYPE_GOTO;
 		} else if (newScene.getSceneType() == SceneType.SCENE_HOME_WORLD) {
 			// Home
+			enterReason = EnterReason.EnterHome;
 			enterType = EnterType.ENTER_TYPE_SELF_HOME;
+
 		}
 		
 		// Teleport packet

--- a/src/main/java/emu/grasscutter/net/packet/PacketOpcodes.java
+++ b/src/main/java/emu/grasscutter/net/packet/PacketOpcodes.java
@@ -777,6 +777,9 @@ public class PacketOpcodes {
     public static final int HomeSceneJumpRsp = 4570;
     public static final int HomeTransferReq = 4880;
     public static final int HomeTransferRsp = 4767;
+    public static final int HomeUnknown1Notify = 4528;
+    public static final int HomeUnknown2Req = 4857;
+    public static final int HomeUnknown2Rsp = 4670;
     public static final int HomeUpdateArrangementInfoReq = 4472;
     public static final int HomeUpdateArrangementInfoRsp = 4822;
     public static final int HomeUpdateFishFarmingInfoReq = 4604;

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerFurnitureMakeReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerFurnitureMakeReq.java
@@ -1,0 +1,16 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.server.game.GameSession;
+
+@Opcodes(PacketOpcodes.FurnitureMakeReq)
+public class HandlerFurnitureMakeReq extends PacketHandler {
+	
+	@Override
+	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+		session.getPlayer().getFurnitureManager().queryStatus();
+	}
+
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerFurnitureMakeStartReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerFurnitureMakeStartReq.java
@@ -1,0 +1,20 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.FurnitureMakeStartReqOuterClass;
+import emu.grasscutter.server.game.GameSession;
+
+@Opcodes(PacketOpcodes.FurnitureMakeStartReq)
+public class HandlerFurnitureMakeStartReq extends PacketHandler {
+	
+	@Override
+	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+		var req = FurnitureMakeStartReqOuterClass.FurnitureMakeStartReq.parseFrom(payload);
+
+		session.getPlayer().getFurnitureManager().startMake(req.getMakeId(), req.getAvatarId());
+
+	}
+
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetFurnitureCurModuleArrangeCountReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetFurnitureCurModuleArrangeCountReq.java
@@ -1,0 +1,17 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketFurnitureCurModuleArrangeCountNotify;
+
+@Opcodes(PacketOpcodes.GetFurnitureCurModuleArrangeCountReq)
+public class HandlerGetFurnitureCurModuleArrangeCountReq extends PacketHandler {
+	
+	@Override
+	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+		session.send(new PacketFurnitureCurModuleArrangeCountNotify());
+	}
+
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerHomeCompInfoReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerHomeCompInfoReq.java
@@ -1,0 +1,17 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketPlayerHomeCompInfoNotify;
+
+@Opcodes(PacketOpcodes.GetPlayerHomeCompInfoReq)
+public class HandlerGetPlayerHomeCompInfoReq extends PacketHandler {
+	
+	@Override
+	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+		session.send(new PacketPlayerHomeCompInfoNotify(session.getPlayer()));
+	}
+
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeChangeEditModeReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeChangeEditModeReq.java
@@ -1,0 +1,24 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.HomeChangeEditModeReqOuterClass;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.*;
+
+@Opcodes(PacketOpcodes.HomeChangeEditModeReq)
+public class HandlerHomeChangeEditModeReq extends PacketHandler {
+	
+	@Override
+	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+		var req = HomeChangeEditModeReqOuterClass.HomeChangeEditModeReq.parseFrom(payload);
+
+		session.send(new PacketHomeUnknown1Notify(req.getIsEnterEditMode()));
+		session.send(new PacketHomeBasicInfoNotify(session.getPlayer(), req.getIsEnterEditMode()));
+		session.send(new PacketHomeComfortInfoNotify(session.getPlayer()));
+
+		session.send(new PacketHomeChangeEditModeRsp(req.getIsEnterEditMode()));
+	}
+
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeGetArrangementInfoReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeGetArrangementInfoReq.java
@@ -1,0 +1,20 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.HomeGetArrangementInfoReqOuterClass;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketHomeGetArrangementInfoRsp;
+
+@Opcodes(PacketOpcodes.HomeGetArrangementInfoReq)
+public class HandlerHomeGetArrangementInfoReq extends PacketHandler {
+	
+	@Override
+	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+		var req = HomeGetArrangementInfoReqOuterClass.HomeGetArrangementInfoReq.parseFrom(payload);
+
+		session.send(new PacketHomeGetArrangementInfoRsp(session.getPlayer(), req.getSceneIdListList()));
+	}
+
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeGetBasicInfoReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeGetBasicInfoReq.java
@@ -1,0 +1,18 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketHomeBasicInfoNotify;
+
+@Opcodes(PacketOpcodes.HomeGetBasicInfoReq)
+public class HandlerHomeGetBasicInfoReq extends PacketHandler {
+	
+	@Override
+	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+
+		session.send(new PacketHomeBasicInfoNotify(session.getPlayer(), false));
+	}
+
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeSceneInitFinishReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeSceneInitFinishReq.java
@@ -1,0 +1,17 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketHomeSceneInitFinishRsp;
+
+@Opcodes(PacketOpcodes.HomeSceneInitFinishReq)
+public class HandlerHomeSceneInitFinishReq extends PacketHandler {
+	
+	@Override
+	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+		session.send(new PacketHomeSceneInitFinishRsp());
+	}
+
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeSceneJumpReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeSceneJumpReq.java
@@ -1,0 +1,42 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.HomeSceneJumpReqOuterClass;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketHomeSceneJumpRsp;
+
+@Opcodes(PacketOpcodes.HomeSceneJumpReq)
+public class HandlerHomeSceneJumpReq extends PacketHandler {
+	
+	@Override
+	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+		var req = HomeSceneJumpReqOuterClass.HomeSceneJumpReq.parseFrom(payload);
+
+		int realmId = 2000 + session.getPlayer().getCurrentRealmId();
+
+		var home = session.getPlayer().getHome();
+		var homeScene = home.getHomeSceneItem(realmId);
+		home.save();
+
+		if(req.getIsEnterRoomScene()){
+			var roomScene = home.getHomeSceneItem(homeScene.getRoomSceneId());
+
+			session.getPlayer().getWorld().transferPlayerToScene(
+					session.getPlayer(),
+					homeScene.getRoomSceneId(),
+					roomScene.getBornPos()
+			);
+		}else{
+			session.getPlayer().getWorld().transferPlayerToScene(
+					session.getPlayer(),
+					realmId,
+					homeScene.getBornPos()
+			);
+		}
+
+		session.send(new PacketHomeSceneJumpRsp(req.getIsEnterRoomScene()));
+	}
+
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeSceneJumpReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeSceneJumpReq.java
@@ -1,11 +1,13 @@
 package emu.grasscutter.server.packet.recv;
 
+import emu.grasscutter.game.world.Scene;
 import emu.grasscutter.net.packet.Opcodes;
 import emu.grasscutter.net.packet.PacketHandler;
 import emu.grasscutter.net.packet.PacketOpcodes;
 import emu.grasscutter.net.proto.HomeSceneJumpReqOuterClass;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.packet.send.PacketHomeSceneJumpRsp;
+import emu.grasscutter.utils.Position;
 
 @Opcodes(PacketOpcodes.HomeSceneJumpReq)
 public class HandlerHomeSceneJumpReq extends PacketHandler {
@@ -20,21 +22,14 @@ public class HandlerHomeSceneJumpReq extends PacketHandler {
 		var homeScene = home.getHomeSceneItem(realmId);
 		home.save();
 
-		if(req.getIsEnterRoomScene()){
-			var roomScene = home.getHomeSceneItem(homeScene.getRoomSceneId());
-
-			session.getPlayer().getWorld().transferPlayerToScene(
-					session.getPlayer(),
-					homeScene.getRoomSceneId(),
-					roomScene.getBornPos()
-			);
-		}else{
-			session.getPlayer().getWorld().transferPlayerToScene(
-					session.getPlayer(),
-					realmId,
-					homeScene.getBornPos()
-			);
-		}
+		Scene scene = session.getPlayer().getWorld().getSceneById(req.getIsEnterRoomScene() ? homeScene.getRoomSceneId() : realmId);
+		Position pos = scene.getScriptManager().getConfig().born_pos;
+		
+		session.getPlayer().getWorld().transferPlayerToScene(
+				session.getPlayer(),
+				req.getIsEnterRoomScene() ? homeScene.getRoomSceneId() : realmId,
+				pos
+		);
 
 		session.send(new PacketHomeSceneJumpRsp(req.getIsEnterRoomScene()));
 	}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeSceneJumpReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeSceneJumpReq.java
@@ -24,7 +24,7 @@ public class HandlerHomeSceneJumpReq extends PacketHandler {
 
 		Scene scene = session.getPlayer().getWorld().getSceneById(req.getIsEnterRoomScene() ? homeScene.getRoomSceneId() : realmId);
 		Position pos = scene.getScriptManager().getConfig().born_pos;
-		
+
 		session.getPlayer().getWorld().transferPlayerToScene(
 				session.getPlayer(),
 				req.getIsEnterRoomScene() ? homeScene.getRoomSceneId() : realmId,

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeUnknown2Req.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeUnknown2Req.java
@@ -1,0 +1,20 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketHomeUnknown2Rsp;
+
+@Opcodes(PacketOpcodes.HomeUnknown2Req)
+public class HandlerHomeUnknown2Req extends PacketHandler {
+	
+	@Override
+	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+		/*
+		 * This packet is about the edit mode
+		 */
+		session.send(new PacketHomeUnknown2Rsp());
+	}
+
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeUpdateArrangementInfoReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeUpdateArrangementInfoReq.java
@@ -1,0 +1,27 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.HomeUpdateArrangementInfoReqOuterClass;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketHomeUpdateArrangementInfoRsp;
+
+@Opcodes(PacketOpcodes.HomeUpdateArrangementInfoReq)
+public class HandlerHomeUpdateArrangementInfoReq extends PacketHandler {
+	
+	@Override
+	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+		var req = HomeUpdateArrangementInfoReqOuterClass.HomeUpdateArrangementInfoReq.parseFrom(payload);
+
+		var homeScene = session.getPlayer().getHome()
+				.getHomeSceneItem(session.getPlayer().getSceneId());
+
+		homeScene.update(req.getSceneArrangementInfo());
+
+		session.getPlayer().getHome().save();
+
+		session.send(new PacketHomeUpdateArrangementInfoRsp());
+	}
+
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerTakeFurnitureMakeReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerTakeFurnitureMakeReq.java
@@ -1,0 +1,19 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.TakeFurnitureMakeReqOuterClass;
+import emu.grasscutter.server.game.GameSession;
+
+@Opcodes(PacketOpcodes.TakeFurnitureMakeReq)
+public class HandlerTakeFurnitureMakeReq extends PacketHandler {
+	
+	@Override
+	public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+		var req = TakeFurnitureMakeReqOuterClass.TakeFurnitureMakeReq.parseFrom(payload);
+
+		session.getPlayer().getFurnitureManager().take(req.getIndex(), req.getMakeId(), req.getIsFastFinish());
+	}
+
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerTryEnterHomeReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerTryEnterHomeReq.java
@@ -1,6 +1,8 @@
 package emu.grasscutter.server.packet.recv;
 
 import emu.grasscutter.data.GameData;
+import emu.grasscutter.database.DatabaseHelper;
+import emu.grasscutter.game.home.GameHome;
 import emu.grasscutter.game.world.Scene;
 import emu.grasscutter.net.packet.Opcodes;
 import emu.grasscutter.net.packet.PacketHandler;
@@ -27,13 +29,14 @@ public class HandlerTryEnterHomeReq extends PacketHandler {
 
         int realmId = 2000 + session.getPlayer().getCurrentRealmId();
 
-        Scene scene = session.getPlayer().getWorld().getSceneById(realmId);
-        Position pos = scene.getScriptManager().getConfig().born_pos;
+        var home = session.getPlayer().getHome();
+        var homeScene = home.getHomeSceneItem(realmId);
+        home.save();
 
         session.getPlayer().getWorld().transferPlayerToScene(
                 session.getPlayer(),
                 realmId,
-                pos
+                homeScene.getBornPos()
         );
 
 

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerTryEnterHomeReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerTryEnterHomeReq.java
@@ -30,13 +30,18 @@ public class HandlerTryEnterHomeReq extends PacketHandler {
         int realmId = 2000 + session.getPlayer().getCurrentRealmId();
 
         var home = session.getPlayer().getHome();
+
+        // prepare the default arrangement for first come in
         var homeScene = home.getHomeSceneItem(realmId);
         home.save();
+
+        Scene scene = session.getPlayer().getWorld().getSceneById(realmId);
+        Position pos = scene.getScriptManager().getConfig().born_pos;
 
         session.getPlayer().getWorld().transferPlayerToScene(
                 session.getPlayer(),
                 realmId,
-                homeScene.getBornPos()
+                pos
         );
 
 

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketFurnitureCurModuleArrangeCountNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketFurnitureCurModuleArrangeCountNotify.java
@@ -1,0 +1,57 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.FurnitureCurModuleArrangeCountNotifyOuterClass;
+import emu.grasscutter.net.proto.Uint32PairOuterClass;
+
+public class PacketFurnitureCurModuleArrangeCountNotify extends BasePacket {
+
+	public PacketFurnitureCurModuleArrangeCountNotify() {
+		super(PacketOpcodes.FurnitureCurModuleArrangeCountNotify);
+
+		var proto = FurnitureCurModuleArrangeCountNotifyOuterClass.FurnitureCurModuleArrangeCountNotify.newBuilder();
+
+		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
+						.setKey(360101)
+						.setValue(7)
+				.build());
+
+		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
+				.setKey(360201)
+				.setValue(7)
+				.build());
+
+		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
+				.setKey(360301)
+				.setValue(7)
+				.build());
+
+		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
+				.setKey(360401)
+				.setValue(2)
+				.build());
+
+		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
+				.setKey(360402)
+				.setValue(4)
+				.build());
+
+		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
+				.setKey(364301)
+				.setValue(1)
+				.build());
+
+		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
+				.setKey(364401)
+				.setValue(1)
+				.build());
+
+		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
+				.setKey(3750102)
+				.setValue(1)
+				.build());
+
+		this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketFurnitureCurModuleArrangeCountNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketFurnitureCurModuleArrangeCountNotify.java
@@ -12,45 +12,7 @@ public class PacketFurnitureCurModuleArrangeCountNotify extends BasePacket {
 
 		var proto = FurnitureCurModuleArrangeCountNotifyOuterClass.FurnitureCurModuleArrangeCountNotify.newBuilder();
 
-		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
-						.setKey(360101)
-						.setValue(7)
-				.build());
-
-		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
-				.setKey(360201)
-				.setValue(7)
-				.build());
-
-		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
-				.setKey(360301)
-				.setValue(7)
-				.build());
-
-		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
-				.setKey(360401)
-				.setValue(2)
-				.build());
-
-		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
-				.setKey(360402)
-				.setValue(4)
-				.build());
-
-		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
-				.setKey(364301)
-				.setValue(1)
-				.build());
-
-		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
-				.setKey(364401)
-				.setValue(1)
-				.build());
-
-		proto.addFurnitureArrangeCountList(Uint32PairOuterClass.Uint32Pair.newBuilder()
-				.setKey(3750102)
-				.setValue(1)
-				.build());
+		// TODO
 
 		this.setData(proto);
 	}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketFurnitureMakeRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketFurnitureMakeRsp.java
@@ -1,0 +1,25 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.game.home.FurnitureMakeSlotItem;
+import emu.grasscutter.game.home.GameHome;
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.FurnitureMakeRspOuterClass;
+import emu.grasscutter.net.proto.FurnitureMakeSlotOuterClass;
+
+public class PacketFurnitureMakeRsp extends BasePacket {
+
+	public PacketFurnitureMakeRsp(GameHome home) {
+		super(PacketOpcodes.FurnitureMakeRsp);
+
+		var proto = FurnitureMakeRspOuterClass.FurnitureMakeRsp.newBuilder();
+
+		proto.setFurnitureMakeSlot(FurnitureMakeSlotOuterClass.FurnitureMakeSlot.newBuilder()
+				.addAllFurnitureMakeDataList(home.getFurnitureMakeSlotItemList().stream()
+						.map(FurnitureMakeSlotItem::toProto)
+						.toList())
+				.build());
+
+		this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketFurnitureMakeStartRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketFurnitureMakeStartRsp.java
@@ -1,0 +1,28 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.FurnitureMakeDataOuterClass;
+import emu.grasscutter.net.proto.FurnitureMakeSlotOuterClass;
+import emu.grasscutter.net.proto.FurnitureMakeStartRspOuterClass;
+
+import java.util.List;
+
+public class PacketFurnitureMakeStartRsp extends BasePacket {
+
+	public PacketFurnitureMakeStartRsp(int ret, List<FurnitureMakeDataOuterClass.FurnitureMakeData> furnitureMakeData) {
+		super(PacketOpcodes.FurnitureMakeStartRsp);
+
+		var proto = FurnitureMakeStartRspOuterClass.FurnitureMakeStartRsp.newBuilder();
+
+		proto.setRetcode(ret);
+
+		if(furnitureMakeData != null){
+			proto.setFurnitureMakeSlot(FurnitureMakeSlotOuterClass.FurnitureMakeSlot.newBuilder()
+					.addAllFurnitureMakeDataList(furnitureMakeData)
+					.build());
+		}
+
+		this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeBasicInfoNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeBasicInfoNotify.java
@@ -1,0 +1,50 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.HomeBasicInfoNotifyOuterClass;
+import emu.grasscutter.net.proto.HomeBasicInfoOuterClass;
+import emu.grasscutter.net.proto.HomeLimitedShopInfoOuterClass;
+import emu.grasscutter.net.proto.VectorOuterClass;
+
+public class PacketHomeBasicInfoNotify extends BasePacket {
+
+	public PacketHomeBasicInfoNotify(Player player, boolean editMode) {
+		super(PacketOpcodes.HomeBasicInfoNotify);
+
+		if(player.getCurrentRealmId() == null){
+			return;
+		}
+
+		var proto = HomeBasicInfoNotifyOuterClass.HomeBasicInfoNotify.newBuilder();
+
+		var sceneId = player.getCurrentRealmId() + 2000;
+		var homeScene = player.getHome().getHomeSceneItem(sceneId);
+
+		proto.setBasicInfo(HomeBasicInfoOuterClass.HomeBasicInfo.newBuilder()
+				.setCurModuleId(player.getCurrentRealmId())
+				.setCurRoomSceneId(homeScene.getRoomSceneId())
+				.setIsInEditMode(editMode)
+				.setHomeOwnerUid(player.getUid())
+				.setLevel(1)
+				.setOwnerNickName(player.getNickname())
+				.setLimitedShopInfo(HomeLimitedShopInfoOuterClass.HomeLimitedShopInfo.newBuilder()
+						.setDjinnPos(VectorOuterClass.Vector.newBuilder()
+								.setZ(192)
+								.setX(792)
+								.setY(316.7f)
+								.build())
+						.setDjinnRot(VectorOuterClass.Vector.newBuilder()
+								.setY(176)
+								.build())
+						.setNextCloseTime(Integer.MAX_VALUE)
+						.setNextGuestOpenTime(0)
+						.setNextOpenTime(0)
+						.setUid(player.getUid())
+						.build())
+				.build());
+
+		this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeBasicInfoNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeBasicInfoNotify.java
@@ -27,22 +27,9 @@ public class PacketHomeBasicInfoNotify extends BasePacket {
 				.setCurRoomSceneId(homeScene.getRoomSceneId())
 				.setIsInEditMode(editMode)
 				.setHomeOwnerUid(player.getUid())
-				.setLevel(1)
+				.setLevel(player.getHome().getLevel())
 				.setOwnerNickName(player.getNickname())
-				.setLimitedShopInfo(HomeLimitedShopInfoOuterClass.HomeLimitedShopInfo.newBuilder()
-						.setDjinnPos(VectorOuterClass.Vector.newBuilder()
-								.setZ(192)
-								.setX(792)
-								.setY(316.7f)
-								.build())
-						.setDjinnRot(VectorOuterClass.Vector.newBuilder()
-								.setY(176)
-								.build())
-						.setNextCloseTime(Integer.MAX_VALUE)
-						.setNextGuestOpenTime(0)
-						.setNextOpenTime(0)
-						.setUid(player.getUid())
-						.build())
+				// TODO limit shop
 				.build());
 
 		this.setData(proto);

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeChangeEditModeRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeChangeEditModeRsp.java
@@ -1,0 +1,18 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.HomeChangeEditModeRspOuterClass;
+
+public class PacketHomeChangeEditModeRsp extends BasePacket {
+
+	public PacketHomeChangeEditModeRsp(boolean enterEditMode) {
+		super(PacketOpcodes.HomeChangeEditModeRsp);
+
+		var proto = HomeChangeEditModeRspOuterClass.HomeChangeEditModeRsp.newBuilder();
+
+		proto.setIsEnterEditMode(enterEditMode);
+
+		this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeComfortInfoNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeComfortInfoNotify.java
@@ -25,6 +25,11 @@ public class PacketHomeComfortInfoNotify extends BasePacket {
             comfortInfoList.add(
                     HomeModuleComfortInfoOuterClass.HomeModuleComfortInfo.newBuilder()
                         .setModuleId(moduleId)
+                            .setRoomSceneComfortValue(1050)
+                            .addWorldSceneBlockComfortValueList(750)
+                            .addWorldSceneBlockComfortValueList(0)
+                            .addWorldSceneBlockComfortValueList(0)
+                            .addWorldSceneBlockComfortValueList(0)
                         .build()
             );
         }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeComfortInfoNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeComfortInfoNotify.java
@@ -1,5 +1,6 @@
 package emu.grasscutter.server.packet.send;
 
+import emu.grasscutter.game.home.HomeBlockItem;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.net.packet.BasePacket;
 import emu.grasscutter.net.packet.PacketOpcodes;
@@ -22,14 +23,17 @@ public class PacketHomeComfortInfoNotify extends BasePacket {
         List<HomeModuleComfortInfoOuterClass.HomeModuleComfortInfo> comfortInfoList = new ArrayList<>();
 
         for (int moduleId : player.getRealmList()) {
+            var homeScene = player.getHome().getHomeSceneItem(moduleId + 2000);
+            var blockComfortList = homeScene.getBlockItems().values().stream()
+                    .map(HomeBlockItem::calComfort)
+                    .toList();
+            var homeRoomScene = player.getHome().getHomeSceneItem(homeScene.getRoomSceneId());
+
             comfortInfoList.add(
                     HomeModuleComfortInfoOuterClass.HomeModuleComfortInfo.newBuilder()
                         .setModuleId(moduleId)
-                            .setRoomSceneComfortValue(1050)
-                            .addWorldSceneBlockComfortValueList(750)
-                            .addWorldSceneBlockComfortValueList(0)
-                            .addWorldSceneBlockComfortValueList(0)
-                            .addWorldSceneBlockComfortValueList(0)
+                            .setRoomSceneComfortValue(homeRoomScene.calComfort())
+                            .addAllWorldSceneBlockComfortValueList(blockComfortList)
                         .build()
             );
         }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeGetArrangementInfoRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeGetArrangementInfoRsp.java
@@ -1,0 +1,31 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.game.home.HomeSceneItem;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.HomeGetArrangementInfoRspOuterClass;
+
+import java.util.List;
+
+public class PacketHomeGetArrangementInfoRsp extends BasePacket {
+
+	public PacketHomeGetArrangementInfoRsp(Player player, List<Integer> sceneIdList) {
+		super(PacketOpcodes.HomeGetArrangementInfoRsp);
+
+		var home = player.getHome();
+
+		var homeScenes = sceneIdList.stream()
+				.map(home::getHomeSceneItem)
+				.map(HomeSceneItem::toProto)
+				.toList();
+
+		home.save();
+
+		var proto = HomeGetArrangementInfoRspOuterClass.HomeGetArrangementInfoRsp.newBuilder();
+
+		proto.addAllSceneArrangementInfoList(homeScenes);
+
+		this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeMarkPointNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeMarkPointNotify.java
@@ -1,10 +1,14 @@
 package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.game.home.GameHome;
+import emu.grasscutter.game.home.HomeBlockItem;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.net.packet.BasePacket;
 import emu.grasscutter.net.packet.PacketOpcodes;
 import emu.grasscutter.net.proto.HomeMarkPointNotifyOuterClass;
+import emu.grasscutter.net.proto.HomeMarkPointSceneDataOuterClass;
+
+import java.util.Collection;
 
 public class PacketHomeMarkPointNotify extends BasePacket {
 
@@ -13,6 +17,26 @@ public class PacketHomeMarkPointNotify extends BasePacket {
 
 		var proto = HomeMarkPointNotifyOuterClass.HomeMarkPointNotify.newBuilder();
 
+		for(var moduleId : player.getRealmList()){
+			var homeScene = home.getHomeSceneItem(moduleId + 2000);
+
+			var markPointData = HomeMarkPointSceneDataOuterClass.HomeMarkPointSceneData.newBuilder()
+					.setModuleId(moduleId)
+					.setSceneId(moduleId + 2000)
+					.setTeapotSpiritPos(homeScene.getDjinnPos().toProto());
+
+			// Now it only supports the teleport point
+			// TODO add more types
+			var marks = homeScene.getBlockItems().values().stream()
+					.map(HomeBlockItem::getDeployFurnitureList)
+					.flatMap(Collection::stream)
+					.filter(i -> i.getFurnitureId() == 373501)
+					.map(x -> x.toMarkPointProto(3))
+					.toList();
+
+			markPointData.addAllFurnitureList(marks);
+			proto.addMarkPointDataList(markPointData);
+		}
 
 		this.setData(proto);
 	}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeMarkPointNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeMarkPointNotify.java
@@ -1,0 +1,19 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.game.home.GameHome;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.HomeMarkPointNotifyOuterClass;
+
+public class PacketHomeMarkPointNotify extends BasePacket {
+
+	public PacketHomeMarkPointNotify(Player player, GameHome home) {
+		super(PacketOpcodes.HomeMarkPointNotify);
+
+		var proto = HomeMarkPointNotifyOuterClass.HomeMarkPointNotify.newBuilder();
+
+
+		this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeMarkPointNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeMarkPointNotify.java
@@ -12,13 +12,16 @@ import java.util.Collection;
 
 public class PacketHomeMarkPointNotify extends BasePacket {
 
-	public PacketHomeMarkPointNotify(Player player, GameHome home) {
+	public PacketHomeMarkPointNotify(Player player) {
 		super(PacketOpcodes.HomeMarkPointNotify);
 
 		var proto = HomeMarkPointNotifyOuterClass.HomeMarkPointNotify.newBuilder();
 
+		if(player.getRealmList() == null){
+			return;
+		}
 		for(var moduleId : player.getRealmList()){
-			var homeScene = home.getHomeSceneItem(moduleId + 2000);
+			var homeScene = player.getHome().getHomeSceneItem(moduleId + 2000);
 
 			var markPointData = HomeMarkPointSceneDataOuterClass.HomeMarkPointSceneData.newBuilder()
 					.setModuleId(moduleId)

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeSceneInitFinishRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeSceneInitFinishRsp.java
@@ -1,0 +1,17 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.HomeSceneArrangementInfoOuterClass;
+
+public class PacketHomeSceneInitFinishRsp extends BasePacket {
+
+	public PacketHomeSceneInitFinishRsp() {
+		super(PacketOpcodes.HomeSceneInitFinishRsp);
+
+		var proto = HomeSceneArrangementInfoOuterClass.HomeSceneArrangementInfo.newBuilder();
+
+		this.setData(proto);
+
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeSceneInitFinishRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeSceneInitFinishRsp.java
@@ -3,13 +3,14 @@ package emu.grasscutter.server.packet.send;
 import emu.grasscutter.net.packet.BasePacket;
 import emu.grasscutter.net.packet.PacketOpcodes;
 import emu.grasscutter.net.proto.HomeSceneArrangementInfoOuterClass;
+import emu.grasscutter.net.proto.HomeSceneInitFinishReqOuterClass;
 
 public class PacketHomeSceneInitFinishRsp extends BasePacket {
 
 	public PacketHomeSceneInitFinishRsp() {
 		super(PacketOpcodes.HomeSceneInitFinishRsp);
 
-		var proto = HomeSceneArrangementInfoOuterClass.HomeSceneArrangementInfo.newBuilder();
+		var proto = HomeSceneInitFinishReqOuterClass.HomeSceneInitFinishReq.newBuilder();
 
 		this.setData(proto);
 

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeSceneJumpRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeSceneJumpRsp.java
@@ -1,0 +1,18 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.HomeSceneJumpRspOuterClass;
+
+public class PacketHomeSceneJumpRsp extends BasePacket {
+
+	public PacketHomeSceneJumpRsp(boolean enterRoomScene) {
+		super(PacketOpcodes.HomeSceneJumpRsp);
+
+		var proto = HomeSceneJumpRspOuterClass.HomeSceneJumpRsp.newBuilder();
+
+		proto.setIsEnterRoomScene(enterRoomScene);
+
+		this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeUnknown1Notify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeUnknown1Notify.java
@@ -1,0 +1,18 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.HomeUnknown1NotifyOuterClass;
+
+public class PacketHomeUnknown1Notify extends BasePacket {
+
+	public PacketHomeUnknown1Notify(boolean isEnterEditMode) {
+		super(PacketOpcodes.HomeUnknown1Notify);
+
+		var proto = HomeUnknown1NotifyOuterClass.HomeUnknown1Notify.newBuilder();
+
+		proto.setIsEnterEditMode(isEnterEditMode);
+
+		this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeUnknown2Rsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeUnknown2Rsp.java
@@ -1,0 +1,12 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+
+public class PacketHomeUnknown2Rsp extends BasePacket {
+
+	public PacketHomeUnknown2Rsp() {
+		super(PacketOpcodes.HomeUnknown2Rsp);
+
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeUpdateArrangementInfoRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeUpdateArrangementInfoRsp.java
@@ -1,0 +1,12 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+
+public class PacketHomeUpdateArrangementInfoRsp extends BasePacket {
+
+	public PacketHomeUpdateArrangementInfoRsp() {
+		super(PacketOpcodes.HomeUpdateArrangementInfoRsp);
+
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketTakeFurnitureMakeRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketTakeFurnitureMakeRsp.java
@@ -1,0 +1,38 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.data.common.ItemParamData;
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.FurnitureMakeDataOuterClass;
+import emu.grasscutter.net.proto.FurnitureMakeSlotOuterClass;
+import emu.grasscutter.net.proto.ItemParamOuterClass;
+import emu.grasscutter.net.proto.TakeFurnitureMakeRspOuterClass;
+
+import java.util.List;
+
+public class PacketTakeFurnitureMakeRsp extends BasePacket {
+
+	public PacketTakeFurnitureMakeRsp(int ret,
+									  int makeId,
+									  List<ItemParamOuterClass.ItemParam> output,
+									  List<FurnitureMakeDataOuterClass.FurnitureMakeData> others) {
+		super(PacketOpcodes.TakeFurnitureMakeRsp);
+
+		var proto = TakeFurnitureMakeRspOuterClass.TakeFurnitureMakeRsp.newBuilder();
+
+		proto.setRetcode(ret)
+				.setMakeId(makeId);
+
+		if(output != null){
+			proto.addAllOutputItemList(output);
+		}
+
+		if(others != null){
+			proto.setFurnitureMakeSlot(FurnitureMakeSlotOuterClass.FurnitureMakeSlot.newBuilder()
+					.addAllFurnitureMakeDataList(others)
+					.build());
+		}
+
+		this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketUnlockedFurnitureFormulaDataNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketUnlockedFurnitureFormulaDataNotify.java
@@ -1,0 +1,27 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.UnlockedFurnitureFormulaDataNotifyOuterClass;
+
+public class PacketUnlockedFurnitureFormulaDataNotify extends BasePacket {
+
+	public PacketUnlockedFurnitureFormulaDataNotify() {
+		super(PacketOpcodes.UnlockedFurnitureFormulaDataNotify);
+
+		var proto = UnlockedFurnitureFormulaDataNotifyOuterClass.UnlockedFurnitureFormulaDataNotify.newBuilder();
+
+		proto.addFurnitureIdList(361207);
+		proto.addFurnitureIdList(362202);
+		proto.addFurnitureIdList(362304);
+		proto.addFurnitureIdList(363102);
+		proto.addFurnitureIdList(363103);
+		proto.addFurnitureIdList(363203);
+		proto.addFurnitureIdList(370201);
+		proto.addFurnitureIdList(370302);
+
+		proto.setIsAll(true);
+
+		this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketUnlockedFurnitureFormulaDataNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketUnlockedFurnitureFormulaDataNotify.java
@@ -4,22 +4,16 @@ import emu.grasscutter.net.packet.BasePacket;
 import emu.grasscutter.net.packet.PacketOpcodes;
 import emu.grasscutter.net.proto.UnlockedFurnitureFormulaDataNotifyOuterClass;
 
+import java.util.Set;
+
 public class PacketUnlockedFurnitureFormulaDataNotify extends BasePacket {
 
-	public PacketUnlockedFurnitureFormulaDataNotify() {
+	public PacketUnlockedFurnitureFormulaDataNotify(Set<Integer> unlockList) {
 		super(PacketOpcodes.UnlockedFurnitureFormulaDataNotify);
 
 		var proto = UnlockedFurnitureFormulaDataNotifyOuterClass.UnlockedFurnitureFormulaDataNotify.newBuilder();
 
-		proto.addFurnitureIdList(361207);
-		proto.addFurnitureIdList(362202);
-		proto.addFurnitureIdList(362304);
-		proto.addFurnitureIdList(363102);
-		proto.addFurnitureIdList(363103);
-		proto.addFurnitureIdList(363203);
-		proto.addFurnitureIdList(370201);
-		proto.addFurnitureIdList(370302);
-
+		proto.addAllFurnitureIdList(unlockList);
 		proto.setIsAll(true);
 
 		this.setData(proto);

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketUnlockedFurnitureSuiteDataNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketUnlockedFurnitureSuiteDataNotify.java
@@ -1,0 +1,21 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.UnlockedFurnitureSuiteDataNotifyOuterClass;
+
+import java.util.Set;
+
+public class PacketUnlockedFurnitureSuiteDataNotify extends BasePacket {
+
+	public PacketUnlockedFurnitureSuiteDataNotify(Set<Integer> unlockList) {
+		super(PacketOpcodes.UnlockedFurnitureSuiteDataNotify);
+
+		var proto = UnlockedFurnitureSuiteDataNotifyOuterClass.UnlockedFurnitureSuiteDataNotify.newBuilder();
+
+		proto.addAllFurnitureSuiteIdList(unlockList);
+		proto.setIsAll(true);
+
+		this.setData(proto);
+	}
+}


### PR DESCRIPTION
## Description

Implement the Home System (Serenitea Pot)

- [x] Support players to open the home world edit mode and save their arrangement
  - [x] Persist the home arrangement into DB
  - [x] Load default home arrangement save from bin output
  - [x] Implement the MapMark of the home world (only support the teleport point)
  - [x] Support NPC/Animals spawn
  - [x] Enter the room scene
  - [x] Furniture Suite
- [x] Support furniture items in ItemData
  - [x] home coin (204) and pay in the shop
  - [x] furniture unlock and make
- [x] Update morphia to 2.2.7 and fix the persistence of the list


Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.