### PR TITLE
Daily Reset for Forge Points

### DIFF
--- a/src/main/java/emu/grasscutter/data/excels/ForgeData.java
+++ b/src/main/java/emu/grasscutter/data/excels/ForgeData.java
@@ -6,7 +6,6 @@ import emu.grasscutter.data.GameResource;
 import emu.grasscutter.data.ResourceType;
 import emu.grasscutter.data.ResourceType.LoadPriority;
 import emu.grasscutter.data.common.ItemParamData;
-import emu.grasscutter.data.common.OpenCondData;
 
 @ResourceType(name = {"ForgeExcelConfigData.json"}, loadPriority = LoadPriority.HIGHEST)
 public class ForgeData extends GameResource {
@@ -19,6 +18,7 @@ public class ForgeData extends GameResource {
     private int queueNum;
     private int scoinCost;
     private int priority;
+    private int forgePoint;
     private List<ItemParamData> materialItems;
 
     @Override
@@ -56,6 +56,10 @@ public class ForgeData extends GameResource {
 
     public int getPriority() {
         return priority;
+    }
+
+    public int getForgePoint() {
+        return forgePoint;
     }
 
     public List<ItemParamData> getMaterialItems() {

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -447,6 +447,8 @@ public class Player {
 	}
 
 	public void setWorldLevel(int level) {
+		this.getWorld().setWorldLevel(newWorldLevel);
+		
 		this.setProperty(PlayerProperty.PROP_PLAYER_WORLD_LEVEL, level);
 		this.sendPacket(new PacketPlayerPropNotify(this, PlayerProperty.PROP_PLAYER_WORLD_LEVEL));
 
@@ -545,7 +547,6 @@ public class Player {
 			0;
 
 		if (newWorldLevel != currentWorldLevel) {
-			this.getWorld().setWorldLevel(newWorldLevel);
 			this.setWorldLevel(newWorldLevel);
 		}
 	}

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -1380,8 +1380,6 @@ public class Player {
 			return;
 		}
 
-		Grasscutter.getLogger().info("Executing daily reset logic ...");
-
 		// We should - now execute all the resetting logic we need.
 		// Reset forge points.
 		this.setForgePoints(300_000);


### PR DESCRIPTION
## Description

This PR adds handling for daily resets for players. Logic that should run for a daily reset can be put into `Player::doDailyReset`. It also uses this new mechanism to implement daily resetting for forge points, and adds forge point handling to `ForgingManager`. This enables the crafting of Enhancement Ores, which was not possible yet.

This new resetting mechanism could in the future be used to implement things like resetting of resource gather points, respawning of enemies etc. We probably could also move at least part of the moon card logic there.

It also contains another small change (moving the setting of the world level on `World` from `Player::updateWorldLevel` to `Player::setWorldLevel`) which seemed to small to make a separate PR for.

## Issues fixed by this PR

## Type of changes

- [ ] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.