### PR TITLE
Set world level automatically on level up

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -429,6 +429,14 @@ public class Player {
 		return this.getProperty(PlayerProperty.PROP_PLAYER_LEVEL);
 	}
 
+	public void setLevel(int level) {
+		this.setProperty(PlayerProperty.PROP_PLAYER_LEVEL, level);
+		this.sendPacket(new PacketPlayerPropNotify(this, PlayerProperty.PROP_PLAYER_LEVEL));
+
+		this.updateWorldLevel();
+		this.updateProfile();
+	}
+
 	public int getExp() {
 		return this.getProperty(PlayerProperty.PROP_PLAYER_EXP);
 	}
@@ -440,6 +448,8 @@ public class Player {
 	public void setWorldLevel(int level) {
 		this.setProperty(PlayerProperty.PROP_PLAYER_WORLD_LEVEL, level);
 		this.sendPacket(new PacketPlayerPropNotify(this, PlayerProperty.PROP_PLAYER_WORLD_LEVEL));
+
+		this.updateProfile();
 	}
 
 	public int getPrimogems() {
@@ -508,12 +518,7 @@ public class Player {
 		}
 
 		if (hasLeveledUp) {
-			// Set level property
-			this.setProperty(PlayerProperty.PROP_PLAYER_LEVEL, level);
-			// Update social status
-			this.updateProfile();
-			// Update player with packet
-			this.sendPacket(new PacketPlayerPropNotify(this, PlayerProperty.PROP_PLAYER_LEVEL));
+			this.setLevel(level);
 		}
 
 		// Set exp
@@ -521,6 +526,27 @@ public class Player {
 
 		// Update player with packet
 		this.sendPacket(new PacketPlayerPropNotify(this, PlayerProperty.PROP_PLAYER_EXP));
+	}
+
+	private void updateWorldLevel() {
+		int currentWorldLevel = this.getWorldLevel();
+		int currentLevel = this.getLevel();
+
+		int newWorldLevel =
+			(currentLevel >= 55) ? 8 :
+			(currentLevel >= 50) ? 7 :
+			(currentLevel >= 45) ? 6 :
+			(currentLevel >= 40) ? 5 :
+			(currentLevel >= 35) ? 4 :
+			(currentLevel >= 30) ? 3 :
+			(currentLevel >= 25) ? 2 :
+			(currentLevel >= 20) ? 1 :
+			0;
+
+		if (newWorldLevel != currentWorldLevel) {
+			this.getWorld().setWorldLevel(newWorldLevel);
+			this.setWorldLevel(newWorldLevel);
+		}
 	}
 
 	private void updateProfile() {


### PR DESCRIPTION
## Description

Automatically update the world level when the player levels up.

## Issues fixed by this PR

## Type of changes

- [ ] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.