### PR TITLE
BP: Daily/Weekly Mission Reset, Gnostic Hymn per Default, Selection Chests

### DIFF
--- a/src/main/java/emu/grasscutter/GameConstants.java
+++ b/src/main/java/emu/grasscutter/GameConstants.java
@@ -22,6 +22,7 @@ public final class GameConstants {
 	public static final int BATTLE_PASS_POINT_PER_LEVEL = 1000;
 	public static final int BATTLE_PASS_POINT_PER_WEEK = 10000;
 	public static final int BATTLE_PASS_LEVEL_PRICE = 150;
+	public static final int BATTLE_PASS_CURRENT_INDEX = 2;
 	
 	// Default entity ability hashes.
 	public static final String[] DEFAULT_ABILITY_STRINGS = {

--- a/src/main/java/emu/grasscutter/data/excels/BattlePassRewardData.java
+++ b/src/main/java/emu/grasscutter/data/excels/BattlePassRewardData.java
@@ -17,11 +17,12 @@ public class BattlePassRewardData extends GameResource {
 
     @Override
     public int getId() {
-        return this.level;
+        // Reward ID is a combination of index and level.
+        // We do this to get a unique ID.
+        return this.indexId * 100 + this.level;
     }
 
     @Override
     public void onLoad() {
-    	
     }
 }

--- a/src/main/java/emu/grasscutter/game/battlepass/BattlePassManager.java
+++ b/src/main/java/emu/grasscutter/game/battlepass/BattlePassManager.java
@@ -12,6 +12,7 @@ import dev.morphia.annotations.Id;
 import dev.morphia.annotations.Indexed;
 import dev.morphia.annotations.Transient;
 import emu.grasscutter.GameConstants;
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.common.ItemParamData;
 import emu.grasscutter.data.excels.BattlePassRewardData;
@@ -44,7 +45,7 @@ public class BattlePassManager {
     @Getter private int level;
     
     @Getter private boolean viewed;
-    @Getter private boolean paid;
+    private boolean paid;
     
     private Map<Integer, BattlePassMission> missions;
     private Map<Integer, BattlePassReward> takenRewards;
@@ -120,6 +121,11 @@ public class BattlePassManager {
 	
 	public boolean hasMission(int id) {
 		return getMissions().containsKey(id);
+	}
+
+	public boolean isPaid() {
+		// ToDo: Change this when we actually support unlocking "paid" BP.
+		return true;
 	}
 
 	public Map<Integer, BattlePassReward> getTakenRewards() {
@@ -266,7 +272,8 @@ public class BattlePassManager {
                 .setEndTime(2059483200)
                 .setIsViewed(this.isViewed())
                 .setUnlockStatus(this.isPaid() ? BattlePassUnlockStatus.BATTLE_PASS_UNLOCK_STATUS_PAID : BattlePassUnlockStatus.BATTLE_PASS_UNLOCK_STATUS_FREE)
-                .setCurCyclePoints(this.getCyclePoints())
+                .setJPFMGBEBBBJ(2) // Not bought on Playstation.
+				.setCurCyclePoints(this.getCyclePoints())
                 .setCurCycle(BattlePassCycle.newBuilder().setBeginTime(0).setEndTime(2059483200).setCycleIdx(3));
 		
 		for (BattlePassReward reward : getTakenRewards().values()) {

--- a/src/main/java/emu/grasscutter/game/battlepass/BattlePassManager.java
+++ b/src/main/java/emu/grasscutter/game/battlepass/BattlePassManager.java
@@ -226,7 +226,6 @@ public class BattlePassManager {
 	
 	public void takeReward(List<BattlePassRewardTakeOption> takeOptionList) {
 		List<BattlePassRewardTakeOption> rewardList = new ArrayList<>();
-		// List<BattlePassRewardTag> rewardList = new ArrayList<>();
 		
 		for (BattlePassRewardTakeOption option : takeOptionList) {
 			// Duplicate check
@@ -250,8 +249,6 @@ public class BattlePassManager {
 			else {
 				Grasscutter.getLogger().info("Not in rewards list: {}", option.getTag().getRewardId());
 			}
-
-			// rewardList.add(new Pair<>(option.getTag(), option.getOptionIdx()));
 		}
 		
 		// Get rewards

--- a/src/main/java/emu/grasscutter/game/battlepass/BattlePassManager.java
+++ b/src/main/java/emu/grasscutter/game/battlepass/BattlePassManager.java
@@ -352,7 +352,10 @@ public class BattlePassManager {
 	
 	//
 	public BattlePassSchedule getScheduleProto() {
-		var nextSundayDate = LocalDate.now().with(TemporalAdjusters.next(DayOfWeek.SUNDAY));
+		var currentDate = LocalDate.now();
+		var nextSundayDate = (currentDate.getDayOfWeek() == DayOfWeek.SUNDAY) 
+			? currentDate 
+			: LocalDate.now().with(TemporalAdjusters.next(DayOfWeek.SUNDAY));
 		var nextSundayTime = LocalDateTime.of(nextSundayDate.getYear(), nextSundayDate.getMonthValue(), nextSundayDate.getDayOfMonth(), 23, 59, 59);
 		
 		BattlePassSchedule.Builder schedule = BattlePassSchedule.newBuilder()

--- a/src/main/java/emu/grasscutter/game/battlepass/BattlePassMission.java
+++ b/src/main/java/emu/grasscutter/game/battlepass/BattlePassMission.java
@@ -37,6 +37,10 @@ public class BattlePassMission {
 		return progress;
 	}
 
+	public void setProgress(int value) {
+		this.progress = value;
+	}
+
 	public void addProgress(int addProgress, int maxProgress) {
 		this.progress = Math.min(addProgress + this.progress, maxProgress);
 	}

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -77,6 +77,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import lombok.Getter;
 
+import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -1368,7 +1369,7 @@ public class Player {
 		this.getResinManager().rechargeResin();
 	}
 
-	private void doDailyReset() {
+	private synchronized void doDailyReset() {
 		// Check if we should execute a daily reset on this tick.
 		int currentTime = Utils.getCurrentSeconds();
 
@@ -1382,6 +1383,14 @@ public class Player {
 		// We should - now execute all the resetting logic we need.
 		// Reset forge points.
 		this.setForgePoints(300_000);
+
+		// Reset daily BP missions.
+		this.getBattlePassManager().resetDailyMissions();
+
+		// Reset weekly BP missions.
+		if (currentDate.getDayOfWeek() == DayOfWeek.MONDAY) {
+			this.getBattlePassManager().resetWeeklyMissions();
+		}
 
 		// Done. Update last reset time.
 		this.setLastDailyReset(currentTime);
@@ -1454,6 +1463,9 @@ public class Player {
 		// Multiplayer setting
 		this.setProperty(PlayerProperty.PROP_PLAYER_MP_SETTING_TYPE, this.getMpSetting().getNumber(), false);
 		this.setProperty(PlayerProperty.PROP_IS_MP_MODE_AVAILABLE, 1, false);
+
+		// Execute daily reset logic if this is a new day.
+		this.doDailyReset();
 
 		// Packets
 		session.send(new PacketPlayerDataNotify(this)); // Player data

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketTakeBattlePassRewardRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketTakeBattlePassRewardRsp.java
@@ -12,21 +12,6 @@ import emu.grasscutter.server.game.GameSession;
 import java.util.List;
 
 public class PacketTakeBattlePassRewardRsp extends BasePacket {
-    /*public PacketTakeBattlePassRewardRsp(List<BattlePassRewardTakeOption> takeOptionList, List<ItemParamData> rewardItems) {
-        super(PacketOpcodes.TakeBattlePassRewardRsp);
-
-        var proto = TakeBattlePassRewardRsp.newBuilder()
-        		.addAllTakeOptionList(takeOptionList);
-        
-        if (rewardItems != null) {
-        	for (ItemParamData param : rewardItems) {
-            	proto.addItemList(ItemParam.newBuilder().setItemId(param.getItemId()).setCount(param.getCount()));
-            }
-        }
-
-        setData(proto);
-    }*/
-
     public PacketTakeBattlePassRewardRsp(List<BattlePassRewardTakeOption> takeOptionList, List<GameItem> rewardItems) {
         super(PacketOpcodes.TakeBattlePassRewardRsp);
 

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketTakeBattlePassRewardRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketTakeBattlePassRewardRsp.java
@@ -1,6 +1,7 @@
 package emu.grasscutter.server.packet.send;
 
 import emu.grasscutter.data.common.ItemParamData;
+import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.net.packet.BasePacket;
 import emu.grasscutter.net.packet.PacketOpcodes;
 import emu.grasscutter.net.proto.BattlePassRewardTakeOptionOuterClass.BattlePassRewardTakeOption;
@@ -11,7 +12,7 @@ import emu.grasscutter.server.game.GameSession;
 import java.util.List;
 
 public class PacketTakeBattlePassRewardRsp extends BasePacket {
-    public PacketTakeBattlePassRewardRsp(List<BattlePassRewardTakeOption> takeOptionList, List<ItemParamData> rewardItems) {
+    /*public PacketTakeBattlePassRewardRsp(List<BattlePassRewardTakeOption> takeOptionList, List<ItemParamData> rewardItems) {
         super(PacketOpcodes.TakeBattlePassRewardRsp);
 
         var proto = TakeBattlePassRewardRsp.newBuilder()
@@ -20,6 +21,21 @@ public class PacketTakeBattlePassRewardRsp extends BasePacket {
         if (rewardItems != null) {
         	for (ItemParamData param : rewardItems) {
             	proto.addItemList(ItemParam.newBuilder().setItemId(param.getItemId()).setCount(param.getCount()));
+            }
+        }
+
+        setData(proto);
+    }*/
+
+    public PacketTakeBattlePassRewardRsp(List<BattlePassRewardTakeOption> takeOptionList, List<GameItem> rewardItems) {
+        super(PacketOpcodes.TakeBattlePassRewardRsp);
+
+        var proto = TakeBattlePassRewardRsp.newBuilder()
+        		.addAllTakeOptionList(takeOptionList);
+        
+        if (rewardItems != null) {
+        	for (var item : rewardItems) {
+            	proto.addItemList(ItemParam.newBuilder().setItemId(item.getItemId()).setCount(item.getCount()));
             }
         }
 


### PR DESCRIPTION
## Description

This PR extends the existing BP implementation by the following things:
- It adds a reset for daily and weekly missions, so they can be cleared again.
- It automatically unlocks Gnostic Hymn. This is probably preferable to not having it until we add a natural way to unlock it.
- It implements handling for rewards that come in selection chests (i.e., rewards were the user can choose between multiple options).

## Issues fixed by this PR

## Type of changes

- [ ] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.