### PR TITLE
Add "unlocked" to "/clear" arguments

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/ClearCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ClearCommand.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "clear", usage = "clear <all|wp|art|mat>", //Merged /clearartifacts and /clearweapons to /clear <args> [uid]
+@Command(label = "clear", usage = "clear <all|wp|art|mat|unlocked>", //Merged /clearartifacts and /clearweapons to /clear <args> [uid]
         description = "commands.clear.description",
         aliases = {"clear"}, permission = "player.clearinv", permissionTargeted = "player.clearinv.others")
 
@@ -50,6 +50,21 @@ public final class ClearCommand implements CommandHandler {
                         .filter(item -> !item.isLocked() && !item.isEquipped())
                         .toList();
                 CommandHandler.sendMessage(sender, translate(sender, "commands.clear.materials", targetPlayer.getNickname()));
+            }
+            case "unlocked" -> {
+                 toDelete = playerInventory.getItems().values().stream()
+                        .filter(item1 -> item1.getItemType() == ItemType.ITEM_WEAPON)
+                        .filter(item1 -> !item1.isLocked() && !item1.isEquipped())
+                        .toList();
+                playerInventory.removeItems(toDelete);
+
+                toDelete = playerInventory.getItems().values().stream()
+                        .filter(item2 -> item2.getItemType() == ItemType.ITEM_RELIQUARY)
+                        .filter(item2 -> item2.getLevel() >= 1 && item2.getExp() >= 0)
+                        .filter(item2 -> !item2.isLocked() && !item2.isEquipped())
+                        .toList();
+                playerInventory.removeItems(toDelete);
+                CommandHandler.sendMessage(sender, translate(sender, "commands.clear.unlocked", targetPlayer.getNickname()));
             }
             case "all" -> {
             	toDelete = playerInventory.getItems().values().stream()

--- a/src/main/resources/languages/en-US.json
+++ b/src/main/resources/languages/en-US.json
@@ -125,13 +125,14 @@
       "description": "Changes your scene"
     },
     "clear": {
-      "command_usage": "Usage: clear <all|wp|art|mat>",
+      "command_usage": "Usage: clear <all|wp|art|mat|unlocked>",
       "weapons": "Cleared weapons for %s.",
       "artifacts": "Cleared artifacts for %s.",
       "materials": "Cleared materials for %s.",
       "furniture": "Cleared furniture for %s.",
       "displays": "Cleared displays for %s.",
       "virtuals": "Cleared virtuals for %s.",
+      "unlocked": "Cleared unlocked weapons and artifacts for %s.",
       "everything": "Cleared everything for %s.",
       "description": "Deletes unequipped unlocked items, including yellow rarity ones from your inventory"
     },


### PR DESCRIPTION
## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR

Added "unlocked" argument in ClearCommand to target unlocked artifacts and weapons regardless of level
<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.