### PR TITLE
fix some region errors

### DIFF
--- a/proto/DungeonShowReminderNotify.proto
+++ b/proto/DungeonShowReminderNotify.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "emu.grasscutter.net.proto";
+
+// CmdId: 930
+// EnetChannelId: 0
+// EnetIsReliable: true
+message DungeonShowReminderNotify {
+	uint32 reminder_id = 10;
+}

--- a/src/main/java/emu/grasscutter/game/entity/EntityRegion.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityRegion.java
@@ -71,4 +71,8 @@ public class EntityRegion extends GameEntity{
          */
         return null;
     }
+
+    public int getFirstEntityId() {
+        return entities.stream().findFirst().orElse(0);
+    }
 }

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -7,6 +7,7 @@ import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.excels.MonsterData;
 import emu.grasscutter.data.excels.WorldLevelData;
 import emu.grasscutter.game.entity.*;
+import emu.grasscutter.game.props.EntityType;
 import emu.grasscutter.game.world.Scene;
 import emu.grasscutter.net.proto.VisionTypeOuterClass;
 import emu.grasscutter.scripts.constants.EventType;
@@ -167,11 +168,11 @@ public class SceneScriptManager {
 	public boolean isInit() {
 		return isInit;
 	}
-	
+
 	public void loadBlockFromScript(SceneBlock block) {
 		block.load(scene.getId(), meta.context);
 	}
-	
+
 	public void loadGroupFromScript(SceneGroup group) {
 		group.load(getScene().getId());
 
@@ -188,13 +189,17 @@ public class SceneScriptManager {
 		}
 
 		for (var region : this.regions.values()) {
+            // currently all condition_ENTER_REGION Events check for avatar, so we have no necessary to add other types of entity
 			getScene().getEntities().values()
 				.stream()
-				.filter(e -> e.getEntityType() <= 2 && region.getMetaRegion().contains(e.getPosition()))
+				.filter(e -> e.getEntityType() == EntityType.Avatar.getValue() && region.getMetaRegion().contains(e.getPosition()))
 				.forEach(region::addEntity);
 
 			if (region.hasNewEntities()) {
-				callEvent(EventType.EVENT_ENTER_REGION, new ScriptArgs(region.getConfigId()).setSourceEntityId(region.getId()));
+				callEvent(EventType.EVENT_ENTER_REGION, new ScriptArgs(region.getConfigId())
+                    .setSourceEntityId(region.getId())
+                    .setTargetEntityId(region.getFirstEntityId())
+                );
 
 				region.resetNewEntities();
 			}
@@ -409,18 +414,18 @@ public class SceneScriptManager {
 
 		this.getScriptMonsterSpawnService()
 				.onMonsterCreatedListener.forEach(action -> action.onNotify(entity));
-		
+
 		return entity;
 	}
 
 	public void addEntity(GameEntity gameEntity){
 		getScene().addEntity(gameEntity);
 	}
-	
+
 	public void meetEntities(List<? extends GameEntity> gameEntity){
 		getScene().addEntities(gameEntity, VisionTypeOuterClass.VisionType.VISION_TYPE_MEET);
 	}
-	
+
 	public void addEntities(List<? extends GameEntity> gameEntity){
 		getScene().addEntities(gameEntity);
 	}

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -6,9 +6,13 @@ import emu.grasscutter.game.entity.EntityMonster;
 import emu.grasscutter.game.entity.GameEntity;
 import emu.grasscutter.game.entity.gadget.GadgetWorktop;
 import emu.grasscutter.game.dungeons.challenge.factory.ChallengeFactory;
+import emu.grasscutter.game.props.EntityType;
+import emu.grasscutter.game.quest.enums.QuestState;
+import emu.grasscutter.game.quest.enums.QuestTrigger;
 import emu.grasscutter.scripts.data.SceneGroup;
 import emu.grasscutter.scripts.data.SceneRegion;
 import emu.grasscutter.server.packet.send.PacketCanUseSkillNotify;
+import emu.grasscutter.server.packet.send.PacketDungeonShowReminderNotify;
 import emu.grasscutter.server.packet.send.PacketWorktopOptionNotify;
 import io.netty.util.concurrent.FastThreadLocal;
 import org.luaj.vm2.LuaTable;
@@ -502,4 +506,47 @@ public class ScriptLib {
 
 		return 1;
 	}
+
+    public int GetEntityType(int entityId){
+        var entity = getSceneScriptManager().getScene().getEntityById(entityId);
+        if(entity == null){
+            return EntityType.None.getValue();
+        }
+
+        return entity.getEntityType();
+    }
+
+    public int GetQuestState(int entityId, int questId){
+        var player = getSceneScriptManager().getScene().getWorld().getHost();
+
+        var quest = player.getQuestManager().getQuestById(questId);
+        if(quest == null){
+            return QuestState.QUEST_STATE_NONE.getValue();
+        }
+
+        return quest.getState().getValue();
+    }
+
+    public int ShowReminder(int reminderId){
+        getSceneScriptManager().getScene().broadcastPacket(new PacketDungeonShowReminderNotify(reminderId));
+        return 0;
+    }
+
+    public int RemoveEntityByConfigId(int groupId, int entityType, int configId){
+        logger.debug("[LUA] Call RemoveEntityByConfigId");
+
+        var entity = getSceneScriptManager().getScene().getEntities().values().stream()
+            .filter(e -> e.getGroupId() == groupId)
+            .filter(e -> e.getEntityType() == entityType)
+            .filter(e -> e.getConfigId() == configId)
+            .findFirst();
+
+        if(entity.isEmpty()){
+            return 1;
+        }
+
+        getSceneScriptManager().getScene().removeEntity(entity.get());
+
+        return 0;
+    }
 }

--- a/src/main/java/emu/grasscutter/scripts/ScriptLoader.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLoader.java
@@ -2,6 +2,7 @@ package emu.grasscutter.scripts;
 
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.game.props.EntityType;
+import emu.grasscutter.game.quest.enums.QuestState;
 import emu.grasscutter.scripts.constants.EventType;
 import emu.grasscutter.scripts.constants.ScriptGadgetState;
 import emu.grasscutter.scripts.constants.ScriptRegionShape;
@@ -66,6 +67,10 @@ public class ScriptLoader {
 		LuaTable table = new LuaTable();
 		Arrays.stream(EntityType.values()).forEach(e -> table.set(e.name().toUpperCase(), e.getValue()));
 		ctx.globals.set("EntityType", table);
+
+        LuaTable table1 = new LuaTable();
+        Arrays.stream(QuestState.values()).forEach(e -> table1.set(e.name().toUpperCase(), e.getValue()));
+        ctx.globals.set("QuestState", table1);
 
 		ctx.globals.set("EventType", CoerceJavaToLua.coerce(new EventType())); // TODO - make static class to avoid instantiating a new class every scene
 		ctx.globals.set("GadgetState", CoerceJavaToLua.coerce(new ScriptGadgetState()));

--- a/src/main/java/emu/grasscutter/scripts/data/ScriptArgs.java
+++ b/src/main/java/emu/grasscutter/scripts/data/ScriptArgs.java
@@ -5,9 +5,9 @@ public class ScriptArgs {
 	public int param2;
 	public int param3;
 	public int source_eid; // Source entity
-	
+    public int target_eid;
 	public ScriptArgs() {
-		
+
 	}
 
 	public ScriptArgs(int param1) {
@@ -54,4 +54,13 @@ public class ScriptArgs {
 		this.source_eid = source_eid;
 		return this;
 	}
+
+    public int getTargetEntityId() {
+        return target_eid;
+    }
+
+    public ScriptArgs setTargetEntityId(int target_eid) {
+        this.target_eid = target_eid;
+        return this;
+    }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketDungeonShowReminderNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketDungeonShowReminderNotify.java
@@ -1,0 +1,18 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.DungeonShowReminderNotifyOuterClass;
+
+public class PacketDungeonShowReminderNotify extends BasePacket {
+
+	public PacketDungeonShowReminderNotify(int reminderId) {
+		super(PacketOpcodes.DungeonShowReminderNotify);
+
+        var proto = DungeonShowReminderNotifyOuterClass.DungeonShowReminderNotify.newBuilder();
+
+        proto.setReminderId(reminderId);
+
+        this.setData(proto);
+	}
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketGroupSuiteNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketGroupSuiteNotify.java
@@ -18,8 +18,9 @@ public class PacketGroupSuiteNotify extends BasePacket {
 
 		var proto = GroupSuiteNotifyOuterClass.GroupSuiteNotify.newBuilder();
 
-        npcBornEntries.forEach(x ->
-            x.getSuiteIdList().forEach(y ->
+        npcBornEntries.stream()
+            .filter(x -> x.getGroupId() > 0 && x.getSuiteIdList() != null)
+            .forEach(x -> x.getSuiteIdList().forEach(y ->
                 proto.putGroupMap(x.getGroupId(), y)
             ));
 


### PR DESCRIPTION
## Description

currently, all condition_ENTER_REGION events check for the avatar, so we do not need to add other types of entities into the region for check.

also add func in ScriptLib

fix GroupSuiteNotify NPE in some case

<img width="587" alt="" src="https://user-images.githubusercontent.com/104902222/177030911-2a3b98e3-691f-42d8-865c-62af82cb94a3.png">


## Issues fixed by this PR
#1388
<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.