### PR TITLE
Big time translation & command changes

### DIFF
--- a/src/main/java/emu/grasscutter/auth/DefaultAuthentication.java
+++ b/src/main/java/emu/grasscutter/auth/DefaultAuthentication.java
@@ -31,7 +31,7 @@ public final class DefaultAuthentication implements AuthenticationSystem {
 
     @Override
     public Account verifyUser(String details) {
-        Grasscutter.getLogger().info(translate("dispatch.authentication.default_unable_to_verify"));
+        Grasscutter.getLogger().info(translate("messages.dispatch.authentication.default_unable_to_verify"));
         return null;
     }
 

--- a/src/main/java/emu/grasscutter/command/CommandMap.java
+++ b/src/main/java/emu/grasscutter/command/CommandMap.java
@@ -106,7 +106,12 @@ public final class CommandMap {
      * @return The command handler.
      */
     public CommandHandler getHandler(String label) {
-        return this.commands.get(label);
+        CommandHandler handler = this.commands.get(label);
+        if (handler == null) {
+            // Try getting by alias
+            handler = this.aliases.get(label);
+        }
+        return handler;
     }
 
     private Player getTargetPlayer(String playerId, Player player, Player targetPlayer, List<String> args) {
@@ -220,12 +225,9 @@ public final class CommandMap {
         }
 
         // Get command handler.
-        CommandHandler handler = this.commands.get(label);
-        if(handler == null)
-            // Try to get the handler by alias.
-            handler = this.aliases.get(label);
+        CommandHandler handler = this.getHandler(label);
 
-        // Check if the handler is still null.
+        // Check if the handler is null.
         if (handler == null) {
             CommandHandler.sendTranslatedMessage(player, "commands.generic.unknown_command", label);
             return;

--- a/src/main/java/emu/grasscutter/command/commands/AccountCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/AccountCommand.java
@@ -11,7 +11,12 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "account", usage = "account <create|delete> <username> [uid]", description = "commands.account.description", targetRequirement = Command.TargetRequirement.NONE)
+@Command(
+    label = "account",
+    usage = "commands.account.usage",
+    description = "commands.account.description",
+    targetRequirement = Command.TargetRequirement.NONE
+)
 public final class AccountCommand implements CommandHandler {
 
     @Override
@@ -22,7 +27,7 @@ public final class AccountCommand implements CommandHandler {
         }
 
         if (args.size() < 2) {
-            CommandHandler.sendMessage(null, translate(sender, "commands.account.command_usage"));
+            CommandHandler.sendMessage(null, translate(sender, "commands.account.usage"));
             return;
         }
 
@@ -31,7 +36,7 @@ public final class AccountCommand implements CommandHandler {
 
         switch (action) {
             default:
-                CommandHandler.sendMessage(null, translate(sender, "commands.account.command_usage"));
+                CommandHandler.sendMessage(null, translate(sender, "commands.account.usage"));
                 return;
             case "create":
                 int uid = 0;

--- a/src/main/java/emu/grasscutter/command/commands/AnnounceCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/AnnounceCommand.java
@@ -12,26 +12,28 @@ import java.util.Random;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "announce",
-    usage = "a <tpl templateId|refresh|revoke templateId|content>",
-    permission = "server.announce",
-    aliases = {"a"},
+@Command(
+    label = "announce",
+    usage = "commands.announce.usage",
     description = "commands.announce.description",
-    targetRequirement = Command.TargetRequirement.NONE)
+    targetRequirement = Command.TargetRequirement.NONE,
+    permission = "server.announce",
+    aliases = {"a"}
+)
 public final class AnnounceCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
         var manager = Grasscutter.getGameServer().getAnnouncementManager();
         if (args.size() < 1) {
-            CommandHandler.sendTranslatedMessage(sender, "commands.announce.command_usage");
+            CommandHandler.sendTranslatedMessage(sender, "commands.announce.usage");
             return;
         }
 
         switch (args.get(0)){
             case "tpl":
                 if (args.size() < 2) {
-                    CommandHandler.sendTranslatedMessage(sender, "commands.announce.command_usage");
+                    CommandHandler.sendTranslatedMessage(sender, "commands.announce.usage");
                     return;
                 }
 
@@ -53,7 +55,7 @@ public final class AnnounceCommand implements CommandHandler {
 
             case "revoke":
                 if (args.size() < 2) {
-                    CommandHandler.sendTranslatedMessage(sender, "commands.announce.command_usage");
+                    CommandHandler.sendTranslatedMessage(sender, "commands.announce.usage");
                     return;
                 }
 

--- a/src/main/java/emu/grasscutter/command/commands/BanCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/BanCommand.java
@@ -10,10 +10,10 @@ import emu.grasscutter.server.game.GameSession;
 
 @Command(
     label = "ban",
-    usage = "ban <@player> [time] [reason]",
+    usage = "commands.ban.usage",
     description = "commands.ban.description",
-    permission = "server.ban",
-    targetRequirement = Command.TargetRequirement.PLAYER
+    targetRequirement = Command.TargetRequirement.PLAYER,
+    permission = "server.ban"
 )
 public final class BanCommand implements CommandHandler {
 

--- a/src/main/java/emu/grasscutter/command/commands/ClearCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ClearCommand.java
@@ -12,16 +12,20 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "clear", usage = "clear <all|wp|art|mat>", //Merged /clearartifacts and /clearweapons to /clear <args> [uid]
-        description = "commands.clear.description",
-        aliases = {"clear"}, permission = "player.clearinv", permissionTargeted = "player.clearinv.others")
-
+@Command(
+    label = "clear",
+    usage = "commands.clear.usage",
+    description = "commands.clear.description",
+    aliases = {"clear"},
+    permission = "player.clearinv",
+    permissionTargeted = "player.clearinv.others"
+)
 public final class ClearCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
         if (args.size() < 1) {
-            CommandHandler.sendMessage(sender, translate(sender, "commands.clear.command_usage"));
+            CommandHandler.sendMessage(sender, translate(sender, "commands.clear.usage"));
             return;
         }
         Inventory playerInventory = targetPlayer.getInventory();

--- a/src/main/java/emu/grasscutter/command/commands/CoopCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/CoopCommand.java
@@ -9,7 +9,13 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "coop", usage = "coop [host uid]", permission = "server.coop", permissionTargeted = "server.coop.others", description = "commands.coop.description")
+@Command(
+    label = "coop",
+    usage = "commands.coop.usage",
+    description = "commands.coop.description",
+    permission = "server.coop",
+    permissionTargeted = "server.coop.others"
+)
 public final class CoopCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/EnterDungeonCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/EnterDungeonCommand.java
@@ -8,7 +8,14 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "enterdungeon", usage = "enterdungeon <dungeonId>", aliases = {"dungeon"}, permission = "player.enterdungeon", permissionTargeted = "player.enterdungeon.others", description = "commands.enter_dungeon.description")
+@Command(
+    label = "enterdungeon",
+    usage = "commands.enter_dungeon.usage",
+    description = "commands.enter_dungeon.description",
+    aliases = {"dungeon"},
+    permission = "player.enterdungeon",
+    permissionTargeted = "player.enterdungeon.others"
+)
 public final class EnterDungeonCommand implements CommandHandler {
 
     @Override
@@ -26,10 +33,11 @@ public final class EnterDungeonCommand implements CommandHandler {
             }
             
             boolean result = targetPlayer.getServer().getDungeonManager().enterDungeon(targetPlayer.getSession().getPlayer(), 0, dungeonId);
-            CommandHandler.sendMessage(sender, translate(sender, "commands.enter_dungeon.changed", dungeonId));
 
             if (!result) {
                 CommandHandler.sendMessage(sender, translate(sender, "commands.enter_dungeon.not_found_error"));
+            } else {
+                CommandHandler.sendMessage(sender, translate(sender, "commands.enter_dungeon.changed", dungeonId));
             }
         } catch (Exception e) {
             CommandHandler.sendMessage(sender, translate(sender, "commands.enter_dungeon.usage"));

--- a/src/main/java/emu/grasscutter/command/commands/GiveCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/GiveCommand.java
@@ -23,8 +23,14 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-@Command(label = "give", usage = "give <itemId|avatarId|\"all\"|\"weapons\"|\"mats\"|\"avatars\"> [lv<level>] [r<refinement>] [x<amount>] | give <artifactId> [lv<level>] [x<amount>] [mainPropId] [<appendPropId>[,<times>]]...", aliases = {
-        "g", "item", "giveitem"}, permission = "player.give", permissionTargeted = "player.give.others", description = "commands.give.description")
+@Command(
+    label = "give",
+    usage = "commands.give.usage",
+    description = "commands.give.description",
+    aliases = {"g", "item", "giveitem"},
+    permission = "player.give",
+    permissionTargeted = "player.give.others"
+)
 public final class GiveCommand implements CommandHandler {
     private static Pattern lvlRegex = Pattern.compile("l(?:vl?)?(\\d+)");  // Java doesn't have raw string literals :(
     private static Pattern refineRegex = Pattern.compile("r(\\d+)");
@@ -216,11 +222,11 @@ public final class GiveCommand implements CommandHandler {
             switch (param.data.getItemType()) {
                 case ITEM_WEAPON:
                     targetPlayer.getInventory().addItems(makeUnstackableItems(param), ActionReason.SubfieldDrop);
-                    CommandHandler.sendTranslatedMessage(sender, "commands.give.given_with_level_and_refinement", Integer.toString(param.id), Integer.toString(param.lvl), Integer.toString(param.refinement), Integer.toString(param.amount), Integer.toString(targetPlayer.getUid()));
+                    CommandHandler.sendTranslatedMessage(sender, "commands.give.given_with_level_and_refinement", Integer.toString(param.amount), Integer.toString(param.lvl), Integer.toString(param.refinement), Integer.toString(param.id), Integer.toString(targetPlayer.getUid()));
                     return;
                 case ITEM_RELIQUARY:
                     targetPlayer.getInventory().addItems(makeArtifacts(param), ActionReason.SubfieldDrop);
-                    CommandHandler.sendTranslatedMessage(sender, "commands.give.given_level", Integer.toString(param.id), Integer.toString(param.lvl), Integer.toString(param.amount), Integer.toString(targetPlayer.getUid()));
+                    CommandHandler.sendTranslatedMessage(sender, "commands.give.given_level", Integer.toString(param.amount), Integer.toString(param.lvl), Integer.toString(param.id), Integer.toString(targetPlayer.getUid()));
                     //CommandHandler.sendTranslatedMessage(sender, "commands.giveArtifact.success", Integer.toString(param.id), Integer.toString(targetPlayer.getUid()));
                     return;
                 default:

--- a/src/main/java/emu/grasscutter/command/commands/HealCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/HealCommand.java
@@ -11,7 +11,14 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "heal", usage = "heal|h", aliases = {"h"}, permission = "player.heal", permissionTargeted = "player.heal.others", description = "commands.heal.description")
+@Command(
+    label = "heal",
+    usage = "commands.heal.usage",
+    description = "commands.heal.description",
+    aliases = {"h"},
+    permission = "player.heal",
+    permissionTargeted = "player.heal.others"
+)
 public final class HealCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/HelpCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/HelpCommand.java
@@ -10,8 +10,35 @@ import java.util.*;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "help", usage = "help [command]", description = "commands.help.description", targetRequirement = Command.TargetRequirement.NONE)
+@Command(
+    label = "help",
+    usage = "commands.help.usage",
+    description = "commands.help.description",
+    targetRequirement = Command.TargetRequirement.NONE
+)
 public final class HelpCommand implements CommandHandler {
+
+    private void createCommand(StringBuilder builder, Player player, Command annotation) {
+        builder.append("\n").append(annotation.label()).append(" - ").append(translate(player, annotation.description()));
+        builder.append("\n\t").append(translate(player, "commands.help.usage_prefix")).append(translate(player, annotation.usage()));
+        if (annotation.aliases().length >= 1) {
+            builder.append("\n\t").append(translate(player, "commands.help.aliases"));
+            for (String alias : annotation.aliases()) {
+                builder.append(alias).append(" ");
+            }
+        }
+        builder.append("\n\t").append(translate(player, "commands.help.tip_need_permission"));
+        if(annotation.permission().isEmpty() || annotation.permission().isBlank()) {
+            builder.append(translate(player, "commands.help.tip_need_no_permission"));
+        } else {
+            builder.append(annotation.permission());
+        }
+
+        if(!annotation.permissionTargeted().isEmpty() && !annotation.permissionTargeted().isBlank()) {
+            String permissionTargeted = annotation.permissionTargeted();
+            builder.append(" ").append(translate(player, "commands.help.tip_permission_targeted", permissionTargeted));
+        }
+    }
 
     @Override
     public void execute(Player player, Player targetPlayer, List<String> args) {
@@ -32,38 +59,16 @@ public final class HelpCommand implements CommandHandler {
         } else {
             String command = args.get(0);
             CommandHandler handler = CommandMap.getInstance().getHandler(command);
-            StringBuilder builder = new StringBuilder(player == null ? "\n" + translate(player, "commands.status.help") + " - " : translate(player, "commands.status.help") + " - ").append(command).append(": \n");
+            StringBuilder builder = new StringBuilder("");
             if (handler == null) {
                 builder.append(translate(player, "commands.generic.command_exist_error"));
             } else {
                 Command annotation = handler.getClass().getAnnotation(Command.class);
 
-                builder.append("   ").append(translate(player, annotation.description())).append("\n");
-                builder.append(translate(player, "commands.help.usage")).append(annotation.usage());
-                if (annotation.aliases().length >= 1) {
-                    builder.append("\n").append(translate(player, "commands.help.aliases"));
-                    for (String alias : annotation.aliases()) {
-                        builder.append(alias).append(" ");
-                    }
-                }
-
-                builder.append("\n").append(translate(player, "commands.help.tip_need_permission"));
-                if(annotation.permission().isEmpty() || annotation.permission().isBlank()) {
-                    builder.append(translate(player, "commands.help.tip_need_no_permission"));
-                }
-                else {
-                    builder.append(annotation.permission());
-                }
-                builder.append(" ");
-
-                if(!annotation.permissionTargeted().isEmpty() && !annotation.permissionTargeted().isBlank()) {
-                    String permissionTargeted = annotation.permissionTargeted();
-                    builder.append(translate(player, "commands.help.tip_permission_targeted", permissionTargeted));
-                }
+                this.createCommand(builder, player, annotation);
 
                 if (player != null && !Objects.equals(annotation.permission(), "") && !player.getAccount().hasPermission(annotation.permission())) {
-                    builder.append("\n ");
-                    builder.append(translate(player, "commands.help.warn_player_has_no_permission"));
+                    builder.append("\n\t").append(translate(player, "commands.help.warn_player_has_no_permission"));
                 }
             }
 
@@ -72,67 +77,12 @@ public final class HelpCommand implements CommandHandler {
     }
 
     void SendAllHelpMessage(Player player, List<Command> annotations) {
-        if (player == null) {
-            StringBuilder builder = new StringBuilder("\n" + translate(player, "commands.help.available_commands") + "\n");
-            annotations.forEach(annotation -> {
-                builder.append(annotation.label()).append("\n");
-                builder.append("   ").append(translate(player, annotation.description())).append("\n");
-                builder.append(translate(player, "commands.help.usage")).append(annotation.usage());
-                if (annotation.aliases().length >= 1) {
-                    builder.append("\n").append(translate(player, "commands.help.aliases"));
-                    for (String alias : annotation.aliases()) {
-                        builder.append(alias).append(" ");
-                    }
-                }
-                builder.append("\n").append(translate(player, "commands.help.tip_need_permission"));
-                if(annotation.permission().isEmpty() || annotation.permission().isBlank()) {
-                    builder.append(translate(player, "commands.help.tip_need_no_permission"));
-                }
-                else {
-                    builder.append(annotation.permission());
-                }
+        StringBuilder builder = new StringBuilder(translate(player, "commands.help.available_commands"));
+        annotations.forEach(annotation -> {
+            this.createCommand(builder, player, annotation);
+            builder.append("\n");
+        });
 
-                builder.append(" ");
-
-                if(!annotation.permissionTargeted().isEmpty() && !annotation.permissionTargeted().isBlank()) {
-                    String permissionTargeted = annotation.permissionTargeted();
-                    builder.append(translate(player, "commands.help.tip_permission_targeted", permissionTargeted));
-                }
-
-                builder.append("\n");
-            });
-
-            CommandHandler.sendMessage(null, builder.toString());
-        } else {
-            CommandHandler.sendMessage(player, translate(player, "commands.help.available_commands"));
-            annotations.forEach(annotation -> {
-                StringBuilder builder = new StringBuilder(annotation.label()).append("\n");
-                builder.append("   ").append(translate(player, annotation.description())).append("\n");
-                builder.append(translate(player, "commands.help.usage")).append(annotation.usage());
-                if (annotation.aliases().length >= 1) {
-                    builder.append("\n").append(translate(player, "commands.help.aliases"));
-                    for (String alias : annotation.aliases()) {
-                        builder.append(alias).append(" ");
-                    }
-                }
-                builder.append("\n").append(translate(player, "commands.help.permission"));
-                if(annotation.permission().isEmpty() || annotation.permission().isBlank()) {
-                    builder.append(translate(player, "commands.help.no_permission"));
-                }
-                else {
-                    builder.append(annotation.permission());
-                }
-
-                builder.append(" ");
-
-                if(!annotation.permissionTargeted().isEmpty() && !annotation.permissionTargeted().isBlank()) {
-                    String permissionTargeted = annotation.permissionTargeted();
-                    builder.append(translate(player, "commands.help.tip_permission_targeted", permissionTargeted));
-                }
-
-
-                CommandHandler.sendMessage(player, builder.toString());
-            });
-        }
+        CommandHandler.sendMessage(player, builder.toString());
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/KickCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/KickCommand.java
@@ -8,7 +8,13 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "kick", usage = "kick", aliases = {"restart"}, permissionTargeted = "server.kick", description = "commands.kick.description")
+@Command(
+    label = "kick",
+    usage = "commands.kick.usage",
+    description = "commands.kick.description",
+    aliases = {"restart"},
+    permissionTargeted = "server.kick"
+)
 public final class KickCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/KillAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/KillAllCommand.java
@@ -12,7 +12,13 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "killall", usage = "killall [sceneId]", permission = "server.killall", permissionTargeted = "server.killall.others", description = "commands.killall.description")
+@Command(
+    label = "killall",
+    usage = "commands.killall.usage",
+    description = "commands.killall.description",
+    permission = "server.killall",
+    permissionTargeted = "server.killall.others"
+)
 public final class KillAllCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/KillCharacterCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/KillCharacterCommand.java
@@ -13,7 +13,14 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "killcharacter", usage = "killcharacter", aliases = {"suicide", "kill"}, permission = "player.killcharacter", permissionTargeted = "player.killcharacter.others", description = "commands.killCharacter.description")
+@Command(
+    label = "killcharacter",
+    usage = "commands.killCharacter.usage",
+    description = "commands.killCharacter.description",
+    aliases = {"suicide", "kill"},
+    permission = "player.killcharacter",
+    permissionTargeted = "player.killcharacter.others"
+)
 public final class KillCharacterCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/LanguageCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/LanguageCommand.java
@@ -13,7 +13,13 @@ import java.util.Locale;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "language", usage = "language [language code]", description = "commands.language.description", aliases = {"lang"}, targetRequirement = Command.TargetRequirement.NONE)
+@Command(
+    label = "language",
+    usage = "commands.language.usage",
+    description = "commands.language.description",
+    aliases = {"lang"},
+    targetRequirement = Command.TargetRequirement.NONE
+)
 public final class LanguageCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/ListCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ListCommand.java
@@ -10,7 +10,13 @@ import java.util.Map;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "list", usage = "list [uid]", aliases = {"players"}, description = "commands.list.description", targetRequirement = Command.TargetRequirement.NONE)
+@Command(
+    label = "list",
+    usage = "commands.list.usage",
+    description = "commands.list.description",
+    aliases = {"players"},
+    targetRequirement = Command.TargetRequirement.NONE
+)
 public final class ListCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/PermissionCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/PermissionCommand.java
@@ -11,7 +11,13 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "permission", usage = "permission <add|remove> <permission>", permission = "permission", description = "commands.permission.description", targetRequirement = TargetRequirement.PLAYER)
+@Command(
+    label = "permission",
+    usage = "commands.permission.usage",
+    description = "commands.permission.description",
+    targetRequirement = TargetRequirement.PLAYER,
+    permission = "permission"
+)
 public final class PermissionCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/PositionCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/PositionCommand.java
@@ -9,7 +9,12 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "position", usage = "position", aliases = {"pos"}, description = "commands.position.description")
+@Command(
+    label = "position",
+    usage = "commands.position.usage",
+    description = "commands.position.description",
+    aliases = {"pos"}
+)
 public final class PositionCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/QuestCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/QuestCommand.java
@@ -10,7 +10,13 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "quest", usage = "quest <add|finish> [questId]", permission = "player.quest", permissionTargeted = "player.quest.others", description = "commands.quest.description")
+@Command(
+    label = "quest",
+    usage = "commands.quest.usage",
+    description = "commands.quest.description",
+    permission = "player.quest",
+    permissionTargeted = "player.quest.others"
+)
 public final class QuestCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/ReloadCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ReloadCommand.java
@@ -9,7 +9,13 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "reload", usage = "reload", permission = "server.reload", description = "commands.reload.description", targetRequirement = Command.TargetRequirement.NONE)
+@Command(
+    label = "reload",
+    usage = "commands.reload.usage",
+    description = "commands.reload.description",
+    targetRequirement = Command.TargetRequirement.NONE,
+    permission = "server.reload"
+)
 public final class ReloadCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/ResetConstCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ResetConstCommand.java
@@ -10,8 +10,14 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "resetconst", usage = "resetconst [all]",
-        aliases = {"resetconstellation"}, permission = "player.resetconstellation", permissionTargeted = "player.resetconstellation.others", description = "commands.resetConst.description")
+@Command(
+    label = "resetconst",
+    usage = "commands.resetConst.usage",
+    description = "commands.resetConst.description",
+    aliases = {"resetconstellation"},
+    permission = "player.resetconstellation",
+    permissionTargeted = "player.resetconstellation.others"
+)
 public final class ResetConstCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/ResetShopLimitCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ResetShopLimitCommand.java
@@ -9,7 +9,13 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "resetshop", usage = "resetshop", permission = "server.resetshop", permissionTargeted = "server.resetshop.others", description = "commands.resetShopLimit.description")
+@Command(
+    label = "resetshop",
+    usage = "commands.resetShopLimit.usage",
+    description = "commands.resetShopLimit.description",
+    permission = "server.resetshop",
+    permissionTargeted = "server.resetshop.others"
+)
 public final class ResetShopLimitCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/SendMailCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SendMailCommand.java
@@ -13,7 +13,13 @@ import java.util.List;
 import static emu.grasscutter.utils.Language.translate;
 
 @SuppressWarnings("ConstantConditions")
-@Command(label = "sendmail", usage = "sendmail <userId|all|help> [templateId]", permission = "server.sendmail", description = "commands.sendMail.description", targetRequirement = Command.TargetRequirement.NONE)
+@Command(
+    label = "sendmail",
+    usage = "commands.sendMail.usage",
+    description = "commands.sendMail.description",
+    targetRequirement = Command.TargetRequirement.NONE,
+    permission = "server.sendmail"
+)
 public final class SendMailCommand implements CommandHandler {
 
     // TODO: You should be able to do /sendmail and then just send subsequent messages until you finish
@@ -106,7 +112,7 @@ public final class SendMailCommand implements CommandHandler {
                             case 2 -> {
                                 String msgSender = String.join(" ", args.subList(0, args.size()));
                                 mailBuilder.mail.mailContent.sender = msgSender;
-                                CommandHandler.sendMessage(sender, translate(sender, "commands.sendMail.set_message_sender", msgSender));
+                                CommandHandler.sendMessage(sender, translate(sender, "commands.sendMail.set_message_sender", msgSender, getConstructionArgs(mailBuilder.constructionStage, sender)));
                                 mailBuilder.constructionStage++;
                             }
                             case 3 -> {

--- a/src/main/java/emu/grasscutter/command/commands/SendMessageCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SendMessageCommand.java
@@ -10,8 +10,15 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "sendmessage", usage = "sendmessage <message>",
-    aliases = {"say", "sendservmsg", "sendservermessage", "b", "broadcast"}, permission = "server.sendmessage", permissionTargeted = "server.sendmessage.others", description = "commands.sendMessage.description", targetRequirement = TargetRequirement.NONE)
+@Command(
+    label = "sendmessage",
+    usage = "commands.sendMessage.usage",
+    description = "commands.sendMessage.description",
+    targetRequirement = TargetRequirement.NONE,
+    aliases = {"say", "sendservmsg", "sendservermessage", "b", "broadcast"},
+    permission = "server.sendmessage",
+    permissionTargeted = "server.sendmessage.others"
+)
 public final class SendMessageCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/SetFetterLevelCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetFetterLevelCommand.java
@@ -11,8 +11,14 @@ import emu.grasscutter.server.packet.send.PacketAvatarFetterDataNotify;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "setfetterlevel", usage = "setfetterlevel <level>",
-        aliases = {"setfetterlvl", "setfriendship"}, permission = "player.setfetterlevel", permissionTargeted = "player.setfetterlevel.others", description = "commands.setFetterLevel.description")
+@Command(
+    label = "setfetterlevel",
+    usage = "commands.setFetterLevel.usage",
+    description = "commands.setFetterLevel.description",
+    aliases = {"setfetterlvl", "setfriendship"},
+    permission = "player.setfetterlevel",
+    permissionTargeted = "player.setfetterlevel.others"
+)
 public final class SetFetterLevelCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/SetPropCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetPropCommand.java
@@ -10,7 +10,14 @@ import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.PlayerProperty;
 import emu.grasscutter.game.tower.TowerLevelRecord;
 
-@Command(label = "setprop", usage = "setprop|prop <prop> <value>", aliases = {"prop"}, permission = "player.setprop", permissionTargeted = "player.setprop.others", description = "commands.setProp.description")
+@Command(
+    label = "setprop",
+    usage = "commands.setProp.usage",
+    description = "commands.setProp.description",
+    aliases = {"prop"},
+    permission = "player.setprop",
+    permissionTargeted = "player.setprop.others"
+)
 public final class SetPropCommand implements CommandHandler {
     static enum PseudoProp {
         NONE,

--- a/src/main/java/emu/grasscutter/command/commands/SetStatsCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetStatsCommand.java
@@ -11,7 +11,14 @@ import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.FightProperty;
 import emu.grasscutter.server.packet.send.PacketEntityFightPropUpdateNotify;
 
-@Command(label = "setstats", usage = "setstats|stats <stat> <value>", aliases = {"stats"}, permission = "player.setstats", permissionTargeted = "player.setstats.others", description = "commands.setStats.description")
+@Command(
+    label = "setstats",
+    usage = "commands.setStats.usage",
+    description = "commands.setStats.description",
+    aliases = {"stats"},
+    permission = "player.setstats",
+    permissionTargeted = "player.setstats.others"
+)
 public final class SetStatsCommand implements CommandHandler {
     static class Stat {
         String name;

--- a/src/main/java/emu/grasscutter/command/commands/SpawnCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SpawnCommand.java
@@ -23,7 +23,14 @@ import java.util.Random;
 import static emu.grasscutter.Configuration.*;
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "spawn", usage = "spawn <entityId> [amount] [level(monster only)] [<x> <y> <z>(monster only, optional)]", aliases = {"drop"}, permission = "server.spawn", permissionTargeted = "server.spawn.others", description = "commands.spawn.description")
+@Command(
+    label = "spawn",
+    usage = "commands.spawn.usage",
+    description = "commands.spawn.description",
+    aliases = {"drop"},
+    permission = "server.spawn",
+    permissionTargeted = "server.spawn.others"
+)
 public final class SpawnCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/StopCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/StopCommand.java
@@ -9,7 +9,13 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "stop", usage = "stop", permission = "server.stop", description = "commands.stop.description", targetRequirement = Command.TargetRequirement.NONE)
+@Command(
+    label = "stop",
+    usage = "commands.stop.usage",
+    description = "commands.stop.description",
+    targetRequirement = Command.TargetRequirement.NONE,
+    permission = "server.stop"
+)
 public final class StopCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/TalentCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TalentCommand.java
@@ -14,7 +14,13 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "talent", usage = "talent <talentId> <value>", permission = "player.settalent", permissionTargeted = "player.settalent.others", description = "commands.talent.description")
+@Command(
+    label = "talent",
+    usage = "commands.talent.usage",
+    description = "commands.talent.description",
+    permission = "player.settalent",
+    permissionTargeted = "player.settalent.others"
+)
 public final class TalentCommand implements CommandHandler {
     private void setTalentLevel(Player sender, Player player, Avatar avatar, int talentId, int talentLevel) {
         int oldLevel = avatar.getSkillLevelMap().get(talentId);

--- a/src/main/java/emu/grasscutter/command/commands/TeamCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TeamCommand.java
@@ -11,8 +11,13 @@ import java.util.HashSet;
 
 import static emu.grasscutter.Configuration.*;
 
-@Command(label = "team", usage = "team <add|remove|set> [avatarId,...] [index|first|last|index-index,...]",
-permission = "player.team", permissionTargeted = "player.team.others", description = "commands.team.description")
+@Command(
+    label = "team",
+    usage = "commands.team.usage",
+    description = "commands.team.description",
+    permission = "player.team",
+    permissionTargeted = "player.team.others"
+)
 public final class TeamCommand implements CommandHandler {
     private static final int BASE_AVATARID = 10000000;
 

--- a/src/main/java/emu/grasscutter/command/commands/TeleportAllCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TeleportAllCommand.java
@@ -10,7 +10,13 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "tpall", usage = "tpall", permission = "player.tpall", permissionTargeted = "player.tpall.others", description = "commands.teleportAll.description")
+@Command(
+    label = "tpall",
+    usage = "commands.teleportAll.usage",
+    description = "commands.teleportAll.description",
+    permission = "player.tpall",
+    permissionTargeted = "player.tpall.others"
+)
 public final class TeleportAllCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/TeleportCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TeleportCommand.java
@@ -10,7 +10,14 @@ import java.util.List;
 
 import static emu.grasscutter.utils.Language.translate;
 
-@Command(label = "teleport", usage = "teleport <x> <y> <z> [sceneId]", aliases = {"tp"}, permission = "player.teleport", permissionTargeted = "player.teleport.others", description = "commands.teleport.description")
+@Command(
+    label = "teleport",
+    usage = "commands.teleport.usage",
+    description = "commands.teleport.description",
+    aliases = {"tp"},
+    permission = "player.teleport",
+    permissionTargeted = "player.teleport.others"
+)
 public final class TeleportCommand implements CommandHandler {
 
     private float parseRelative(String input, Float current) {  // TODO: Maybe this will be useful elsewhere later

--- a/src/main/java/emu/grasscutter/command/commands/UnBanCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/UnBanCommand.java
@@ -9,7 +9,7 @@ import emu.grasscutter.game.player.Player;
 
 @Command(
     label = "unban",
-    usage = "unban <@player>",
+    usage = "commands.unban.usage",
     description = "commands.unban.description",
     permission = "server.ban",
     targetRequirement = Command.TargetRequirement.PLAYER

--- a/src/main/java/emu/grasscutter/command/commands/WeatherCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/WeatherCommand.java
@@ -8,7 +8,14 @@ import emu.grasscutter.game.world.Scene;
 
 import java.util.List;
 
-@Command(label = "weather", usage = "weather [weatherId] [climateType]", aliases = {"w"}, permission = "player.weather", permissionTargeted = "player.weather.others", description = "commands.weather.description")
+@Command(
+    label = "weather",
+    usage = "commands.weather.usage",
+    description = "commands.weather.description",
+    aliases = {"w"},
+    permission = "player.weather",
+    permissionTargeted = "player.weather.others"
+)
 public final class WeatherCommand implements CommandHandler {
 
     @Override

--- a/src/main/resources/languages/en-US.json
+++ b/src/main/resources/languages/en-US.json
@@ -1,86 +1,86 @@
 {
   "messages": {
     "game": {
-      "port_bind": "Game Server started on port %s",
-      "connect": "Client connected from %s",
-      "disconnect": "Client disconnected from %s",
-      "game_update_error": "An error occurred during game update.",
-      "command_error": "Command error:"
+      "port_bind": "Game server started on port %s.",
+      "connect": "Client connected from %s.",
+      "disconnect": "Client disconnected from %s.",
+      "game_update_error": "An error occurred while updating the game.",
+      "command_error": "Command error: "
     },
     "dispatch": {
-      "port_bind": "[Dispatch] Dispatch server started on port %s",
-      "request": "[Dispatch] Client %s %s request: %s",
+      "port_bind": "[Dispatch] Dispatch server started on port %s.",
+      "request": "[Dispatch] Client %s requests (method: %s): %s",
       "keystore": {
-        "general_error": "[Dispatch] Error while loading keystore!",
-        "password_error": "[Dispatch] Unable to load keystore. Trying default keystore password...",
-        "no_keystore_error": "[Dispatch] No SSL cert found! Falling back to HTTP server.",
-        "default_password": "[Dispatch] The default keystore password was loaded successfully. Please consider setting the password to 123456 in config.json."
+        "general_error": "[Dispatch] Error while loading keystore.",
+        "password_error": "[Dispatch] Unable to load keystore. Trying the default keystore password...",
+        "no_keystore_error": "[Dispatch] No SSL certificate found. Falling back to a HTTP server.",
+        "default_password": "[Dispatch] The default keystore password was loaded successfully. Please consider setting the password to \"123456\" in config.json."
       },
       "authentication": {
-        "default_unable_to_verify": "[Authentication] Something called the verifyUser method which is unavailable in the default authentication handler."
+        "default_unable_to_verify": "[Authentication] Something called the \"verifyUser\" method, which is unavailable in the default authentication handler."
       },
-      "no_commands_error": "Commands are not supported in dispatch only mode.",
-      "unhandled_request_error": "[Dispatch] Potential unhandled %s request: %s.",
+      "no_commands_error": "Commands are not supported in the DISPATCH_ONLY mode.",
+      "unhandled_request_error": "[Dispatch] Potentially unhandled request (method: %s): %s",
       "account": {
         "login_attempt": "[Dispatch] Client %s is trying to log in.",
         "login_success": "[Dispatch] Client %s logged in as %s.",
-        "login_max_player_limit": "[Dispatch] Client %s failed to log in: The number of online players has reached the limit",
+        "login_max_player_limit": "[Dispatch] Client %s failed to log in: the number of online players has reached the maximum.",
         "login_token_attempt": "[Dispatch] Client %s is trying to log in via token.",
         "login_token_error": "[Dispatch] Client %s failed to log in via token.",
         "login_token_success": "[Dispatch] Client %s logged in via token as %s.",
         "combo_token_success": "[Dispatch] Client %s succeed to exchange combo token.",
         "combo_token_error": "[Dispatch] Client %s failed to exchange combo token.",
-        "account_login_create_success": "[Dispatch] Client %s failed to log in: Account %s created.",
-        "account_login_create_error": "[Dispatch] Client %s failed to log in: Account create failed.",
-        "account_login_exist_error": "[Dispatch] Client %s failed to log in: Account not found.",
+        "account_login_create_success": "[Dispatch] Client %s succeeded logging in: account %s created.",
+        "account_login_create_error": "[Dispatch] Client %s failed to log in: failed creating an account.",
+        "account_login_exist_error": "[Dispatch] Client %s failed to log in: account not found.",
         "account_cache_error": "Game account cache information error.",
-        "session_key_error": "Wrong session key.",
+        "session_key_error": "Invalid session key.",
         "username_error": "Username not found.",
-        "username_create_error": "Username not found, create failed.",
-        "server_max_player_limit": "The number of online players has reached the limit"
+        "username_create_error": "Username not found and failed automatically creating a new account.",
+        "server_max_player_limit": "The number of online players has reached the maximum."
       },
       "router_error": "[Dispatch] Unable to attach router."
     },
     "status": {
-      "free_software": "Grasscutter is FREE software. If you have paid for this, you may have been scammed. Homepage: https://github.com/Grasscutters/Grasscutter",
+      "free_software": "Grasscutter is FREE software, licensed under AGPL-3.0. If you paid for this, you were scammed. Our homepage: https://github.com/Grasscutters/Grasscutter",
       "starting": "Starting Grasscutter...",
-      "shutdown": "Shutting down...",
-      "done": "Done! For help, type \"help\"",
+      "shutdown": "Stopping Grasscutter...",
+      "done": "Done! For help, type \"help\".",
       "error": "An error occurred.",
       "welcome": "Welcome to Grasscutter!",
       "run_mode_error": "Invalid server run mode: %s.",
-      "run_mode_help": "Server run mode must be 'HYBRID', 'DISPATCH_ONLY', or 'GAME_ONLY'. Unable to start Grasscutter...",
-      "create_resources": "Creating resources folder...",
-      "resources_error": "Place a copy of 'BinOutput' and 'ExcelBinOutput' in the resources folder.",
+      "run_mode_help": "Server run mode must be \"HYBRID\", \"DISPATCH_ONLY\", or \"GAME_ONLY\".",
+      "create_resources": "Creating the \"resources\" folder...",
+      "resources_error": "Place a copy of the \"BinOutput\" and \"ExcelBinOutput\" folders in the \"resources\" folder.",
       "version": "Grasscutter version: %s-%s",
       "game_version": "Game version: %s",
       "resources": {
         "loading": "Loading resources...",
-        "finish": "Finished loading resources."
+        "finish": "Loaded resources."
       }
     }
   },
   "commands": {
     "generic": {
       "not_specified": "No command specified.",
-      "unknown_command": "Unknown command: %s",
-      "permission_error": "You do not have permission to run this command.",
+      "unknown_command": "Unknown command: %s.",
+      "permission_error": "You do not have the necessary permissions to run this command.",
       "console_execute_error": "This command can only be run from the console.",
-      "player_execute_error": "Run this command in-game.",
-      "command_exist_error": "No command found.",
-      "no_usage_specified": "No usage specified",
-      "no_description_specified": "No description specified",
-      "set_to": "%s set to %s.",
-      "set_for_to": "%s for %s set to %s.",
+      "player_execute_error": "This command can only ben run from in-game.",
+      "command_exist_error": "Command not found.",
+      "no_usage_specified": "No usage example.",
+      "no_description_specified": "No description.",
+      "set_to": "%s was set to %s.",
+      "set_for_to": "%s (UID %s) was set to %s.",
       "invalid": {
         "amount": "Invalid amount.",
         "artifactId": "Invalid artifact ID.",
         "avatarId": "Invalid avatar ID.",
-        "avatarLevel": "Invalid avatarLevel.",
+        "avatarLevel": "Invalid avatar level.",
         "entityId": "Invalid entity ID.",
         "itemId": "Invalid item ID.",
-        "itemLevel": "Invalid itemLevel.",
-        "itemRefinement": "Invalid itemRefinement.",
+        "itemLevel": "Invalid item level.",
+        "itemRefinement": "Invalid item refinement level.",
         "statValue": "Invalid stat value.",
         "value_between": "Invalid value: %s must be between %s and %s.",
         "playerId": "Invalid player ID.",
@@ -91,16 +91,16 @@
     "execution": {
       "player_exist_error": "Player not found.",
       "player_offline_error": "Player is not online.",
-      "item_player_exist_error": "Invalid item or UID.",
+      "item_player_exist_error": "Invalid item or ID.",
       "player_exist_offline_error": "Player not found or is not online.",
       "argument_error": "Invalid arguments.",
       "clear_target": "Target cleared.",
       "set_target": "Subsequent commands will target @%s by default.",
       "set_target_online": "@%s is online. Some commands may require an offline target.",
       "set_target_offline": "@%s is offline. Some commands may require an online target.",
-      "need_target": "This command requires a target UID. Add a <@UID> argument or set a persistent target with /target @UID.",
-      "need_target_online": "This command requires an online target UID, but current target is offline. Add a different <@UID> argument or set a persistent target with /target @UID.",
-      "need_target_offline": "This command requires an offline target UID, but current target is online. Add a different <@UID> argument or set a persistent target with /target @UID."
+      "need_target": "This command requires a target player's ID. Add a <@ID> argument or set a persistent target with \"target @ID\".",
+      "need_target_online": "This command requires an online target, but current target is offline. Add a different <@ID> argument or set a persistent target with \"target @ID\".",
+      "need_target_offline": "This command requires an offline target, but current target is online. Add a different <@ID> argument or set a persistent target with \"target @ID\"."
     },
     "status": {
       "enabled": "Enabled",
@@ -109,108 +109,114 @@
       "success": "Success"
     },
     "account": {
-      "command_usage": "Usage: account <create|delete> <username> [UID]",
+      "usage": "account <create|delete> <username> [UID]",
       "invalid": "Invalid UID.",
       "exists": "An account with this username and/or UID already exists.",
       "create": "Account created with UID %s.",
       "delete": "Account deleted.",
       "no_account": "Account not found.",
-      "description": "Modify user accounts"
+      "description": "Modify user accounts."
     },
     "announce": {
-      "command_usage": "Usage: a <tpl templateId|refresh|revoke templateId|content>",
-      "send_success": "Send an announcement successfully, you can revoke it by /a revoke %s.",
-      "refresh_success": "Refresh announcement config file successfully. (Total %s)",
-      "revoke_done": "Try to revoke announcement %s.",
-      "description": "Send announcement to all online players, or manage server's announcement.",
-      "not_found": "Could not found announcement %s."
+      "usage": "announce <tpl> <templateID> OR announce <refresh> OR announce <message> OR announce <revoke> <templateID>",
+      "send_success": "Sent the announcement. You can revoke it using \"announce revoke %s\".",
+      "refresh_success": "Refreshed announcements (total %s).",
+      "revoke_done": "Revoked announcement ID %s.",
+      "not_found": "Could not find announcement %s.",
+      "description": "Manage and send game announcements."
     },
     "clear": {
-      "command_usage": "Usage: clear <all|wp|art|mat>",
-      "weapons": "Cleared weapons for %s.",
-      "artifacts": "Cleared artifacts for %s.",
-      "materials": "Cleared materials for %s.",
-      "furniture": "Cleared furniture for %s.",
-      "displays": "Cleared displays for %s.",
-      "virtuals": "Cleared virtuals for %s.",
-      "everything": "Cleared everything for %s.",
-      "description": "Deletes unequipped unlocked items, including yellow rarity ones from your inventory"
+      "usage": "clear <all|wp|art|mat>",
+      "weapons": "Cleared weapons of player %s.",
+      "artifacts": "Cleared artifacts of player %s.",
+      "materials": "Cleared materials of player %s.",
+      "furniture": "Cleared furniture of player %s.",
+      "displays": "Cleared displays of player %s.",
+      "virtuals": "Cleared virtuals of player %s.",
+      "everything": "Cleared everything of player %s.",
+      "description": "Delete unequipped unlocked items from the target player's inventory."
     },
     "coop": {
-      "usage": "Usage: coop [host UID]",
-      "success": "Summoned %s to %s's world.",
-      "description": "Forces someone to join the world of others. If no one is targeted, it sends you into co-op mode anyway."
+      "usage": "coop @[playerID]",
+      "success": "Summoned player %s to player %s's world.",
+      "description": "Add a player to your world. If no one is specified, you are placed in a multiplayer version of your world."
     },
     "enter_dungeon": {
-      "usage": "Usage: enterdungeon <dungeonID>",
-      "changed": "Changed to dungeon %s.",
-      "not_found_error": "Dungeon does not exist.",
-      "in_dungeon_error": "You are already in that dungeon.",
-      "description": "Enter a dungeon"
+      "usage": "enterdungeon <dungeonID>",
+      "changed": "Moved to dungeon %s.",
+      "not_found_error": "Given dungeonID doesn't exist.",
+      "in_dungeon_error": "Target player is already in that dungeonID.",
+      "description": "Changed target player's dungeon to the given one."
     },
     "give": {
-      "usage": "Usage: give <itemID|avatarID|\"all\"|\"weapons\"|\"mats\"|\"avatars\"> [x<amount>] [lv<level>] [r<refinement>]",
-      "usage_relic": "Usage: give <artifactID> [mainPropID] [<appendPropID>[,<times>]]... [lv<level 0-20>]",
+      "usage": "give <itemID|avatarID|all|weapons|mats|avatars> [x<amount>] [lv<level>] [r<refinement>]",
+      "usage_relic": "give <artifactID> [mainPropID] [<appendPropID>[, <times>]]... [lv<level 0-20>]",
       "illegal_relic": "This artifactID belongs to a blacklisted range, it may not be the one you wanted.",
-      "given": "Given %s of %s to %s.",
-      "given_with_level_and_refinement": "Given %s with level %s, refinement %s %s times to %s.",
-      "given_level": "Given %s with level %s %s times to %s.",
-      "given_avatar": "Given %s with level %s to %s.",
+      "given": "Given %s items with ID %s to player ID %s.",
+      "given_with_level_and_refinement": "Given %s items with level %s, refinement %s and ID %s, to player ID %s.",
+      "given_level": "Given %s items with level %s and ID %s to player ID %s.",
+      "given_avatar": "Given an avatar ID %s with level %s to player ID %s.",
       "giveall_success": "Successfully gave all items.",
-      "description": "Gives an item to you or the specified player. Can also give all weapons, avatars and/or materials, and can construct custom artifacts."
+      "description": "Gives chosen items to the specified player. Can also give all weapons, avatars, materials, and can construct custom artifacts."
     },
     "heal": {
+      "usage": "heal",
       "success": "All characters have been healed.",
       "description": "Heal all characters in your current team."
     },
     "help": {
-      "usage": "Usage: ",
+      "usage": "help [command]",
+      "usage_prefix": "Usage: ",
       "aliases": "Aliases: ",
       "available_commands": "Available commands: ",
-      "description": "Sends the help message or shows information about a specified command",
-      "tip_need_permission": "Permission: ",
-      "tip_need_no_permission": " None",
-      "tip_permission_targeted": " (Permission %s is also required to use on other players)",
-      "warn_player_has_no_permission": "Notice: You do not have permission to run this command."
+      "description": "Send the help message or show information about a specified command.",
+      "tip_need_permission": "Required permission: ",
+      "tip_need_no_permission": "none",
+      "tip_permission_targeted": "(to use this command on other players, you also need the %s permission)",
+      "warn_player_has_no_permission": "You do not have permission to run this command."
     },
     "kick": {
-      "player_kick_player": "Player [%s:%s] has kicked player [%s:%s]",
-      "server_kick_player": "Kicking player [%s:%s]...",
-      "description": "Kicks the specified player from the server (WIP)"
+      "usage": "kick",
+      "player_kick_player": "Player [%s:%s] has kicked player [%s:%s].",
+      "server_kick_player": "Kicked player [%s:%s].",
+      "description": "Kick the specified player from the server."
     },
     "killall": {
-      "usage": "Usage: killall [playerUID] [sceneID]",
-      "scene_not_found_in_player_world": "Scene not found in player world.",
-      "kill_monsters_in_scene": "Killing %s monsters in scene %s.",
-      "description": "Kill all entities"
+      "usage": "killall @[playerID] [sceneID]",
+      "scene_not_found_in_player_world": "The given sceneID was not found.",
+      "kill_monsters_in_scene": "Killed %s monsters in scene %s.",
+      "description": "Kill all entities in the given scene."
     },
     "killCharacter": {
-      "usage": "Usage: killcharacter [playerID]",
+      "usage": "killcharacter @[playerID]",
       "success": "Killed %s's current character.",
-      "description": "Kills the players current character"
+      "description": "Kill the target player's current character."
     },
     "language": {
-      "current_language": "Current language is %s.",
-      "language_changed": "Language changed to %s.",
-      "language_not_found": "Currently, the server does not have that language.",
-      "description": "Display or change current language"
+      "usage": "language [languageID]",
+      "current_language": "Current language ID is %s.",
+      "language_changed": "LanguageID changed to %s.",
+      "language_not_found": "Couldn't find a languageID %s.",
+      "description": "Display or change current language."
     },
     "list": {
+      "usage": "list @[playerID]",
       "success": "There are %s player(s) online:",
-      "description": "List online players"
+      "description": "List online players."
     },
     "permission": {
-      "usage": "Usage: permission <add|remove> <username> <permission>",
+      "usage": "permission <add|remove> <username> <permission>",
       "add": "Permission added.",
-      "has_error": "They already have this permission!",
+      "has_error": "The target player already has this permission.",
       "remove": "Permission removed.",
-      "not_have_error": "They don't have this permission!",
-      "account_error": "The account cannot be found.",
-      "description": "Grants or removes a permission for a user"
+      "not_have_error": "The target player doesn't have this permission.",
+      "account_error": "An account with the given username does not exist.",
+      "description": "Add or remove a player's permission."
     },
     "position": {
-      "success": "Coordinates: %s, %s, %s\nScene ID: %s",
-      "description": "Get coordinates"
+      "usage": "position",
+      "success": "Coordinates: (%s, %s, %s).\nScene ID: %s.",
+      "description": "Get coordinates of a player."
     },
     "quest": {
       "usage": "quest <add|finish> [questID]",
@@ -218,143 +224,147 @@
       "finished": "Finished quest %s.",
       "not_found": "Quest not found.",
       "invalid_id": "Invalid quest ID.",
-      "description": "Add or finish quests"
+      "description": "Add or finish quests."
     },
     "reload": {
-      "reload_start": "Reloading config.",
+      "usage": "reload",
+      "reload_start": "Reloading config...",
       "reload_done": "Reload complete.",
-      "description": "Reload server config"
+      "description": "Reload the language, configuration, and other game data."
     },
     "resetConst": {
-      "reset_all": "Reset all avatars' constellations.",
-      "success": "Constellations for %s have been reset. Please relog to see changes.",
-      "description": "Resets the constellation level on your current active character, you will need to relog after using the command to see any changes"
+      "usage": "resetconst [all]",
+      "reset_all": "Resetted all avatars' constellations. To see the changes, login again.",
+      "success": "Constellations for avatar %s have been reset. To see the changes, login again.",
+      "description": "Reset the constellation level on your current active character(s)."
     },
     "resetShopLimit": {
-      "usage": "Usage: resetshop <playerID>",
-      "success": "Reset complete.",
-      "description": "Reset target player's shop refresh time"
+      "usage": "resetshop @<playerID>",
+      "success": "Resetted target player's shop refresh time.",
+      "description": "Reset target player's shop refresh time."
     },
     "sendMail": {
-      "usage": "Usage: sendmail <userID|all|help> [templateID]",
-      "user_not_exist": "The user with an ID of '%s' does not exist.",
-      "start_composition": "Starting composition of message.\nPlease use '/sendmail <title>' to continue.\nYou can use '/sendmail stop' at any time.",
-      "templates": "Mail templates coming soon implemented...",
+      "usage": "sendmail <@<playerID>|all|help> [templateID]",
+      "user_not_exist": "A player with given playerID %s does not exist.",
+      "start_composition": "Starting composition of the message.\nPlease use \"sendmail <title>\" to continue.\nYou can use \"sendmail stop\" at any time to stop creating the mail.",
+      "templates": "Mail templates are not implemented yet.",
       "invalid_arguments": "Invalid arguments.",
       "send_cancel": "Message sending cancelled.",
-      "send_done": "Message sent to user %s!",
-      "send_all_done": "Message sent to all users!",
-      "not_composition_end": "Message composition not at final stage.\nPlease use '/sendmail %s' or '/sendmail stop' to cancel",
-      "please_use": "Please use '/sendmail %s'",
-      "set_title": "Message title set as '%s'.\nUse '/sendmail <content>' to continue.",
-      "set_contents": "Message contents set as '%s'.\nUse '/sendmail <sender>' to continue.",
-      "set_message_sender": "Message sender set as '%s'.\nUse '/sendmail <itemID|itemName|finish> [amount] [level]' to continue.",
-      "send": "Attached %s of %s (level %s) to the message.\nContinue adding more items or use '/sendmail finish' to send the message.",
-      "invalid_arguments_please_use": "Invalid arguments.\n Please use '/sendmail %s'",
+      "send_done": "Message sent to player %s.",
+      "send_all_done": "Message sent to all players.",
+      "not_composition_end": "Message composition not at final stage.\nPlease use 'sendmail %s' or 'sendmail stop' to cancel",
+      "please_use": "Usage: \"sendmail %s\".",
+      "set_title": "Message title set to:\n\n%s\n\nUse \"sendmail <content>\" to continue.",
+      "set_contents": "Message's contents set to:\n\n%s\n\nUse \"sendmail <sender>\" to continue.",
+      "set_message_sender": "Message sender set to:\n\n%s\n\nUse \"sendmail %s\" to continue.",
+      "send": "Attached %s of %s with level %s to the message.\nContinue adding more items or use \"sendmail finish\" to send the message.",
+      "invalid_arguments_please_use": "Invalid arguments.\n Please use 'sendmail %s'",
       "title": "<title>",
       "message": "<message>",
       "sender": "<sender>",
-      "arguments": "<itemID|itemName|finish> [amount] [level]",
-      "error": "ERROR: Invalid construction stage %s. Check console for stacktrace.",
-      "description": "Sends mail to the specified user. The usage of this command changes based on its composition state"
+      "arguments": "<itemID|itemName|finish> [amount] [level] [refinement]",
+      "error": "ERROR: Invalid construction stage %s.",
+      "description": "Send a mail to the specified player."
     },
     "sendMessage": {
-      "usage": "Usage: sendmessage <message>",
+      "usage": "sendmessage @<playerID> <message>",
       "success": "Message sent.",
-      "description": "Sends a message to a player as the server. If used with no target, sends to all players on the server."
+      "description": "Send a message to a player as the server. If used with no target, send to all players on the server."
     },
     "setFetterLevel": {
-      "usage": "Usage: setfetterlevel <level>",
+      "usage": "setfetterlevel <level>",
       "range_error": "Fetter level must be between 0 and 10.",
       "success": "Fetter level set to %s.",
       "level_error": "Invalid fetter level.",
-      "description": "Sets your fetter level for your current active character"
+      "description": "Set the target player's fetter level for their current active character."
     },
     "setProp": {
-      "usage": "Usage: setprop|prop <prop> <value>\n\tValues for <prop>: godmode | nostamina | unlimitedenergy | abyss | worldlevel | bplevel\n\t(cont.) see PlayerProperty enum for other possible values, of form PROP_MAX_SPRING_VOLUME -> max_spring_volume",
-      "description": "Sets accountwide properties. Things like godmode can be enabled this way, as well as changing things like unlocked abyss floor and battle pass progress."
+      "usage": "setprop <prop> <value>\n\tPossible values for \"prop\": godmode | nostamina | unlimitedenergy | abyss | worldlevel | ...\n\tThis command supports more types of \"prop\". You can see them all in the file \"game/props/PlayerProperty.java\".\n\tIn that file, the \"prop\" names are in the form of \"PROP_XXX_YYY_ZZZ\", but you need to write them as \"xxx_yyy_zzz\" if you want to use them in this command.",
+      "description": "Set accountwide properties. Things like godmode can be enabled this way, as well as changing things like unlocked abyss floor and battle pass progress."
     },
     "setStats": {
-      "usage": "Usage: setstats|stats <stat> <value>\n\tValues for <stat>: hp | maxhp | def | atk | em | er | crate | cdmg | cdr | heal | heali | shield | defi\n\t(cont.) Elemental DMG Bonus: epyro | ecryo | ehydro | egeo | edendro | eelectro | ephys\n\t(cont.) Elemental RES: respyro | rescryo | reshydro | resgeo | resdendro | reselectro | resphys\n",
-      "description": "Sets fight property for your current active character"
+      "usage": "setstats <stat> <value>\n\tValues for \"stat\": hp | maxhp | def | atk | em | er | crate | cdmg | cdr | heal | heali | shield | defi\n\tElemental DMG Bonus: epyro | ecryo | ehydro | egeo | edendro | eelectro | ephys\n\tElemental RES: respyro | rescryo | reshydro | resgeo | resdendro | reselectro | resphys",
+      "description": "Set a fight property for the target player's current active character."
     },
     "spawn": {
-      "usage": "Usage: spawn <entityID> [amount] [level(monster only)] [<x> <y> <z>(monster only, optional)]",
-      "success": "Spawned %s of %s.",
+      "usage": "spawn <entityID> [amount] [level (monster only)] [<x> <y> <z> (monster only)]",
+      "success": "Spawned %s entities of ID %s.",
       "limit_reached": "Scene spawn limit reached. Spawning %s entities instead.",
-      "description": "Spawns an entity near you"
+      "description": "Spawn an entity near the target player."
     },
     "stop": {
-      "success": "Server shutting down...",
-      "description": "Stops the server"
+      "usage": "stop",
+      "success": "Server is stopping...",
+      "description": "Stop the server."
     },
     "talent": {
-      "usage_1": "To set talent level: /talent set <talentID> <value>",
-      "usage_2": "Another way to set talent level: /talent <n or e or q> <value>",
-      "usage_3": "To get talent ID: /talent getid",
-      "lower_16": "Invalid talent level. Level should be lower than 16.",
-      "set_id": "Set talent to %s.",
-      "set_atk": "Set talent Normal ATK to %s.",
-      "set_e": "Set talent E to %s.",
-      "set_q": "Set talent Q to %s.",
+      "usage_1": "To set talent level, use: \"talent set <talentID> <level>\".",
+      "usage_2": "You can also use: \"talent <n or e or q> <level>\".",
+      "usage_3": "To get a talent ID, use: \"talent getid\"",
+      "lower_16": "Invalid talent level. It should be lower than 16.",
+      "set_id": "Set talent level to %s.",
+      "set_atk": "Set talent Normal ATK's level to %s.",
+      "set_e": "Set talent E's level to %s.",
+      "set_q": "Set talent Q's level to %s.",
       "invalid_skill_id": "Invalid skill ID.",
-      "set_this": "Set this talent to %s.",
+      "set_this": "Set this talent's level to %s.",
       "invalid_level": "Invalid talent level.",
-      "normal_attack_id": "Normal Attack ID %s.",
-      "e_skill_id": "E skill ID %s.",
-      "q_skill_id": "Q skill ID %s.",
-      "description": "Set talent level for your current active character"
+      "normal_attack_id": "Normal Attack ID: %s.",
+      "e_skill_id": "E skill ID: %s.",
+      "q_skill_id": "Q skill ID: %s.",
+      "description": "Set talent level for the target player's current active character."
     },
     "team": {
-      "usage": "Usage: team <add|remove|set> [avatarID,...] [index|first|last|index-index,...]",
+      "usage": "team <add|remove|set> [avatarID, ...] [index|first|last|minIndex-maxIndex, ...]",
       "invalid_usage": "Invalid usage.",
-      "add_usage": "Usage (add): team add <avatarID,...> [index]",
+      "add_usage": "team add <avatarID, ...> [index]",
       "invalid_index": "Index is invalid.",
-      "add_too_much": "The server only allows you to have at most %d avatar(s) in your team.",
-      "failed_to_add_avatar": "Failed to add avatar ID %s.",
-      "remove_usage": "Usage (remove): team remove <index|first|last|index-index,...>",
-      "failed_to_parse_index": "Failed to parse index: %s",
+      "add_too_much": "The server only allows one to have at most %d avatar(s) in their team.",
+      "failed_to_add_avatar": "Failed to add avatar ID \"%s\".",
+      "remove_usage": "team remove <index|first|last|minIndex-maxIndex, ...>",
+      "failed_to_parse_index": "Failed to parse index \"%s\".",
       "remove_too_much": "You can't remove all your avatars.",
       "ignore_index": "Ignored index(es): %s",
-      "set_usage": "Usage (set): team set <index> <avatarID>",
+      "set_usage": "team set <index> <avatarID>",
       "index_out_of_range": "The index you specified is out of range.",
-      "failed_parse_avatar_id": "Failed to parse avatar ID: %s",
-      "avatar_already_in_team": "Avatar is already in team.",
-      "avatar_not_found": "Avatar %d not found.",
-      "description": "Modify your team manually."
+      "failed_parse_avatar_id": "Failed to parse avatar ID \"%s\".",
+      "avatar_already_in_team": "Given avatar ID is already in target player's team.",
+      "avatar_not_found": "Avatar ID %d not found.",
+      "description": "Modify the target player's team."
     },
     "teleportAll": {
-      "success": "Summoned all players to your location.",
+      "usage": "tpall",
+      "success": "Teleported all players to the target player.",
       "error": "You can only use this command in MP mode.",
-      "description": "Teleports all players in your world to your position"
+      "description": "Teleport all players to the target player."
     },
     "teleport": {
-      "usage_server": "Usage: tp @<playerID> <x> <y> <z> [sceneID]",
-      "usage": "Usage: tp [@<playerID>] <x> <y> <z> [sceneID]",
+      "usage_server": "tp @<playerID> <x> <y> <z> [sceneID]",
+      "usage": "tp [@<playerID>] <x> <y> <z> [sceneID]",
       "specify_player_id": "You must specify a player ID.",
-      "invalid_position": "Invalid position.",
+      "invalid_position": "Invalid position xyz.",
       "exists_error": "The specified scene does not exist.",
-      "success": "Teleported %s to %s, %s, %s in scene %s.",
-      "description": "Change the player's position"
+      "success": "Teleported player %s to coordinates (%s, %s, %s) in scene ID %s.",
+      "description": "Change the target player's position."
     },
     "weather": {
-      "usage": "Usage: weather [weatherId] [climateType]\nWeather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny, cloudy, rain, thunderstorm, snow, mist",
+      "usage": "weather [weatherId] [climateType]\n\tWeather IDs can be found in the \"WeatherExcelConfigData.json\" file.\n\tClimate types: sunny, cloudy, rain, thunderstorm, snow, mist.",
       "success": "Set weather ID to %s with climate type %s.",
       "status": "Current weather ID is %s with climate type %s.",
-      "description": "Changes weather ID and climate type. Weather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny, cloudy, rain, thunderstorm, snow, mist"
+      "description": "Change weather ID and climate type."
     },
     "ban": {
-      "command_usage": "Usage: ban <@playerId> [timestamp] [reason]",
-      "success": "Successful.",
+      "usage": "ban <@playerID> [for how long] [reason]",
+      "success": "Successfully banned the player.",
       "failure": "Failed, player not found.",
       "invalid_time": "Unable to parse timestamp.",
-      "description": "Ban a player"
+      "description": "Ban the target player."
     },
     "unban": {
-      "command_usage": "Usage: unban <@playerId>",
-      "success": "Successful.",
+      "usage": "unban <@playerID>",
+      "success": "Successfully unbanned the player.",
       "failure": "Failed, player not found.",
-      "description": "Unban a player"
+      "description": "Unban the target player."
     }
   },
   "gacha": {
@@ -389,7 +399,7 @@
     "index": {
       "title": "Documentation",
       "handbook": "GM Handbook",
-      "gacha_mapping": "Gacha mapping JSON"
+      "gacha_mapping": "JSON gacha mapping"
     }
   }
 }

--- a/src/main/resources/languages/pl-PL.json
+++ b/src/main/resources/languages/pl-PL.json
@@ -1,99 +1,106 @@
 {
   "messages": {
     "game": {
-      "port_bind": "Serwer gry uruchomiony na porcie: %s",
-      "connect": "Klient połączył się z %s",
-      "disconnect": "Klient rozłączył się z %s",
+      "port_bind": "Serwer gry został uruchomiony na porcie %s.",
+      "connect": "Klient połączył się z %s.",
+      "disconnect": "Klient rozłączył się z %s.",
       "game_update_error": "Wystąpił błąd podczas aktualizacji gry.",
-      "command_error": "Błąd komendy:"
+      "command_error": "Błąd komendy: "
     },
     "dispatch": {
-      "port_bind": "[Dispatch] Serwer dispatch wystartował na porcie %s",
-      "request": "[Dispatch] Klient %s %s zapytanie: %s",
+      "port_bind": "[Dispatch] Serwer Dispatch został uruchomiony na porcie %s.",
+      "request": "[Dispatch] Żądanie klienta %s (metoda %s): %s",
       "keystore": {
-        "general_error": "[Dispatch] Błąd łądowania keystore!",
-        "password_error": "[Dispatch] Nie można załadować keystore. Próba z domyślnym hasłem keystore...",
-        "no_keystore_error": "[Dispatch] Brak certyfikatu SSL! Przejście na serwer HTTP.",
-        "default_password": "[Dispatch] Domyślne hasło keystore zadziałało. Rozważ ustawienie go na 123456 w pliku config.json."
+        "general_error": "[Keystore] Wystąpił błąd podczas ładowania keystore.",
+        "password_error": "[Keystore] Nie można załadować keystore. Spróbuję użyć domyślnego hasła...",
+        "no_keystore_error": "[Keystore] Brak certyfikatu SSL. Przejście na serwer HTTP.",
+        "default_password": "[Keystore] Domyślne hasło keystore zostało załadowane. Rozważ ustawienie tego hasła jako \"123456\" w pliku config.json."
+      },
+      "authentication": {
+        "default_unable_to_verify": "[Authentication] Coś wywołało metodę \"verifyUser\", która jest niedostępna w domyślnym kontrolerze uwierzytelniającym."
       },
       "no_commands_error": "Komendy nie są wspierane w trybie DISPATCH_ONLY.",
-      "unhandled_request_error": "[Dispatch] Potencjalnie niepodtrzymane %s zapytanie: %s",
+      "unhandled_request_error": "[Dispatch] Potencjalnie nierozstrzygnięte żądanie (metoda %s): %s",
       "account": {
-        "login_attempt": "[Dispatch] Klient %s próbuje się zalogować",
-        "login_success": "[Dispatch] Klient %s zalogował się jako %s",
-        "login_max_player_limit": "[Dispatch] Klient %s nie powiodło się: Liczba graczy online osiągnęła limit",
-        "login_token_attempt": "[Dispatch] Klient %s próbuje się zalogować poprzez token",
-        "login_token_error": "[Dispatch] Klient %s nie mógł się zalogować poprzez token",
-        "login_token_success": "[Dispatch] Klient %s zalogował się poprzez token jako %s",
-        "combo_token_success": "[Dispatch] Klient %s pomyślnie wymienił combo token",
-        "combo_token_error": "[Dispatch] Klient %s nie wymienił combo token'u",
-        "account_login_create_success": "[Dispatch] Klient %s nie mógł się zalogować: Konto %s stworzone",
-        "account_login_create_error": "[Dispatch] Klient %s nie mógł się zalogować: Tworzenie konta nie powiodło się",
-        "account_login_exist_error": "[Dispatch] Klient %s nie mógł się zalogować: Nie znaleziono konta",
-        "account_cache_error": "Błąd pamięci cache konta gry",
+        "login_attempt": "[Account] Klient %s próbuje się zalogować.",
+        "login_success": "[Account] Klient %s zalogował się jako %s.",
+        "login_max_player_limit": "[Account] Logowanie klienta %s nie powiodło się: liczba graczy online osiągnęła swój limit.",
+        "login_token_attempt": "[Account] Klient %s próbuje się zalogować poprzez token.",
+        "login_token_error": "[Account] Logowanie klienta %s poprzez token nie powiodło się.",
+        "login_token_success": "[Account] Klient %s zalogował się poprzez token jako %s.",
+        "combo_token_success": "[Account] Klient %s pomyślnie wymienił token combo.",
+        "combo_token_error": "[Account] Wymienienie tokena combo klienta %s nie powiodło się.",
+        "account_login_create_success": "[Account] Logowanie klienta %s powiodło się: konto %s zostało stworzone.",
+        "account_login_create_error": "[Account] Logowanie klienta %s nie powiodło się: tworzenie konta nie powiodło się.",
+        "account_login_exist_error": "[Account] Logowanie klienta %s nie powiodło się: nie znaleziono konta.",
+        "account_cache_error": "Błąd pamięci cache konta gry.",
         "session_key_error": "Błędny klucz sesji.",
-        "username_error": "Nazwa użytkownika nie znaleziona.",
-        "username_create_error": "Nazwa użytkownika nie znaleziona, tworzenie nie powiodło się.",
-        "server_max_player_limit": "Liczba graczy online osiągnęła limit"
-      }
+        "username_error": "Podana nazwa użytkownika nie istnieje.",
+        "username_create_error": "Podana nazwa użytkownika nie istnieje. Automatyczne tworzenie nowego konta nie powiodło się.",
+        "server_max_player_limit": "Liczba graczy online osiągnęła swój limit."
+      },
+      "router_error": "[Dispatch] Wystąpił błąd podczas tworzenia routera."
     },
     "status": {
-      "free_software": "Grasscutter to DARMOWE oprogramowanie. Jeżeli ktoś Ci je sprzedał, to zostałeś oscamowany. Strona domowa: https://github.com/Grasscutters/Grasscutter",
+      "free_software": "Grasscutter to DARMOWE oprogramowanie oparte na licencji AGPL-3.0. Jeżeli za nie zapłaciłeś, zostałeś oszukany. Strona projektu: https://github.com/Grasscutters/Grasscutter",
       "starting": "Uruchamianie Grasscutter...",
-      "shutdown": "Wyłączanie...",
-      "done": "Gotowe! Wpisz \"help\" aby uzyskać pomoc",
+      "shutdown": "Zatrzymywanie Grasscutter...",
+      "done": "Gotowe! Wpisz \"help\", aby uzyskać pomoc.",
       "error": "Wystąpił błąd.",
-      "welcome": "Witamy w Grasscutter",
+      "welcome": "Witamy w Grasscutter!",
       "run_mode_error": "Błędny tryb pracy serwera: %s.",
-      "run_mode_help": "Tryb pracy serwera musi być ustawiony na 'HYBRID', 'DISPATCH_ONLY', lub 'GAME_ONLY'. Nie można wystartować Grasscutter...",
-      "create_resources": "Tworzenie folderu resources...",
-      "resources_error": "Umieść kopię 'BinOutput' i 'ExcelBinOutput' w folderze resources.",
-      "version": "Grasscutter versión: %s-%s",
-      "game_version": "Game versión: %s",
+      "run_mode_help": "Tryb pracy serwera musi być ustawiony na \"HYBRID\", \"DISPATCH_ONLY\", lub \"GAME_ONLY\".",
+      "create_resources": "Tworzenie folderu \"resources\"...",
+      "resources_error": "Umieść kopię folderów \"BinOutput\" oraz \"ExcelBinOutput\" w folderze \"resources\" i spróbuj ponownie.",
+      "version": "Wersja Grasscutter: %s-%s",
+      "game_version": "Wersja gry: %s",
       "resources": {
-        "loading": "Loading resources...",
-        "finish": "Finished loading resources."
+        "loading": "Ładowanie zasobów...",
+        "finish": "Załadowano zasoby."
       }
     }
   },
   "commands": {
     "generic": {
       "not_specified": "Nie podano komendy.",
-      "unknown_command": "Nieznana komenda: %s",
-      "permission_error": "Nie masz uprawnień do tej komendy.",
-      "console_execute_error": "Tą komende można wywołać tylko z konsoli.",
-      "player_execute_error": "Wywołaj tą komendę w grze.",
+      "unknown_command": "Nieznana komenda: %s.",
+      "permission_error": "Nie masz wystarczających uprawnień do używania tej komendy.",
+      "console_execute_error": "Ta komenda może być użyta tylko w konsoli.",
+      "player_execute_error": "Ta komenda może być użyta tylko w grze.",
       "command_exist_error": "Nie znaleziono komendy.",
+      "no_usage_specified": "Brak przykładu zastosowania.",
+      "no_description_specified": "Brak opisu.",
       "set_to": "%s ustawiono na %s.",
-      "set_for_to": "%s dla %s ustawiono na %s.",
+      "set_for_to": "%s (UID %s) ustawiono na %s.",
       "invalid": {
         "amount": "Błędna ilość.",
         "artifactId": "Błędne ID artefaktu.",
-        "avatarId": "Błędne id postaci.",
+        "avatarId": "Błędne ID postaci.",
         "avatarLevel": "Błędny poziom postaci.",
-        "entityId": "Błędne id obiektu.",
-        "id przedmiotu": "Błędne id przedmiotu.",
+        "entityId": "Błędne ID obiektu.",
+        "itemId": "Błędne ID przedmiotu.",
         "itemLevel": "Błędny poziom przedmiotu.",
         "itemRefinement": "Błędne ulepszenie.",
-        "value_between": "Invalid value: %s must be between %s and %s.",
-        "playerId": "Błędne playerId.",
+        "statValue": "Błędna wartość atrybutu.",
+        "value_between": "Błędna wartość: %s musi być pomiędzy %s a %s.",
+        "playerId": "Błędne ID gracza.",
         "uid": "Błędne UID.",
         "id": "Błędne ID."
       }
     },
     "execution": {
-      "player_exist_error": "Gracz nie znaleziony.",
+      "player_exist_error": "Gracz nie istnieje.",
       "player_offline_error": "Gracz nie jest online.",
-      "item_player_exist_error": "Błędny przedmiot lub UID.",
-      "player_exist_offline_error": "Gracz nie znaleziony lub jest offline.",
-      "argument_error": "Błędne argumenty.",
-      "clear_target": "Cel wyczyszczony.",
-      "set_target": "Następne komendy będą celować w @%s.",
-      "set_target_online": "@%s jest online. Niektóre polecenia mogą wymagać celu offline.",
-      "set_target_offline": "@%s jest offline. Niektóre polecenia mogą wymagać celu online.",
-      "need_target": "Ta komenda wymaga docelowego UID. Dodaj argument <@UID> lub ustaw stały cel poleceniem /target @UID.",
-      "need_target_online": "To polecenie wymaga identyfikatora UID celu w trybie online, ale bieżący cel jest w trybie offline. Dodaj inny argument <@UID> lub ustaw trwały cel za pomocą /target @UID.",
-      "need_target_offline": "To polecenie wymaga identyfikatora UID celu offline, ale bieżący cel jest online. Dodaj inny argument <@UID> lub ustaw trwały cel za pomocą /target @UID."
+      "item_player_exist_error": "Błędny przedmiot lub ID.",
+      "player_exist_offline_error": "Gracz nie istnieje lub nie jest online.",
+      "argument_error": "Błędny argument lub argumenty.",
+      "clear_target": "Następne komendy nie będą dotyczyły nikogo. Będziesz musiał/a sam/a dodać ID gracza docelowego do każdej kolejnej komendy.",
+      "set_target": "Następne komendy będą dotyczyły gracza @%s.",
+      "set_target_online": "Gracz @%s jest online. Niektóre polecenia wymagają trybu offline i mogą nie działać.",
+      "set_target_offline": "Gracz @%s jest offline. Niektóre polecenia wymagają trybu online i mogą nie działać.",
+      "need_target": "Ta komenda wymaga ID gracza. Dodaj argument <@ID>, lub ustaw ID tego gracza na stałe dla każdej kolejnej komendy poleceniem \"set_target @ID\".",
+      "need_target_online": "Ta komenda wymaga ID gracza, który jest online, ale bieżący gracz docelowy jest w trybie offline. Dodaj inny argument <@ID> lub ustaw ID gracza na stałe dla każdej kolejnej komendy poleceniem \"set_target @ID\".",
+      "need_target_offline": "Ta komenda wymaga ID gracza, który jest offline, ale bieżący gracz docelowy jest w trybie online. Dodaj inny argument <@ID> lub ustaw ID gracza na stałe dla każdej kolejnej komendy poleceniem \"set_target @ID\"."
     },
     "status": {
       "enabled": "Włączone",
@@ -102,221 +109,297 @@
       "success": "Sukces"
     },
     "account": {
-      "modify": "Modyfikuj konta użytkowników",
-      "invalid": "Błędne UID.",
-      "exists": "Konto już istnieje.",
+      "usage": "account <create|delete> <nazwa gracza> [UID]",
+      "invalid": "Błędne UID gracza.",
+      "exists": "Konto o tej nazwie użytkownika i/lub UID już istnieje.",
       "create": "Stworzono konto z UID %s.",
-      "delete": "Konto usunięte.",
+      "delete": "Konto zostało usunięte.",
       "no_account": "Nie znaleziono konta.",
-      "command_usage": "Użycie: account <create|delete> <nazwa> [uid]"
+      "description": "Twórz lub usuń konta."
+    },
+    "announce": {
+      "usage": "announce <tpl> <ID szablonu> LUB announce <refresh> LUB announce <wiadomość> LUB announce <revoke> <ID szablonu>",
+      "send_success": "Ogłoszenie zostało pomyślnie wysłane. Możesz je odwołać używając \"announce revoke %s\".",
+      "refresh_success": "Odświeżono konfigurację ogłoszeń (w sumie jest ich %s).",
+      "revoke_done": "Pomyślnie odwołano ogłoszenie %s.",
+      "not_found": "Nie znaleziono ogłoszenia %s.",
+      "description": "Wysyłaj i zarządzaj ogłoszeniami."
     },
     "clear": {
-      "command_usage": "Użycie: clear <all|wp|art|mat>",
-      "weapons": "Wyczyszczono bronie dla %s.",
-      "artifacts": "Wyczyszczono artefakty dla %s.",
-      "materials": "Wyczyszczono materiały dla %s.",
-      "furniture": "Wyczyszczono meble dla %s.",
-      "displays": "Wyczyszczono displays dla %s.",
-      "virtuals": "Wyczyszczono virtuals dla %s.",
-      "everything": "Wyczyszczono wszystko dla %s."
+      "usage": "clear <all|wp|art|mat>",
+      "weapons": "Usunięto bronie gracza %s.",
+      "artifacts": "Usunięto artefakty gracza %s.",
+      "materials": "Usunięto materiały gracza %s.",
+      "furniture": "Usunięto meble gracza %s.",
+      "displays": "Usunięto displaye gracza %s.",
+      "virtuals": "Usunięto virtuale gracza %s.",
+      "everything": "Usunięto wszystkie niewyposażone przedmioty gracza %s.",
+      "description": "Usuń niewyposażone przedmioty wskazanego gracza."
     },
     "coop": {
-      "usage": "Użycie: coop [host uid]",
-      "success": "Przyzwano %s do świata %s."
+      "usage": "coop @[ID gracza]",
+      "success": "Pomyślnie dodano gracza %s do świata gracza %s.",
+      "description": "Dodaj wskazanego gracza do swojego świata."
     },
     "enter_dungeon": {
-      "usage": "Użycie: enterdungeon <ID lochu>",
-      "changed": "Zmieniono loch na %s",
-      "not_found_error": "Ten loch nie istnieje",
-      "in_dungeon_error": "Już jesteś w tym lochu"
-    },
-    "giveAll": {
-      "usage": "Użycie: giveall [gracz] [ilość]",
-      "started": "Dodawanie wszystkich przedmiotów...",
-      "success": "Pomyślnie dodano wszystkie przedmioty dla %s.",
-      "invalid_amount_or_playerId": "Błędna ilość lub ID gracza."
-    },
-    "giveArtifact": {
-      "usage": "Użycie: giveart|gart [gracz] <id artefaktu> <mainPropId> [<appendPropId>[,<razy>]]... [poziom]",
-      "id_error": "Błędne ID artefaktu.",
-      "success": "Dano %s dla %s."
+      "usage": "enterdungeon <ID lochu>",
+      "changed": "Pomyślnie zmieniono loch na %s.",
+      "not_found_error": "Podane ID lochu jest nieprawidłowe.",
+      "in_dungeon_error": "Wskazany gracz już jest w tym lochu.",
+      "description": "Zmień loch, w którym ma się znajdować wskazany gracz."
     },
     "give": {
-            "usage": "Użycie: give <gracz> <id przedmiotu | avatarID> [ilość] [poziom] [refinement]",
-      "refinement_only_applicable_weapons": "Ulepszenie można zastosować tylko dla broni.",
-      "refinement_must_between_1_and_5": "Ulepszenie musi być pomiędzy 1, a 5.",
-      "given": "Dano %s %s dla %s.",
-      "given_with_level_and_refinement": "Dano %s z poziomem %s, ulepszeniem %s %s razy dla %s",
-            "given_level": "Dano %s z poziomem %s %s razy dla %s",
-            "given_avatar": "Dano %s z poziomem %s dla %s."
-    },
-    "godmode": {
-      "success": "Godmode jest teraz %s dla %s."
+      "usage": "give <ID przedmiotu|ID awataru|all|weapons|mats|avatars> [x<ilość>] [lv<poziom>] [r<poziom ulepszenia>]",
+      "usage_relic": "give <ID reliktu> [ID pierwszego przedmiotu] [<ID drugiego przedmiotu>[, <ile razy je połączyć>]]... [lv<poziom od 0 do 20>]",
+      "illegal_relic": "Ten ID reliktu znajduje się na czarnej liście i może być nie tym, czego szukasz.",
+      "given": "Dodano %s przedmiotów o ID %s graczowi o ID %s.",
+      "given_with_level_and_refinement": "Dodano %s przedmiotów o poziomie %s oraz poziomie ulepszenia %s i ID %s graczowi o ID %s.",
+      "given_level": "Dodano %s artefaktów o poziomie %s oraz ID %s graczowi o ID %s.",
+      "given_avatar": "Dodano awatar o ID %s oraz poziomie %s graczowi o ID %s.",
+      "giveall_success": "Pomyślnie dodano wybrane przedmioty.",
+      "description": "Dodaj wybrane przedmioty do ekwipunku wybranego gracza."
     },
     "heal": {
-      "success": "Wszystkie postacie zostały wyleczone."
+      "usage": "heal",
+      "success": "Wszystkie postacie zostały uleczone.",
+      "description": "Ulecz wszystkie postacie w swoim zespole."
+    },
+    "help": {
+      "usage": "help [nazwa komendy]",
+      "usage_prefix": "Użycie: ",
+      "aliases": "Aliasy: ",
+      "available_commands": "Dostępne komendy: ",
+      "description": "Wyświetl wszystkie komendy lub informacje na temat danej komendy.",
+      "tip_need_permission": "Wymagane uprawnienie: ",
+      "tip_need_no_permission": "brak",
+      "tip_permission_targeted": "(użycie tego polecenia na innych graczach również wymaga uprawnienia %s)",
+      "warn_player_has_no_permission": "Nie masz wystarczających uprawnień do używania tej komendy."
     },
     "kick": {
-      "player_kick_player": "Gracz [%s:%s] wyrzucił gracza [%s:%s]",
-      "server_kick_player": "Wyrzucono gracza [%s:%s]"
+      "usage": "kick",
+      "player_kick_player": "Gracz [%s:%s] wyrzucił gracza [%s:%s].",
+      "server_kick_player": "Wyrzucono gracza [%s:%s].",
+      "description": "Wyrzuć wskazanego gracza z gry."
     },
     "killall": {
-      "usage": "Użycie: killall [UID gracza] [ID sceny]",
-      "scene_not_found_in_player_world": "Scena nie znaleziona w świecie gracza",
-      "kill_monsters_in_scene": "Zabito %s potworów w scenie %s"
+      "usage": "killall @[ID gracza] [ID sceny]",
+      "scene_not_found_in_player_world": "Błędny ID sceny.",
+      "kill_monsters_in_scene": "Zabito %s potworów w scenie %s.",
+      "description": "Zabij wszystkie potwory we wskazanej scenie."
     },
     "killCharacter": {
-      "usage": "Użycie: /killcharacter [ID gracza]",
-      "success": "Zabito aktualną postać gracza %s."
+      "usage": "killcharacter @[ID gracza]",
+      "success": "Pomyślnie zabito postać gracza %s.",
+      "description": "Zabij postać wskazanego gracza."
+    },
+    "language": {
+      "usage": "language [kod języka]",
+      "current_language": "Bieżący kod języka to %s.",
+      "language_changed": "Zmieniono język na ten o kodzie %s.",
+      "language_not_found": "Nie znaleziono języka o kodzie \"%s\".",
+      "description": "Pokaż lub zmień bieżący kod języka."
     },
     "list": {
-      "success": "Teraz jest %s gracz(y) online:"
+      "usage": "list @[ID gracza]",
+      "success": "%s graczy online:",
+      "description": "Pokaż ile jest graczy na serwerze."
     },
     "permission": {
-      "usage": "Użycie: permission <add|remove> <nazwa gracza> <uprawnienie>",
-      "add": "Dodano uprawnienie",
-      "has_error": "To konto już ma to uprawnienie!",
-      "remove": "Usunięto uprawnienie.",
-      "not_have_error": "To konto nie ma tych uprawnień!",
-      "account_error": "Konto nie może zostać znalezione."
+      "usage": "permission <add|remove> <nazwa gracza> <uprawnienie>",
+      "add": "Pomyślnie dodano uprawnienie.",
+      "has_error": "Ten gracz już ma to uprawnienie.",
+      "remove": "Pomyślnie usunięto uprawnienie.",
+      "not_have_error": "Ten gracz nie ma tego uprawnienia.",
+      "account_error": "Podana nazwa gracza nie istnieje.",
+      "description": "Dodaj lub usuń uprawnienia podanego gracza."
     },
     "position": {
-      "success": "Koordynaty: %s, %s, %s\nID sceny: %s"
+      "usage": "position",
+      "success": "Koordynaty: (%s, %s, %s).\nID sceny: %s.",
+      "description": "Pokaż gdzie znajduje się dany gracz."
+    },
+    "quest": {
+      "usage": "quest <add|finish> [ID zadania]",
+      "added": "Zadanie %s zostało dodane.",
+      "finished": "Zadanie %s zostało zakończone.",
+      "not_found": "Nie ma zadania o podanym ID.",
+      "invalid_id": "Błędny format ID zadania.",
+      "description": "Dodaj lub wykonaj wskazane zadanie."
     },
     "reload": {
-      "reload_start": "Ponowne ładowanie konfiguracji.",
-      "reload_done": "Ponowne ładowanie zakończone."
+      "usage": "reload",
+      "reload_start": "Ponowne ładowanie konfiguracji...",
+      "reload_done": "Ponowne ładowanie konfiguracji zakończone.",
+      "description": "Ponownie załaduj język, konfigurację oraz inne dane gry."
     },
     "resetConst": {
-      "reset_all": "Resetuj konstelacje wszystkich postaci.",
-      "success": "Konstelacje dla %s zostały zresetowane. Proszę zalogować się ponownie aby zobaczyć zmiany."
+      "usage": "resetconst [all]",
+      "reset_all": "Zresetowano konstelacje dla wszystkich postaci. Aby zobaczyć zmiany, zaloguj się ponownie.",
+      "success": "Konstelacje awatara %s zostały zresetowane. Aby zobaczyć zmiany, zaloguj się ponownie.",
+      "description": "Resetuj konstelacje wszystkich lub wybranej postaci."
     },
     "resetShopLimit": {
-      "usage": "Użycie: /resetshop <ID gracza>",
-      "success": "Reset complete.",
-      "description": "Reset target player's shop refresh time"
+      "usage": "resetshop @<ID gracza>",
+      "success": "Zresetowano czas odświeżania sklepu podanego gracza.",
+      "description": "Resetuj czas odświeżania sklepu podanego gracza."
     },
     "sendMail": {
-      "usage": "Użycie: /sendmail <ID gracza | all | help> [id szablonu]",
-      "user_not_exist": "Gracz o ID '%s' nie istnieje",
-      "start_composition": "Komponowanie wiadomości.\nProszę użyj '/sendmail <tytuł>' aby kontynuować.\nMożesz użyć '/sendmail stop' w dowolnym momencie",
-      "templates": "Szablony zostaną zaimplementowane niedługo...",
+      "usage": "sendmail <@<ID gracza>|all|help> [ID szablonu]",
+      "user_not_exist": "Gracz o podanym ID %s nie istnieje.",
+      "start_composition": "Tworzenie wiadomości.\nUżyj \"sendmail <tytuł>\", aby kontynuować.\nMożesz użyć \"sendmail stop\" w dowolnym momencie, aby przestać.",
+      "templates": "Szablony nie są jeszcze gotowe do użycia.",
       "invalid_arguments": "Błędne argumenty.",
       "send_cancel": "Anulowano wysyłanie wiadomości",
-      "send_done": "Wysłano wiadomość do gracza %s!",
-      "send_all_done": "Wysłano wiadomośc do wszystkich graczy!",
-      "not_composition_end": "Komponowanie nie jest na ostatnim etapie.\nProszę użyj '/sendmail %s' lub '/sendmail stop' aby anulować",
-      "please_use": "Proszę użyj '/sendmail %s'",
-      "set_title": "Tytuł wiadomości to teraz: '%s'.\nUżyj '/sendmail <treść>' aby kontynuować.",
-      "set_contents": "Treść wiadomości to teraz '%s'.\nUżyj '/sendmail <nadawca>' aby kontynuować.",
-      "set_message_sender": "Nadawca wiadomości to teraz '%s'.\nUżyj '/sendmail <id przedmiotu | nazwa przedmiotu | zakończ> [ilość] [poziom]' aby kontynuować.",
-      "send": "Załączono %s %s (poziom %s) do wiadomości.\nDodaj więcej przedmiotów lub użyj '/sendmail finish' aby wysłać wiadomość.",
-      "invalid_arguments_please_use": "Błędne argumenty.\nProszę użyj '/sendmail %s'",
+      "send_done": "Wysłano wiadomość do gracza %s.",
+      "send_all_done": "Wysłano wiadomość do wszystkich graczy.",
+      "not_composition_end": "Tworzenie wiadomości nie jest jeszcze na ostatnim etapie. Jeżeli naprawdę chcesz teraz przestać, użyj \"sendmail %s\" lub \"sendmail stop\".",
+      "please_use": "Użycie: \"sendmail %s\".",
+      "set_title": "Tytuł wiadomości to teraz:\n\n%s\n\nUżyj \"sendmail <treść>\", aby kontynuować.",
+      "set_contents": "Treść wiadomości to teraz:\n\n%s\n\nUżyj \"sendmail <nadawca>\", aby kontynuować.",
+      "set_message_sender": "Nadawca wiadomości to teraz:\n\n%s\n\nUżyj \"sendmail %s\", aby kontynuować.",
+      "send": "Załączono %s przedmiotów %s o poziomie %s do wiadomości.\nMożesz dodać więcej przedmiotów lub użyć \"sendmail finish\", aby wysłać wiadomość.",
+      "invalid_arguments_please_use": "Błędne argumenty.\nProszę użyj \"sendmail %s\"",
       "title": "<tytuł>",
       "message": "<wiadomość>",
       "sender": "<nadawca>",
-      "arguments": "<id przedmiotu | nazwa przedmiotu | zakończ> [ilość] [poziom]",
-      "error": "BŁĄD: niepoprawny etap konstrukcji: %s. Sprawdź konsolę aby dowiedzieć się więcej."
+      "arguments": "<ID przedmiotu|nazwa przedmiotu|finish> [ilość] [poziom] [poziom ulepszenia]",
+      "error": "BŁĄD: niepoprawny etap konstrukcji: %s.",
+      "description": "Wyślij wiadomość wraz z przedmiotami do wybranego lub wszystkich graczy."
     },
     "sendMessage": {
-      "usage": "Użycie: /sendmessage <player> <message>",
-      "success": "Wiadomość wysłana."
+      "usage": "sendmessage @<ID gracza> <wiadomość>",
+      "success": "Wiadomość wysłana.",
+      "description": "Wyślij wiadomość do gracza jako serwer. Jeśli nie określono celu, wysyła do wszystkich graczy na serwerze."
     },
     "setFetterLevel": {
-      "usage": "Użycie: setfetterlevel <poziom>",
-      "range_error": "Poziom przyjaźni musi być pomiędzy 0,a 10.",
-      "success": "Poziom przyjaźni ustawiono na: %s",
-      "level_error": "Błędny poziom przyjaźni."
+      "usage": "setfetterlevel <poziom przyjaźni>",
+      "range_error": "Poziom przyjaźni musi być pomiędzy 0 a 10.",
+      "success": "Poziom przyjaźni został pomyślnie ustawiony na %s.",
+      "level_error": "Błędny poziom przyjaźni.",
+      "description": "Ustaw poziom przyjaźni obecnej postaci."
     },
     "setProp": {
-      "usage": "Usage: setprop|prop <prop> <value>\n\tValues for <prop>: godmode | nostamina | unlimitedenergy | abyss | worldlevel | bplevel\n\t(cont.) see PlayerProperty enum for other possible values, of form PROP_MAX_SPRING_VOLUME -> max_spring_volume",
-      "description": "Sets accountwide properties. Things like godmode can be enabled this way, as well as changing things like unlocked abyss floor and battle pass progress."
+      "usage": "setprop <nazwa własności> <wartość>\n\tMożliwe nazwy własności: godmode | nostamina | unlimitedenergy | abyss | worldlevel | bplevel | ...\n\tTa komenda ma więcej nazw własności, które może otrzymać. Możesz je wszystkie zobaczyć w pliku \"game/props/PlayerProperty.java\".\n\tW tym pliku, przyjmują one formę \"PROP_XXX_YYY_ZZZ\", ale powinieneś je zapisywać jako \"xxx_yyy_zzz\" jeśli chcesz je użyć w tej komendzie.",
+      "description": "Ustaw pewne własności konta, takie jak tryb nieśmiertelności (godmode) czy też zmiana postępu Battle Pass."
     },
     "setStats": {
-      "usage": "Użycie: setstats|stats <statystyka> <wartość>\n\tWartości dla Statystyka: hp | maxhp | def | atk | em | er | crate | cdmg | cdr | heal | heali | shield | defi\n\t(cont.) Bonus DMG żywiołu: epyro | ecryo | ehydro | egeo | edendro | eelectro | ephys\n\t(cont.) RES na żywioł: respyro | rescryo | reshydro | resgeo | resdendro | reselectro | resphys\n",
-      "description": "Sets fight property for your current active character"
-    },
-    "setWorldLevel": {
-      "usage": "Użycie: setworldlevel <poziom>",
-      "value_error": "Poziom świata musi być pomiędzy 0, a 8",
-      "success": "Ustawiono poziom świata na: %s.",
-      "invalid_world_level": "Invalid world level."
+      "usage": "setstats <nazwa statystyki> <wartość>\n\tMożliwe nazwy statystyki: hp | maxhp | def | atk | em | er | crate | cdmg | cdr | heal | heali | shield | defi\n\tDodatkowe obrażenia od żywiołu: epyro | ecryo | ehydro | egeo | edendro | eelectro | ephys\n\tOdporność na żywioł: respyro | rescryo | reshydro | resgeo | resdendro | reselectro | resphys",
+      "description": "Ustaw statystykę walki dla obecnie wybranej postaci wybranego gracza."
     },
     "spawn": {
-      "usage": "Użycie: /spawn <id obiektu> [ilość] [poziom(tylko potwory)]",
-      "success": "Stworzono %s %s."
+      "usage": "spawn <ID obiektu> [ilość] [poziom (tylko potwory)] [<x> <y> <z> (tylko potwory)]",
+      "success": "Stworzono %s obiektów o ID %s.",
+      "limit_reached": "Osiągnięto maksymalną ilość obiektów w scenie. Dodane zostaną tylko %s.",
+      "description": "Dodaj wskazane obiekty do sceny wybranego gracza."
     },
     "stop": {
-      "success": "Serwer wyłącza się..."
+      "usage": "stop",
+      "success": "Serwer zatrzymuje się...",
+      "description": "Zatrzymaj serwer."
     },
     "talent": {
-      "usage_1": "Aby ustawić poziom talentu: /talent set <ID talentu> <wartość>",
-      "usage_2": "Inny sposób na ustawienie poziomu talentu: /talent <n lub e lub q> <wartość>",
-      "usage_3": "Aby uzyskać ID talentu: /talent getid",
-      "lower_16": "Błędny poziom talentu. Poziom powinien być mniejszy niż 16",
-      "set_id": "Ustawiono talent na %s.",
-      "set_atk": "Ustawiono talent Atak Podstawowy na poziom %s.",
+      "usage_1": "Aby ustawić poziom talentu, użyj: \"talent set <ID talentu> <wartość>\".",
+      "usage_2": "Możesz też użyć: \"talent <n lub e lub q> <wartość>\"",
+      "usage_3": "Aby uzyskać ID talentu, użyj: \"talent getid\"",
+      "lower_16": "Błędny poziom talentu. Poziom ten powinien być mniejszy niż 16.",
+      "set_id": "Ustawiono poziom talentu na %s.",
+      "set_atk": "Ustawiono poziom talentu Atak Podstawowy na %s.",
       "set_e": "Ustawiono poziom talentu E na %s.",
       "set_q": "Ustawiono poziom talentu Q na %s.",
       "invalid_skill_id": "Błędne ID umiejętności.",
-      "set_this": "Ustawiono ten talent na poziom %s.",
+      "set_this": "Ustawiono obecny talent na poziom %s.",
       "invalid_level": "Błędny poziom talentu.",
       "normal_attack_id": "ID podstawowego ataku: %s.",
       "e_skill_id": "ID umiejętności E: %s.",
-      "q_skill_id": "ID umiejętności Q: %s."
+      "q_skill_id": "ID umiejętności Q: %s.",
+      "description": "Ustaw poziomu talentu obecnie wybranej postaci wybranego gracza."
+    },
+    "team": {
+      "usage": "team <add|remove|set> [ID awatara, ...] [indeks|pierwszy|ostatni|pierwszy_indeks-ostatni_indeks, ...]",
+      "invalid_usage": "Nieprawidłowe użycie komendy.",
+      "add_usage": "team add <ID awatara, ...> [indeks]",
+      "invalid_index": "Błędny indeks.",
+      "add_too_much": "Można mieć maksymalnie %d postaci w zespole.",
+      "failed_to_add_avatar": "Błąd podczas dodawania awatara o ID \"%s\".",
+      "remove_usage": "team remove <indeks|pierwszy|ostatni|pierwszy_indeks-ostatni_indeks, ...>",
+      "failed_to_parse_index": "Błąd podczas przetwarzania indeksu \"%s\".",
+      "remove_too_much": "Nie możesz usunąć wszystkich awatarów w zespole.",
+      "ignore_index": "Ignorowanie indeksu/ów %s.",
+      "set_usage": "team set <indeks> <ID awatara>",
+      "index_out_of_range": "Podany indeks nie mieści się w swoim zakresie.",
+      "failed_parse_avatar_id": "Błędny ID awatara \"%s\".",
+      "avatar_already_in_team": "Podany awatar jest już w zespole wybranego gracza.",
+      "avatar_not_found": "Awatar o ID \"%d\" nie istnieje.",
+      "description": "Modyfikuj zespół wybranego gracza."
     },
     "teleportAll": {
-      "success": "Przyzwano wszystkich graczy do Ciebie.",
-      "error": "Możesz użyć tej komendy wyłącznie w trybie MP."
+      "usage": "tpall",
+      "success": "Przyzwano wszystkich graczy do wybranego gracza.",
+      "error": "Możesz użyć tej komendy wyłącznie w trybie MP.",
+      "description": "Przyzwij wszystkich graczy do wybranego gracza."
     },
     "teleport": {
-      "usage_server": "Użycie: /tp @<ID gracza> <x> <y> <z> [ID sceny]",
-      "usage": "Użycie: /tp [@<ID gracza>] <x> <y> <z> [ID sceny]",
-      "specify_player_id": "Musisz określić ID gracza.",
-      "invalid_position": "Błędna pozycja.",
-            "exists_error": "Ta scena nie istenieje.",
-      "success": "Przeteleportowano %s do %s, %s, %s w scenie %s"
+      "usage_server": "tp @<ID gracza> <x> <y> <z> [ID sceny]",
+      "usage": "tp [@<ID gracza>] <x> <y> <z> [ID sceny]",
+      "specify_player_id": "Musisz podać ID gracza.",
+      "invalid_position": "Błędna pozycja xyz.",
+      "exists_error": "Ta scena nie istenieje.",
+      "success": "Gracz %s został przeniesiony do pozycji (%s, %s, %s) w scenie o ID %s.",
+      "description": "Przemieść wybranego gracza do podanej pozycji w podanej scenie."
     },
     "weather": {
-      "description": "Changes the weather.Weather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny, cloudy, rain, thunderstorm, snow, mist.",
-      "usage": "Usage: weather [weatherId] [climateType]\nWeather IDs can be found in WeatherExcelConfigData.json.\nClimate types: sunny, cloudy, rain, thunderstorm, snow, mist.",
-      "success": "Set weather ID to %s with climate type %s.",
-      "status": "Current weather ID is %s with climate type %s."
-    },
-    "help": {
-      "usage": "Użycie: ",
-      "aliases": "Aliasy: ",
-      "available_commands": "Dostępne komendy: "
-    },
-    "unlocktower": {
-      "success": "odblokować gotowe",
-      "description": "Odblokuj głęboką spiralę"
+      "usage": "weather [ID pogody] [typ klimatu]\n\tID pogody można znaleźć w pliku \"WeatherExcelConfigData.json\".\n\tMożliwe typy klimatu: sunny (słoneczny), cloudy (pochmurny), rain (deszcz), thunderstorm (burza), snow (śnieg), mist (mgła)",
+      "success": "ID pogody został ustawiony na %s, a typ klimatu na %s.",
+      "status": "Bieżące ID pogody to %s, a typ klimatu to %s.",
+      "description": "Zmień ID pogody i typ klimatu."
     },
     "ban": {
-      "command_usage": "Usage: ban <@playerId> [timestamp] [reason]",
-      "success": "Successful.",
-      "failure": "Failed, player not found.",
-      "invalid_time": "Unable to parse timestamp.",
-      "description": "Ban a player"
+      "usage": "ban @<ID gracza> [na ile czasu] [powód]",
+      "success": "Pomyślnie zbanowano podanego gracza.",
+      "failure": "Gracz o podanym ID nie istnieje.",
+      "invalid_time": "Nieprawidłowy czas bana.",
+      "description": "Zbanuj podanego gracza."
     },
     "unban": {
-      "command_usage": "Usage: unban <@playerId>",
-      "success": "Successful.",
-      "failure": "Failed, player not found.",
-      "description": "Unban a player"
+      "usage": "unban @<ID gracza>",
+      "success": "Pomyślnie odbanowano podanego gracza.",
+      "failure": "Gracz o podanym ID nie istnieje.",
+      "description": "Odbanuj podanego gracza."
     }
   },
   "gacha": {
     "details": {
-      "title": "Banner Details",
-      "available_five_stars": "Available 5-star Items",
-      "available_four_stars": "Available 4-star Items",
-      "available_three_stars": "Available 3-star Items"
+      "title": "Szczegóły losowania",
+      "available_five_stars": "Dostępne 5-gwiazdkowe przedmioty",
+      "available_four_stars": "Dostępne 4-gwiazdkowe przedmioty",
+      "available_three_stars": "Dostępne 3-gwiazdkowe przedmioty"
     },
     "records": {
-      "title": "Gacha Records",
-      "date": "Date",
-      "item": "Item"
+      "title": "Rekordy gracza",
+      "date": "Data",
+      "item": "Przedmiot"
+    }
+  },
+  "documentation": {
+    "handbook": {
+      "title": "GM Handbook",
+      "title_commands": "Komendy",
+      "title_avatars": "Awatary",
+      "title_items": "Przedmioty",
+      "title_scenes": "Sceny",
+      "title_monsters": "Potwory",
+      "header_id": "ID",
+      "header_command": "Komenda",
+      "header_description": "Opis",
+      "header_avatar": "Awatar",
+      "header_item": "Przedmiot",
+      "header_scene": "Scena",
+      "header_monster": "Potwór"
+    },
+    "index": {
+      "title": "Dokumentacja",
+      "handbook": "GM Handbook",
+      "gacha_mapping": "Losowanie w formacie JSON"
     }
   }
 }


### PR DESCRIPTION
## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.

This PR achieves the following things:
* If failed to enter a dungeon via a command, don't send a success message (followed by a failure message),
* Updated english and polish translations to be up-to-date with everything. Redundant old properties were removed (with allowance from the maintaners, namely `shichihachi`), things like `weather`, which will be used in the nearest future, were kept.
* Along with the above, all command translations were updated in the forementioned 2 languages to include "usage" and "description" fields. Moreover, all commands are now using `commands.command_name.usage` instead of their hardcoded usage strings under the `command/commands` directory. I also beautified the Command class creation in every command file so that the line is not long as hell.
* Changed the Help command formatting to be more pleasant to the eye and hopefully more intuitive. This reflects in both `help` and `help [command]`. Additionally, `commands.help.usage` clashed with the mentioned before removal of hardcoded usage strings, so `commands.help.usage` is now `commands.help.usage_prefix` (this is the string that translates to "Usage: ").
* Additionally to the above change, `CommandMap` was fixed so that `getHandler(label)` correctly returns a command if `label` is an alias of the command (which did not work before - for some reason alias fetching was only implemented in `invoke()`).
* `HelpCommand.SendAllHelpMessage()` was quite outdated and it had a giant `if` statement that differentiated between nullish player and not nullish, even though both of the branches did the same thing. I implemented a new private function in the class - `createCommand()`, which adds one command's annotation to a `StringBuilder`, and then used that function both in `SendAllHelpMessage()` and `execute()`. `SendAllHelpMessage()`'s line length went down from 64 to 9 this way.

I would like to ask for english translation to be declared somehow as the mainstream to new or existing contributors, so that other languages can adapt the new (previously missing) fields and delete old, redundant ones, as well as adjust their translation, because, for instance, in ALL languages, `messages.dispatch.account.account_login_create_success` was translated to a FAILURE, not a SUCCESS. This was also fixed by this pr, but of course only for english and polish. Corrected romanian translation should be coming in pretty soon.

For the above translation changes, I did my research and actually was flying around the codebase to check where various props are used (in what context) so that I could adjust my translation appropriately. For this reason, I also edited one command's file so that arguments to the translation string are given in a different order to make it easier for certain languages to translate. I hope that's fine.