### PR TITLE
BP: Add Login Trigger to Daily Reset

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -1387,6 +1387,10 @@ public class Player {
 		// Reset daily BP missions.
 		this.getBattlePassManager().resetDailyMissions();
 
+		// Trigger login BP mission, so players who are online during the reset
+		// don't have to relog to clear the mission.
+		this.getBattlePassManager().triggerMission(WatcherTriggerType.TRIGGER_LOGIN);
+
 		// Reset weekly BP missions.
 		if (currentDate.getDayOfWeek() == DayOfWeek.MONDAY) {
 			this.getBattlePassManager().resetWeeklyMissions();


### PR DESCRIPTION
## Description

Tiny QoL PR that adds the login trigger for BP missions to the daily player reset, so players who are online during the reset don't have to relog to clear the daily login mission.

## Issues fixed by this PR

## Type of changes

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.