### PR TITLE
Fix talent material cannot be added when wish

### DIFF
--- a/src/main/java/emu/grasscutter/game/inventory/Inventory.java
+++ b/src/main/java/emu/grasscutter/game/inventory/Inventory.java
@@ -215,7 +215,26 @@ public class Inventory implements Iterable<GameItem> {
 				getPlayer().addNameCard(item.getItemId());
 			}
 			return null;
-		} else if (tab != null) {
+		} else if (item.getItemData().getMaterialType() == MaterialType.MATERIAL_TALENT) {
+            if (tab == null) {
+                return null;
+            }
+            GameItem existingTalent = tab.getItemById(item.getItemId());
+            if (existingTalent == null) {
+                if (tab.getSize() >= tab.getMaxCapacity()) {
+                    return null;
+                }
+                this.putItem(item, tab);
+            } else {
+                if (existingTalent.getCount() <= 5) {
+                    existingTalent.setCount(Math.min(existingTalent.getCount() + item.getCount(), 6));
+                    existingTalent.save();
+                    return existingTalent;
+                } else {
+                    return null;
+                }
+            }
+        } else if (tab != null) {
 			GameItem existingItem = tab.getItemById(item.getItemId());
 			if (existingItem == null) {
 				// Item type didnt exist before, we will add it to main inventory map if there is enough space


### PR DESCRIPTION
## Description

Fix when more than two duplicate characters are drawn in wish, the talent material of the character will not increase.
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.