### PR TITLE
Fix giveall and givechar giving broken characters.

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/GiveAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveAllCommand.java
@@ -1,5 +1,6 @@
 package emu.grasscutter.command.commands;
 
+import emu.grasscutter.GameConstants;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.command.Command;
 import emu.grasscutter.command.CommandHandler;
@@ -52,9 +53,26 @@ public final class GiveAllCommand implements CommandHandler {
             Avatar avatar = new Avatar(avatarData);
             avatar.setLevel(90);
             avatar.setPromoteLevel(6);
+
+            // Add constellations.
+            int talentBase = switch (avatar.getAvatarId()) {
+                case 10000005   -> 70;
+                case 10000006   -> 40;
+                default         -> (avatar.getAvatarId()-10000000)*10;
+            };
+
             for(int i = 1;i <= 6;++i){
-                avatar.getTalentIdList().add((avatar.getAvatarId()-10000000)*10+i);
+                avatar.getTalentIdList().add(talentBase + i);
             }
+
+            // Handle skill depot for traveller.
+            if (avatar.getAvatarId() == GameConstants.MAIN_CHARACTER_MALE) {
+                avatar.setSkillDepotData(GameData.getAvatarSkillDepotDataMap().get(504));
+            }
+            else if(avatar.getAvatarId() == GameConstants.MAIN_CHARACTER_FEMALE) {
+                avatar.setSkillDepotData(GameData.getAvatarSkillDepotDataMap().get(704));
+            }
+
             // This will handle stats and talents
             avatar.recalcStats();
             // Don't try to add each avatar to the current team

--- a/src/main/java/emu/grasscutter/command/commands/GiveCharCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveCharCommand.java
@@ -1,5 +1,6 @@
 package emu.grasscutter.command.commands;
 
+import emu.grasscutter.GameConstants;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.command.Command;
 import emu.grasscutter.command.CommandHandler;
@@ -67,6 +68,14 @@ public final class GiveCharCommand implements CommandHandler {
         Avatar avatar = new Avatar(avatarId);
         avatar.setLevel(level);
         avatar.setPromoteLevel(ascension);
+
+        // Handle skill depot for traveller.
+        if (avatar.getAvatarId() == GameConstants.MAIN_CHARACTER_MALE) {
+            avatar.setSkillDepotData(GameData.getAvatarSkillDepotDataMap().get(504));
+        }
+        else if(avatar.getAvatarId() == GameConstants.MAIN_CHARACTER_FEMALE) {
+            avatar.setSkillDepotData(GameData.getAvatarSkillDepotDataMap().get(704));
+        }
 
         // This will handle stats and talents
         avatar.recalcStats();


### PR DESCRIPTION
## Description

Currently, both `/giveall` and `/givechar` can give broken characters in some cases.

Both Lisa as well as the additional Traveller copy given by `/giveall` have zero HP, attack and defense, effectively rendering them unusable. This is caused by `/giveall` giving them incorrect talent (constellation) ids. The simple logic `/giveall` uses to determine talent ids (`(avatar id - 10000000) * 10 + talent index`) works for all characters, except Lisa and Traveller. This is fixed by adding special cases for those characters.

Both `/giveall` and `/givechar` also give Travellers with incorrect skill depot (the commands simply assign the default skill depot, which for Traveller is useless). This is fixed by explicitly handling Traveller and adding the Anemo skill depot.

(Figuring out the original cause of this bug took me way longer than I want to admit ...)

## Issues fixed by this PR

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.