### PR TITLE
Follow the official server's protocol for clearing energy on burst.

### DIFF
--- a/src/main/java/emu/grasscutter/game/entity/EntityAvatar.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityAvatar.java
@@ -16,6 +16,7 @@ import emu.grasscutter.net.proto.AbilityControlBlockOuterClass.AbilityControlBlo
 import emu.grasscutter.net.proto.AbilityEmbryoOuterClass.AbilityEmbryo;
 import emu.grasscutter.net.proto.AbilitySyncStateInfoOuterClass.AbilitySyncStateInfo;
 import emu.grasscutter.net.proto.AnimatorParameterValueInfoPairOuterClass.AnimatorParameterValueInfoPair;
+import emu.grasscutter.net.proto.ChangeEnergyReasonOuterClass.ChangeEnergyReason;
 import emu.grasscutter.net.proto.ChangeHpReasonOuterClass.ChangeHpReason;
 import emu.grasscutter.net.proto.EntityAuthorityInfoOuterClass.EntityAuthorityInfo;
 import emu.grasscutter.net.proto.EntityClientDataOuterClass.EntityClientData;
@@ -31,6 +32,7 @@ import emu.grasscutter.net.proto.SceneEntityInfoOuterClass.SceneEntityInfo;
 import emu.grasscutter.net.proto.VectorOuterClass.Vector;
 import emu.grasscutter.server.packet.send.PacketAvatarFightPropUpdateNotify;
 import emu.grasscutter.server.packet.send.PacketEntityFightPropChangeReasonNotify;
+import emu.grasscutter.server.packet.send.PacketEntityFightPropUpdateNotify;
 import emu.grasscutter.utils.Position;
 import emu.grasscutter.utils.ProtoHelper;
 import emu.grasscutter.utils.Utils;
@@ -108,13 +110,13 @@ public class EntityAvatar extends GameEntity {
 	public void onDeath(int killerId) {
 		this.killedType = PlayerDieType.PLAYER_DIE_TYPE_KILL_BY_MONSTER;
 		this.killedBy = killerId;
-		clearEnergy(PropChangeReason.PROP_CHANGE_REASON_STATUE_RECOVER);
+		clearEnergy(ChangeEnergyReason.CHANGE_ENERGY_REASON_NONE);
 	}
 
 	public void onDeath(PlayerDieType dieType, int killerId) {
 		this.killedType = dieType;
 		this.killedBy = killerId;
-		clearEnergy(PropChangeReason.PROP_CHANGE_REASON_STATUE_RECOVER);
+		clearEnergy(ChangeEnergyReason.CHANGE_ENERGY_REASON_NONE);
 	}
 	
 	@Override
@@ -130,14 +132,25 @@ public class EntityAvatar extends GameEntity {
 		return healed;
 	}
 	
-	public void clearEnergy(PropChangeReason reason) {
+	public void clearEnergy(ChangeEnergyReason reason) {
+		// Fight props.
 		FightProperty curEnergyProp = this.getAvatar().getSkillDepot().getElementType().getCurEnergyProp();
-		this.avatar.setCurrentEnergy(curEnergyProp, 0);
-			
-		this.getScene().broadcastPacket(new PacketAvatarFightPropUpdateNotify(this.getAvatar(), curEnergyProp));
-		this.getScene().broadcastPacket(new PacketEntityFightPropChangeReasonNotify(this, curEnergyProp, 0f, reason));
-	}
+		FightProperty maxEnergyProp = this.getAvatar().getSkillDepot().getElementType().getMaxEnergyProp();
 
+		// Get max energy.
+		float maxEnergy = this.avatar.getFightProperty(maxEnergyProp);
+
+		// Set energy to zero.
+		this.avatar.setCurrentEnergy(curEnergyProp, 0);
+
+		// Send packets.
+		this.getScene().broadcastPacket(new PacketEntityFightPropUpdateNotify(this, curEnergyProp));
+
+		if (reason != ChangeEnergyReason.CHANGE_ENERGY_REASON_NONE) {
+			this.getScene().broadcastPacket(new PacketEntityFightPropChangeReasonNotify(this, curEnergyProp, -maxEnergy, reason));
+		}
+	}
+	
 	public void addEnergy(float amount, PropChangeReason reason) {
 		this.addEnergy(amount, reason, false);
 	}

--- a/src/main/java/emu/grasscutter/game/entity/EntityAvatar.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityAvatar.java
@@ -146,7 +146,7 @@ public class EntityAvatar extends GameEntity {
 		// Send packets.
 		this.getScene().broadcastPacket(new PacketEntityFightPropUpdateNotify(this, curEnergyProp));
 
-		if (reason != ChangeEnergyReason.CHANGE_ENERGY_REASON_NONE) {
+		if (reason == ChangeEnergyReason.CHANGE_ENERGY_REASON_SKILL_START) {
 			this.getScene().broadcastPacket(new PacketEntityFightPropChangeReasonNotify(this, curEnergyProp, -maxEnergy, reason));
 		}
 	}

--- a/src/main/java/emu/grasscutter/game/managers/EnergyManager/EnergyManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/EnergyManager/EnergyManager.java
@@ -22,6 +22,7 @@ import emu.grasscutter.net.proto.AbilityActionGenerateElemBallOuterClass.Ability
 import emu.grasscutter.net.proto.AbilityIdentifierOuterClass.AbilityIdentifier;
 import emu.grasscutter.net.proto.AbilityInvokeEntryOuterClass.AbilityInvokeEntry;
 import emu.grasscutter.net.proto.AttackResultOuterClass.AttackResult;
+import emu.grasscutter.net.proto.ChangeEnergyReasonOuterClass.ChangeEnergyReason;
 import emu.grasscutter.net.proto.EvtBeingHitInfoOuterClass.EvtBeingHitInfo;
 import emu.grasscutter.net.proto.PropChangeReasonOuterClass.PropChangeReason;
 import emu.grasscutter.server.game.GameSession;
@@ -334,7 +335,7 @@ public class EnergyManager {
 
         // If the cast skill was a burst, consume energy.
         if (avatar.getSkillDepot() != null && skillId == avatar.getSkillDepot().getEnergySkill()) {
-            avatar.getAsEntity().clearEnergy(PropChangeReason.PROP_CHANGE_REASON_ABILITY);
+            avatar.getAsEntity().clearEnergy(ChangeEnergyReason.CHANGE_ENERGY_REASON_SKILL_START);
         }
     }
 

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketEntityFightPropChangeReasonNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketEntityFightPropChangeReasonNotify.java
@@ -4,6 +4,7 @@ import emu.grasscutter.game.entity.GameEntity;
 import emu.grasscutter.game.props.FightProperty;
 import emu.grasscutter.net.packet.BasePacket;
 import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.ChangeEnergyReasonOuterClass.ChangeEnergyReason;
 import emu.grasscutter.net.proto.ChangeHpReasonOuterClass.ChangeHpReason;
 import emu.grasscutter.net.proto.EntityFightPropChangeReasonNotifyOuterClass.EntityFightPropChangeReasonNotify;
 import emu.grasscutter.net.proto.PropChangeReasonOuterClass.PropChangeReason;
@@ -51,6 +52,19 @@ public class PacketEntityFightPropChangeReasonNotify extends BasePacket {
                 .setPropType(prop.getId())
                 .setPropDelta(value)
                 .setReason(reason)
+                .build();
+        
+        this.setData(proto);
+    }
+
+    public PacketEntityFightPropChangeReasonNotify(GameEntity entity, FightProperty prop, Float value, ChangeEnergyReason reason) {
+        super(PacketOpcodes.EntityFightPropChangeReasonNotify);
+        
+        EntityFightPropChangeReasonNotify proto = EntityFightPropChangeReasonNotify.newBuilder()
+                .setEntityId(entity.getId())
+                .setPropType(prop.getId())
+                .setPropDelta(value)
+                .setChangeEnergyReson(reason)
                 .build();
         
         this.setData(proto);


### PR DESCRIPTION
## Description

This PR adapts the protocol used to clear energy to what the official server seems to be doing. Changes:
- Send `EntitiyFightPropUpdateNotify` instead of `AvatarFightPropUpdateNotify` on energy clear.
- Send `EntityFightPropChangeReasonNotify` with energy change reason `CHANGE_ENERGY_REASON_SKILL_START` when clearing energy due to burst cast.

## Issues fixed by this PR

## Type of changes

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.