### PR TITLE
Fix chest types

### DIFF
--- a/src/main/resources/defaults/data/ChestReward.json
+++ b/src/main/resources/defaults/data/ChestReward.json
@@ -131,5 +131,293 @@
         "count": 1
       }
     ]
+  },
+   {
+    "objNames": [
+      "SceneObj_Chest_Default_Lv3",
+      "SceneObj_Chest_Locked_Lv3",
+      "SceneObj_Chest_Bramble_Lv3",
+      "SceneObj_Chest_Frozen_Lv3"
+    ],
+    "advExp": 200,
+    "resin": 20,
+    "mora": 8888,
+    "sigil": 20,
+    "content": [
+      {
+        "itemId": 104012,
+        "count": 3
+      },
+      {
+        "itemId": 223,
+        "count": 10
+      },
+      {
+        "itemId": 104002,
+        "count": 1
+      }
+    ],
+    "randomCount": 4,
+    "randomContent": [
+      {
+        "itemId": 11509,
+        "count": 1
+      },
+      {
+        "itemId": 13501,
+        "count": 1
+      },
+      {
+        "itemId": 12201,
+        "count": 1
+      },
+      {
+        "itemId": 12301,
+        "count": 1
+      },
+      {
+        "itemId": 13201,
+        "count": 1
+      },
+      {
+        "itemId": 13301,
+        "count": 1
+      },
+      {
+        "itemId": 14201,
+        "count": 1
+      },
+      {
+        "itemId": 14301,
+        "count": 1
+      },
+      {
+        "itemId": 15201,
+        "count": 1
+      },
+      {
+        "itemId": 15301,
+        "count": 1
+      }
+    ]
+  },
+  {
+    "objNames": [
+      "SceneObj_Chest_Default_Lv4",
+      "SceneObj_Chest_Locked_Lv4",
+      "SceneObj_Chest_Bramble_Lv4",
+      "SceneObj_Chest_Frozen_Lv4"
+    ],
+    "advExp": 20000,
+    "resin": 2,
+    "mora": 88888,
+    "sigil": 2,
+    "content": [
+      {
+        "itemId": 104012,
+        "count": 3
+      },
+      {
+        "itemId": 223,
+        "count": 50
+      },
+      {
+        "itemId": 104002,
+        "count": 1
+      }
+    ],
+    "randomCount": 4,
+    "randomContent": [
+      {
+        "itemId": 13501,
+        "count": 1
+      },
+      {
+        "itemId": 11301,
+        "count": 1
+      },
+      {
+        "itemId": 12201,
+        "count": 1
+      },
+      {
+        "itemId": 12301,
+        "count": 1
+      },
+      {
+        "itemId": 13201,
+        "count": 1
+      },
+      {
+        "itemId": 13301,
+        "count": 1
+      },
+      {
+        "itemId": 14201,
+        "count": 1
+      },
+      {
+        "itemId": 14301,
+        "count": 1
+      },
+      {
+        "itemId": 15201,
+        "count": 1
+      },
+      {
+        "itemId": 15301,
+        "count": 1
+      }
+    ]
+  },
+  {
+    "objNames": [
+      "SceneObj_Chest_Default_Lv5",
+      "SceneObj_Chest_Locked_Lv5",
+      "SceneObj_Chest_Bramble_Lv5",
+      "SceneObj_Chest_Frozen_Lv5"
+    ],
+    "advExp": 20000,
+    "resin": 2,
+    "mora": 88888,
+    "sigil": 2,
+    "content": [
+      {
+        "itemId": 104012,
+        "count": 3
+      },
+      {
+        "itemId": 223,
+        "count": 100
+      },
+      {
+        "itemId": 104002,
+        "count": 1
+      }
+    ],
+    "randomCount": 5,
+    "randomContent": [
+      {
+        "itemId": 13501,
+        "count": 1
+      },
+      {
+        "itemId": 11301,
+        "count": 1
+      },
+      {
+        "itemId": 13509,
+        "count": 1
+      },
+      {
+        "itemId": 12301,
+        "count": 1
+      },
+      {
+        "itemId": 14509,
+        "count": 1
+      },
+      {
+        "itemId": 15507,
+        "count": 1
+      },
+      {
+        "itemId": 15509,
+        "count": 1
+      },
+      {
+        "itemId": 11509,
+        "count": 1
+      },
+      {
+        "itemId": 11503,
+        "count": 1
+      },
+      {
+        "itemId": 15301,
+        "count": 1
+      }
+    ]
+  },
+  {
+    "objNames": [
+      "SceneObj_Area_Common_Property_Ani_Prop_MoonlitBox_01"
+    ],
+    "advExp": 20000,
+    "resin": 2,
+    "mora": 88888,
+    "sigil": 2,
+    "content": [
+      {
+        "itemId": 104012,
+        "count": 3
+      },
+      {
+        "itemId": 223,
+        "count": 100
+      },
+      {
+        "itemId": 104002,
+        "count": 1
+      }
+    ],
+    "randomCount": 5,
+    "randomContent": [
+      {
+        "itemId": 13501,
+        "count": 1
+      },
+      {
+        "itemId": 11301,
+        "count": 1
+      },
+      {
+        "itemId": 13509,
+        "count": 1
+      },
+      {
+        "itemId": 12301,
+        "count": 1
+      },
+      {
+        "itemId": 14509,
+        "count": 1
+      },
+      {
+        "itemId": 15507,
+        "count": 1
+      },
+      {
+        "itemId": 15509,
+        "count": 1
+      },
+      {
+        "itemId": 11509,
+        "count": 1
+      },
+      {
+        "itemId": 11503,
+        "count": 1
+      },
+      {
+        "itemId": 15301,
+        "count": 1
+      }
+    ]
+  },
+  {
+    "objNames": [
+      "SceneObj_Area_Dq_Property_Ani_Prop_JunkChest_01",
+      "SceneObj_Area_Common_Property_Ani_Prop_JunkChest_02",
+      "SearchPoint",
+      "SearchPoint_OnWater"
+    ],
+    "mora": 1,
+    "content": [
+      {
+        "itemId": 201,
+        "count": 114
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fixed an issue where some chests could not be opened.
Could not found the handler of this type of Chests SearchPoint_OnWater
Could not found the handler of this type of Chests SearchPoint
Could not found the handler of this type of Chests SceneObj_Area_Common_Property_Ani_Prop_MoonlitBox_01
Could not found the handler of this type of Chests SceneObj_Area_Dq_Property_Ani_Prop_JunkChest_01
Could not found the handler of this type of Chests SceneObj_Area_Common_Property_Ani_Prop_JunkChest_02
![8S0MLC3{W{@O1)61$M8A(74](https://user-images.githubusercontent.com/90933865/175282363-75b55035-7c25-4022-b56b-64fb2ccbc762.png)

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.