### PR TITLE
Add default ClimateTypes per weather

### DIFF
--- a/src/main/java/emu/grasscutter/command/CommandMap.java
+++ b/src/main/java/emu/grasscutter/command/CommandMap.java
@@ -156,7 +156,7 @@ public final class CommandMap {
                         CommandHandler.sendTranslatedMessage(player, targetPlayer.isOnline()? "commands.execution.set_target_online" : "commands.execution.set_target_offline", targetUidStr);
                     }
                 } catch (NumberFormatException e) {
-                    CommandHandler.sendTranslatedMessage(player, "commands.execution.uid_error");
+                    CommandHandler.sendTranslatedMessage(player, "commands.generic.invalid.uid");
                 }
             }
             return;
@@ -183,7 +183,7 @@ public final class CommandMap {
                     }
                     break;
                 } catch (NumberFormatException e) {
-                    CommandHandler.sendTranslatedMessage(player, "commands.execution.uid_error");
+                    CommandHandler.sendTranslatedMessage(player, "commands.generic.invalid.uid");
                     return;
                 }
             }

--- a/src/main/java/emu/grasscutter/command/commands/CoopCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/CoopCommand.java
@@ -31,7 +31,7 @@ public final class CoopCommand implements CommandHandler {
                     }
                     break;
                 } catch (NumberFormatException ignored) {
-                    CommandHandler.sendMessage(sender, translate(sender, "commands.execution.uid_error"));
+                    CommandHandler.sendMessage(sender, translate(sender, "commands.generic.invalid.uid"));
                     return;
                 }
             default:

--- a/src/main/java/emu/grasscutter/command/commands/WeatherCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/WeatherCommand.java
@@ -1,47 +1,45 @@
 package emu.grasscutter.command.commands;
 
-import emu.grasscutter.Grasscutter;
 import emu.grasscutter.command.Command;
 import emu.grasscutter.command.CommandHandler;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.ClimateType;
-import emu.grasscutter.server.packet.send.PacketSceneAreaWeatherNotify;
+import emu.grasscutter.game.world.Scene;
 
 import java.util.List;
 
-import static emu.grasscutter.utils.Language.translate;
-
-@Command(label = "weather", usage = "weather <climate type(weatherId)> <weather type(climateId)>", aliases = {"w"}, permission = "player.weather", permissionTargeted = "player.weather.others", description = "commands.weather.description")
+@Command(label = "weather", usage = "weather [weatherId] [climateType]", aliases = {"w"}, permission = "player.weather", permissionTargeted = "player.weather.others", description = "commands.weather.description")
 public final class WeatherCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        int weatherId = 0;
-        int climateId = 1;
-        switch (args.size()) {
-            case 2:
-                try {
-                    climateId = Integer.parseInt(args.get(1));
-                } catch (NumberFormatException ignored) {
-                        CommandHandler.sendMessage(sender, translate(sender, "commands.weather.invalid_id"));
-                }
-            case 1:
-                try {
-                    weatherId = Integer.parseInt(args.get(0));
-                } catch (NumberFormatException ignored) {
-                    CommandHandler.sendMessage(sender, translate(sender, "commands.weather.invalid_id"));
-                }
-                break;
-            default:
-                CommandHandler.sendMessage(sender, translate(sender, "commands.weather.usage"));
-                return;
+        Scene scene = targetPlayer.getScene();
+        int weatherId = scene.getWeather();
+        ClimateType climate = ClimateType.CLIMATE_NONE;  // Sending ClimateType.CLIMATE_NONE to Scene.setWeather will use the default climate for that weather
+
+        if (args.isEmpty()) {
+            climate = scene.getClimate();
+            CommandHandler.sendTranslatedMessage(sender, "commands.weather.status", Integer.toString(weatherId), climate.getShortName());
+            return;
         }
 
-        ClimateType climate = ClimateType.getTypeByValue(climateId);
+        for (String arg : args) {
+            ClimateType c = ClimateType.getTypeByShortName(arg.toLowerCase());
+            if (c != ClimateType.CLIMATE_NONE) {
+                climate = c;
+            } else {
+                try {
+                    weatherId = Integer.parseInt(arg);
+                } catch (NumberFormatException ignored) {
+                    CommandHandler.sendTranslatedMessage(sender, "commands.generic.invalid.id");
+                    CommandHandler.sendTranslatedMessage(sender, "commands.weather.usage");
+                    return;
+                }
+            }
+        }
 
-        targetPlayer.getScene().setWeather(weatherId);
-        targetPlayer.getScene().setClimate(climate);
-        targetPlayer.getScene().broadcastPacket(new PacketSceneAreaWeatherNotify(targetPlayer));
-        CommandHandler.sendMessage(sender, translate(sender, "commands.weather.success", Integer.toString(weatherId), Integer.toString(climateId)));
+        scene.setWeather(weatherId, climate);
+        climate = scene.getClimate();  // Might be different to what we set
+        CommandHandler.sendTranslatedMessage(sender, "commands.weather.success", Integer.toString(weatherId), climate.getShortName());
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/WeatherCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/WeatherCommand.java
@@ -13,12 +13,11 @@ public final class WeatherCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        Scene scene = targetPlayer.getScene();
-        int weatherId = scene.getWeather();
+        int weatherId = targetPlayer.getWeatherId();
         ClimateType climate = ClimateType.CLIMATE_NONE;  // Sending ClimateType.CLIMATE_NONE to Scene.setWeather will use the default climate for that weather
 
         if (args.isEmpty()) {
-            climate = scene.getClimate();
+            climate = targetPlayer.getClimate();
             CommandHandler.sendTranslatedMessage(sender, "commands.weather.status", Integer.toString(weatherId), climate.getShortName());
             return;
         }
@@ -38,8 +37,8 @@ public final class WeatherCommand implements CommandHandler {
             }
         }
 
-        scene.setWeather(weatherId, climate);
-        climate = scene.getClimate();  // Might be different to what we set
+        targetPlayer.setWeather(weatherId, climate);
+        climate = targetPlayer.getClimate();  // Might be different to what we set
         CommandHandler.sendTranslatedMessage(sender, "commands.weather.success", Integer.toString(weatherId), climate.getShortName());
     }
 }

--- a/src/main/java/emu/grasscutter/data/GameData.java
+++ b/src/main/java/emu/grasscutter/data/GameData.java
@@ -94,6 +94,7 @@ public class GameData {
 	private static final Int2ObjectMap<FurnitureMakeConfigData> furnitureMakeConfigDataMap = new Int2ObjectOpenHashMap<>();
 	private static final Int2ObjectMap<InvestigationMonsterData> investigationMonsterDataMap = new Int2ObjectOpenHashMap<>();
 	private static final Int2ObjectMap<CityData> cityDataMap = new Int2ObjectOpenHashMap<>();
+	private static final Int2ObjectMap<WeatherData> weatherDataMap = new Int2ObjectOpenHashMap<>();
 	private static final Int2ObjectMap<BattlePassMissionExcelConfigData> battlePassMissionExcelConfigDataMap = new Int2ObjectOpenHashMap<>();
 	private static final Int2ObjectMap<BattlePassRewardExcelConfigData> battlePassRewardExcelConfigDataMap = new Int2ObjectOpenHashMap<>();
 
@@ -414,8 +415,13 @@ public class GameData {
 	public static Int2ObjectMap<InvestigationMonsterData> getInvestigationMonsterDataMap() {
 		return investigationMonsterDataMap;
 	}
+
 	public static Int2ObjectMap<CityData> getCityDataMap() {
 		return cityDataMap;
+	}
+
+	public static Int2ObjectMap<WeatherData> getWeatherDataMap() {
+		return weatherDataMap;
 	}
 
 	public static Int2ObjectMap<BattlePassMissionExcelConfigData> getBattlePassMissionExcelConfigDataMap() {

--- a/src/main/java/emu/grasscutter/data/excels/WeatherData.java
+++ b/src/main/java/emu/grasscutter/data/excels/WeatherData.java
@@ -1,0 +1,26 @@
+package emu.grasscutter.data.excels;
+
+import emu.grasscutter.data.GameResource;
+import emu.grasscutter.data.ResourceType;
+import emu.grasscutter.game.props.ClimateType;
+import lombok.Getter;
+
+@ResourceType(name = "WeatherExcelConfigData.json")
+public class WeatherData extends GameResource {
+    @Getter private int areaID;
+    @Getter private int weatherAreaId;
+    @Getter private String maxHeightStr;
+    @Getter private int gadgetID;
+    @Getter private boolean isDefaultValid;
+    @Getter private String templateName;
+    @Getter private int priority;
+    @Getter private String profileName;
+    @Getter private ClimateType defaultClimate;
+    @Getter private boolean isUseDefault;
+    @Getter private int sceneID;
+    
+    @Override
+    public int getId() {
+        return this.areaID;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/props/ClimateType.java
+++ b/src/main/java/emu/grasscutter/game/props/ClimateType.java
@@ -32,7 +32,11 @@ public enum ClimateType {
 	}
 
 	public int getValue() {
-		return value;
+		return this.value;
+	}
+
+	public String getShortName() {
+		return this.name().substring(8).toLowerCase();
 	}
 	
 	public static ClimateType getTypeByValue(int value) {
@@ -40,6 +44,11 @@ public enum ClimateType {
 	}
 	
 	public static ClimateType getTypeByName(String name) {
+		return stringMap.getOrDefault(name, CLIMATE_NONE);
+	}
+	
+	public static ClimateType getTypeByShortName(String shortName) {
+		String name = "CLIMATE_" + shortName.toUpperCase();
 		return stringMap.getOrDefault(name, CLIMATE_NONE);
 	}
 }

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -45,8 +45,6 @@ public class Scene {
 	
 	private int autoCloseTime;
 	private int time;
-	private ClimateType climate;
-	private int weather;
 	
 	private SceneScriptManager scriptManager;
 	private WorldChallenge challenge;
@@ -61,7 +59,6 @@ public class Scene {
 		this.entities = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
 
 		this.time = 8 * 60;
-		this.climate = ClimateType.CLIMATE_SUNNY;
 		this.prevScene = 3;
 		
 		this.spawnedEntities = new HashSet<>();
@@ -128,40 +125,6 @@ public class Scene {
 
 	public void changeTime(int time) {
 		this.time = time % 1440;
-	}
-	
-	public ClimateType getClimate() {
-		return climate;
-	}
-
-	public int getWeather() {
-		return weather;
-	}
-
-	synchronized public void setClimate(ClimateType climate) {
-		this.climate = climate;
-		for (Player player : this.players) {
-			this.broadcastPacket(new PacketSceneAreaWeatherNotify(player));
-		}
-	}
-
-	synchronized public void setWeather(int weather) {
-		this.setWeather(weather, ClimateType.CLIMATE_NONE);
-	}
-
-	synchronized public void setWeather(int weather, ClimateType climate) {
-		// Lookup default climate for this weather
-		if (climate == ClimateType.CLIMATE_NONE) {
-			WeatherData w = GameData.getWeatherDataMap().get(weather);
-			if (w != null) {
-				climate = w.getDefaultClimate();
-			}
-		}
-		this.weather = weather;
-		this.climate = climate;
-		for (Player player : this.players) {
-			this.broadcastPacket(new PacketSceneAreaWeatherNotify(player));
-		}
 	}
 
 	public int getPrevScene() {

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -138,12 +138,30 @@ public class Scene {
 		return weather;
 	}
 
-	public void setClimate(ClimateType climate) {
+	synchronized public void setClimate(ClimateType climate) {
 		this.climate = climate;
+		for (Player player : this.players) {
+			this.broadcastPacket(new PacketSceneAreaWeatherNotify(player));
+		}
 	}
 
-	public void setWeather(int weather) {
+	synchronized public void setWeather(int weather) {
+		this.setWeather(weather, ClimateType.CLIMATE_NONE);
+	}
+
+	synchronized public void setWeather(int weather, ClimateType climate) {
+		// Lookup default climate for this weather
+		if (climate == ClimateType.CLIMATE_NONE) {
+			WeatherData w = GameData.getWeatherDataMap().get(weather);
+			if (w != null) {
+				climate = w.getDefaultClimate();
+			}
+		}
 		this.weather = weather;
+		this.climate = climate;
+		for (Player player : this.players) {
+			this.broadcastPacket(new PacketSceneAreaWeatherNotify(player));
+		}
 	}
 
 	public int getPrevScene() {

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketSceneAreaWeatherNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketSceneAreaWeatherNotify.java
@@ -12,8 +12,8 @@ public class PacketSceneAreaWeatherNotify extends BasePacket {
 		super(PacketOpcodes.SceneAreaWeatherNotify);
 		
 		SceneAreaWeatherNotify proto = SceneAreaWeatherNotify.newBuilder()
-				.setWeatherAreaId(player.getScene().getWeather())
-				.setClimateType(player.getScene().getClimate().getValue())
+				.setWeatherAreaId(player.getWeatherId())
+				.setClimateType(player.getClimate().getValue())
 				.build();
 		
 		this.setData(proto);

--- a/src/main/resources/languages/en-US.json
+++ b/src/main/resources/languages/en-US.json
@@ -385,7 +385,7 @@
       "description": "Unlock all levels of tower"
     },
     "weather": {
-      "description": "Changes the weather. Climate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "description": "Changes weather ID and climate type. Weather IDs can be found in WeatherExcelConfigData.json. Climate types: sunny, cloudy, rain, thunderstorm, snow, mist",
       "usage": "Usage: weather [weatherId] [climateType]\nClimate types sunny, cloudy, rain, thunderstorm, snow, mist.",
       "success": "Set weather ID to %s with climate type %s.",
       "status": "Current weather ID is %s with climate type %s."

--- a/src/main/resources/languages/en-US.json
+++ b/src/main/resources/languages/en-US.json
@@ -81,12 +81,9 @@
       }
     },
     "execution": {
-      "uid_error": "Invalid UID.",
       "player_exist_error": "Player not found.",
       "player_offline_error": "Player is not online.",
-      "item_id_error": "Invalid item ID.",
       "item_player_exist_error": "Invalid item or UID.",
-      "entity_id_error": "Invalid entity ID.",
       "player_exist_offline_error": "Player not found or is not online.",
       "argument_error": "Invalid arguments.",
       "clear_target": "Target cleared.",

--- a/src/main/resources/languages/en-US.json
+++ b/src/main/resources/languages/en-US.json
@@ -76,7 +76,8 @@
         "itemLevel": "Invalid itemLevel.",
         "itemRefinement": "Invalid itemRefinement.",
         "playerId": "Invalid player ID.",
-        "uid": "Invalid UID."
+        "uid": "Invalid UID.",
+        "id": "Invalid ID."
       }
     },
     "execution": {
@@ -387,10 +388,10 @@
       "description": "Unlock all levels of tower"
     },
     "weather": {
-      "usage": "Usage: weather <climate type(weatherId)> <weather type(climateId)>\nWeather types 0: None, 1: Sunny, 2: Cloudy, 3: Rain, 4: Thunderstorm, 5: Snow, 6: Mist",
-      "success": "Changed climate type to %s with weather type %s.",
-      "invalid_id": "Invalid ID.",
-      "description": "Changes the weather"
+      "description": "Changes the weather. Climate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "usage": "Usage: weather [weatherId] [climateType]\nClimate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "success": "Set weather ID to %s with climate type %s.",
+      "status": "Current weather ID is %s with climate type %s."
     },
     "ban": {
       "description": "Ban a player",

--- a/src/main/resources/languages/en-US.json
+++ b/src/main/resources/languages/en-US.json
@@ -385,8 +385,8 @@
       "description": "Unlock all levels of tower"
     },
     "weather": {
-      "description": "Changes weather ID and climate type. Weather IDs can be found in WeatherExcelConfigData.json. Climate types: sunny, cloudy, rain, thunderstorm, snow, mist",
-      "usage": "Usage: weather [weatherId] [climateType]\nClimate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "description": "Changes weather ID and climate type. Weather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny, cloudy, rain, thunderstorm, snow, mist",
+      "usage": "Usage: weather [weatherId] [climateType]\nWeather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny, cloudy, rain, thunderstorm, snow, mist.",
       "success": "Set weather ID to %s with climate type %s.",
       "status": "Current weather ID is %s with climate type %s."
     },

--- a/src/main/resources/languages/fr-FR.json
+++ b/src/main/resources/languages/fr-FR.json
@@ -76,7 +76,8 @@
           "itemLevel": "Niveau de l'objet invalide.",
           "itemRefinement": "Raffinement de l'objet invalide.",
           "playerId": "ID du joueur invalide.",
-          "uid": "UID invalide."
+          "uid": "UID invalide.",
+          "id": "ID invalide."
         }
       },
       "execution": {
@@ -387,10 +388,10 @@
         "description": "Débloque tous les couloirs de l'abysse"
       },
       "weather": {
-        "usage": "Usage: weather <climate type(weatherId)> <weather type(climateId)>\nTypes de météo 0: Aucun, 1: Ensoleillé, 2: Nuageux, 3: Pluvieux, 4: Orageux, 5: Neige, 6: Brouillard",
-        "success": "Le type de climat a été changé à %s avec le type de météo %s.",
-        "invalid_id": "ID invalide.",
-        "description": "Change la météo"
+        "description": "Change la météo. Climate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+        "usage": "Utilisation: weather [weatherId] [climateType]\nClimate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+        "success": "Set weather ID to %s with climate type %s.",
+        "status": "Current weather ID is %s with climate type %s."
       },
       "ban": {
         "description": "Bannis un joueur",

--- a/src/main/resources/languages/fr-FR.json
+++ b/src/main/resources/languages/fr-FR.json
@@ -81,12 +81,9 @@
         }
       },
       "execution": {
-        "uid_error": "UID invalide.",
         "player_exist_error": "Joueur introuvable.",
         "player_offline_error": "Le joueur n'est pas connecté.",
-        "item_id_error": "ID de l'objet invalide.",
         "item_player_exist_error": "UID ou objet invalide.",
-        "entity_id_error": "ID de l'entité invalide.",
         "player_exist_offline_error": "Le joueur est introuvable ou n'est pas connecté.",
         "argument_error": "Arguments invalides.",
         "clear_target": "Cible réinitialisée.",

--- a/src/main/resources/languages/fr-FR.json
+++ b/src/main/resources/languages/fr-FR.json
@@ -385,8 +385,8 @@
         "description": "Débloque tous les couloirs de l'abysse"
       },
       "weather": {
-        "description": "Change la météo. Climate types sunny, cloudy, rain, thunderstorm, snow, mist.",
-        "usage": "Utilisation: weather [weatherId] [climateType]\nClimate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+        "description": "Change la météo. Weather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny, cloudy, rain, thunderstorm, snow, mist.",
+        "usage": "Utilisation: weather [weatherId] [climateType]\nWeather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny, cloudy, rain, thunderstorm, snow, mist.",
         "success": "Set weather ID to %s with climate type %s.",
         "status": "Current weather ID is %s with climate type %s."
       },

--- a/src/main/resources/languages/pl-PL.json
+++ b/src/main/resources/languages/pl-PL.json
@@ -75,12 +75,9 @@
       }
     },
     "execution": {
-      "uid_error": "Błędne UID.",
       "player_exist_error": "Gracz nie znaleziony.",
       "player_offline_error": "Gracz nie jest online.",
-      "item_id_error": "Błędne ID przedmiotu.",
       "item_player_exist_error": "Błędny przedmiot lub UID.",
-      "entity_id_error": "Błędne ID obiektu.",
       "player_exist_offline_error": "Gracz nie znaleziony lub jest offline.",
       "argument_error": "Błędne argumenty.",
       "clear_target": "Cel wyczyszczony.",

--- a/src/main/resources/languages/pl-PL.json
+++ b/src/main/resources/languages/pl-PL.json
@@ -70,7 +70,8 @@
         "itemLevel": "Błędny poziom przedmiotu.",
         "itemRefinement": "Błędne ulepszenie.",
         "playerId": "Błędne playerId.",
-        "uid": "Błędne UID."
+        "uid": "Błędne UID.",
+        "id": "Błędne ID."
       }
     },
     "execution": {
@@ -291,9 +292,10 @@
       "success": "Przeteleportowano %s do %s, %s, %s w scenie %s"
     },
     "weather": {
-      "usage": "Użycie: weather <climate type(weatherId)> <weather type(climateId)>\nWeather types 0: None, 1: Sunny, 2: Cloudy, 3: Rain, 4: Thunderstorm, 5: Snow, 6: Mist",
-      "success": "Changed climate type to %s with weather type %s.",
-      "invalid_id": "Błędne ID."
+      "description": "Changes the weather. Climate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "usage": "Usage: weather [weatherId] [climateType]\nClimate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "success": "Set weather ID to %s with climate type %s.",
+      "status": "Current weather ID is %s with climate type %s."
     },
     "drop": {
       "command_usage": "Użycie: drop <ID przedmiotu|nazwa przedmiotu> [ilość]",

--- a/src/main/resources/languages/pl-PL.json
+++ b/src/main/resources/languages/pl-PL.json
@@ -289,8 +289,8 @@
       "success": "Przeteleportowano %s do %s, %s, %s w scenie %s"
     },
     "weather": {
-      "description": "Changes the weather. Climate types sunny, cloudy, rain, thunderstorm, snow, mist.",
-      "usage": "Usage: weather [weatherId] [climateType]\nClimate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "description": "Changes the weather.Weather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "usage": "Usage: weather [weatherId] [climateType]\nWeather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny, cloudy, rain, thunderstorm, snow, mist.",
       "success": "Set weather ID to %s with climate type %s.",
       "status": "Current weather ID is %s with climate type %s."
     },

--- a/src/main/resources/languages/ru-RU.json
+++ b/src/main/resources/languages/ru-RU.json
@@ -81,12 +81,9 @@
       }
     },
     "execution": {
-      "uid_error": "Некорректный UID.",
       "player_exist_error": "Игрок не найден.",
       "player_offline_error": "Игрок не в сети.",
-      "item_id_error": "Некорректный ID предмета.",
       "item_player_exist_error": "Некорректный предмет или UID.",
-      "entity_id_error": "Некорректный ID сущности.",
       "player_exist_offline_error": "Игрок не был найден или не в сети.",
       "argument_error": "Некорректные аргументы.",
       "clear_target": "Цель была удалена.",

--- a/src/main/resources/languages/ru-RU.json
+++ b/src/main/resources/languages/ru-RU.json
@@ -385,8 +385,8 @@
       "description": "Открывает все уровни башни"
     },
     "weather": {
-      "description": "Изменяет погоду. Climate types sunny, cloudy, rain, thunderstorm, snow, mist.",
-      "usage": "Usage: weather [weatherId] [climateType]\nClimate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "description": "Изменяет погоду.Weather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "usage": "Usage: weather [weatherId] [climateType]\nWeather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny, cloudy, rain, thunderstorm, snow, mist.",
       "success": "Set weather ID to %s with climate type %s.",
       "status": "Current weather ID is %s with climate type %s."
     },

--- a/src/main/resources/languages/ru-RU.json
+++ b/src/main/resources/languages/ru-RU.json
@@ -76,7 +76,8 @@
         "itemLevel": "Некорректный уровень предмета (itemLevel).",
         "itemRefinement": "Некорректный уровень пробуждения предмета (itemRefinement).",
         "playerId": "Некорректный ID игрока.",
-        "uid": "Некорректный UID."
+        "uid": "Некорректный UID.",
+        "id": "Некорректный ID."
       }
     },
     "execution": {
@@ -387,10 +388,10 @@
       "description": "Открывает все уровни башни"
     },
     "weather": {
-      "usage": "Применение: weather <тип_климата(Id погоды)> <тип_погоды(Id климата)>\nТипы погоды 0: Отсутствует, 1: Солнечная, 2: Пасмурная, 3: Дождливая, 4: Грозовая, 5: Снежная, 6: Туманная",
-      "success": "Тип климата был изменен на %s, тип погоды: %s.",
-      "invalid_id": "Некорректный ID.",
-      "description": "Изменяет погоду"
+      "description": "Изменяет погоду. Climate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "usage": "Usage: weather [weatherId] [climateType]\nClimate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "success": "Set weather ID to %s with climate type %s.",
+      "status": "Current weather ID is %s with climate type %s."
     },
     "ban": {
       "description": "Банит игрока",

--- a/src/main/resources/languages/zh-CN.json
+++ b/src/main/resources/languages/zh-CN.json
@@ -76,7 +76,8 @@
         "itemLevel": "无效的物品等级。",
         "itemRefinement": "无效的物品精炼等级。",
         "playerId": "无效的玩家ID。",
-        "uid": "无效的UID。"
+        "uid": "无效的UID。",
+        "id": "无效的ID。"
       }
     },
     "execution": {
@@ -387,10 +388,10 @@
       "description": "解锁深境螺旋"
     },
     "weather": {
-      "usage": "用法：weather <气候类型(天气ID)> <天气类型(气候ID)>\n天气类型 0: 无, 1: 晴天, 2: 多云, 3: 雨, 4: 雷雨, 5: 雪, 6: 雾",
-      "success": "已更改气候类型为 %s，天气类型为 %s。",
-      "invalid_id": "无效的ID。",
-      "description": "更改天气"
+      "description": "更改天气. Climate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "usage": "用法：weather [weatherId] [climateType]\nClimate types sunny (晴天), cloudy (多云), rain (雨), thunderstorm (雷雨), snow (雪), mist (雾).",
+      "success": "Set weather ID to %s with climate type %s.",
+      "status": "Current weather ID is %s with climate type %s."
     },
     "ban": {
       "description": "封禁玩家",

--- a/src/main/resources/languages/zh-CN.json
+++ b/src/main/resources/languages/zh-CN.json
@@ -81,12 +81,9 @@
       }
     },
     "execution": {
-      "uid_error": "无效的UID。",
       "player_exist_error": "玩家不存在。",
       "player_offline_error": "玩家已离线。",
-      "item_id_error": "无效的物品ID。",
       "item_player_exist_error": "无效的物品/玩家UID。",
-      "entity_id_error": "无效的实体ID。",
       "player_exist_offline_error": "玩家不存在或已离线。",
       "argument_error": "无效的参数。",
       "clear_target": "目标已清除。",

--- a/src/main/resources/languages/zh-CN.json
+++ b/src/main/resources/languages/zh-CN.json
@@ -385,8 +385,8 @@
       "description": "解锁深境螺旋"
     },
     "weather": {
-      "description": "更改天气. Climate types sunny, cloudy, rain, thunderstorm, snow, mist.",
-      "usage": "用法：weather [weatherId] [climateType]\nClimate types sunny (晴天), cloudy (多云), rain (雨), thunderstorm (雷雨), snow (雪), mist (雾).",
+      "description": "更改天气. Weather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "usage": "用法：weather [weatherId] [climateType]\nWeather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny (晴天), cloudy (多云), rain (雨), thunderstorm (雷雨), snow (雪), mist (雾).",
       "success": "Set weather ID to %s with climate type %s.",
       "status": "Current weather ID is %s with climate type %s."
     },

--- a/src/main/resources/languages/zh-TW.json
+++ b/src/main/resources/languages/zh-TW.json
@@ -80,12 +80,9 @@
       }
     },
     "execution": {
-      "uid_error": "無效的UID。",
       "player_exist_error": "用戶不存在。",
       "player_offline_error": "玩家已離線。",
-      "item_id_error": "無效的物品ID。.",
       "item_player_exist_error": "無效的物品/玩家UID。",
-      "entity_id_error": "無效的實體ID。",
       "player_exist_offline_error": "玩家不存在或已離線。",
       "argument_error": "無效的參數。",
       "clear_target": "目標已清除.",

--- a/src/main/resources/languages/zh-TW.json
+++ b/src/main/resources/languages/zh-TW.json
@@ -388,8 +388,8 @@
       "description": "解鎖所有級別的深境螺旋。"
     },
     "weather": {
-      "description": "更改目前的天氣。. Climate types sunny, cloudy, rain, thunderstorm, snow, mist.",
-      "usage": "用法：weather [weatherId] [climateType]\nClimate types sunny (晴天), cloudy (多雲), rain (雨), thunderstorm (雷雨), snow (雪), mist (霧).",
+      "description": "更改目前的天氣。Weather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "usage": "用法：weather [weatherId] [climateType]\nWeather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny (晴天), cloudy (多雲), rain (雨), thunderstorm (雷雨), snow (雪), mist (霧).",
       "success": "Set weather ID to %s with climate type %s.",
       "status": "Current weather ID is %s with climate type %s."
     },

--- a/src/main/resources/languages/zh-TW.json
+++ b/src/main/resources/languages/zh-TW.json
@@ -75,7 +75,8 @@
         "itemLevel": "無效的物品等級。",
         "itemRefinement": "無效的物品精煉度。",
         "playerId": "無效的玩家ID。",
-        "uid": "無效的UID。"
+        "uid": "無效的UID。",
+        "id": "無效的ID。"
       }
     },
     "execution": {
@@ -390,10 +391,10 @@
       "description": "解鎖所有級別的深境螺旋。"
     },
     "weather": {
-      "usage": "用法：weather <氣候型別(weatherId)> <天氣型別(climateId)>\n天氣類型： '0：無、 1：晴天、 2：多雲、 3：雨、 4:：雷雨、 5：雪、 6：霧'",
-      "success": "已將當前氣候設定為 %s ，天氣則為 %s 。",
-      "invalid_id": "無效的ID。",
-      "description": "更改目前的天氣。"
+      "description": "更改目前的天氣。. Climate types sunny, cloudy, rain, thunderstorm, snow, mist.",
+      "usage": "用法：weather [weatherId] [climateType]\nClimate types sunny (晴天), cloudy (多雲), rain (雨), thunderstorm (雷雨), snow (雪), mist (霧).",
+      "success": "Set weather ID to %s with climate type %s.",
+      "status": "Current weather ID is %s with climate type %s."
     },
     "ban": {
       "description": "停權指定玩家。",


### PR DESCRIPTION
## Description
Loads in `WeatherExcelConfigData.json` to get default `ClimateType`s for weather IDs.
Updates `WeatherCommand` to take advantage of that, and lays some plumbing for future implementation of proper weather management.
![image](https://user-images.githubusercontent.com/5397662/175036569-bf4c7a94-dd19-494c-844d-d9adbe19678e.png)

## Issues fixed by this PR

## Type of changes
- [ ] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.