### PR TITLE
Automatic whitespace formatting

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -1,23 +1,20 @@
-name: "Build"
+name: "Lint and Build"
 on:
   workflow_dispatch: ~
   push:
     paths:
       - "**.java"
     branches:
-      - "stable"
-  pull_request:
-    paths:
-      - "**.java"
-    types:
-      - opened
-      - synchronize
-      - reopened
+      - "development"
 jobs:
   Build-Server-Jar:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout LintRatchet
+        uses: actions/checkout@v2
+        with:
+          ref: LintRatchet
+      - name: Checkout branch
         uses: actions/checkout@v2
       - name: Setup Java
         uses: actions/setup-java@v3
@@ -34,6 +31,8 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('*.gradle', 'gradle.properties', '**/*.accesswidener') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Run Spotless
+        run: ./gradlew spotlessApply
       - name: Run Gradle
         run: ./gradlew && ./gradlew jar
       - name: Upload build
@@ -41,3 +40,9 @@ jobs:
         with:
           name: Grasscutter
           path: grasscutter-*.jar
+      - name: Commit any Spotless changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: '-u'
+          default_author: github_actions
+          message: 'Fix whitespace'

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ configurations.all {
 
 application {
     // Define the main class for the application
-    mainClassName = 'emu.grasscutter.Grasscutter'
+    getMainClass().set('emu.grasscutter.Grasscutter')
 }
 
 
@@ -112,8 +112,10 @@ jar {
         attributes 'Main-Class': 'emu.grasscutter.Grasscutter'
     }
 
-    jar.baseName = 'grasscutter'
-    jar.archiveName = project.hasProperty('jarFilename') ? "${jarFilename}.${extension}" : archiveName
+    archiveBaseName = 'grasscutter'
+    if (project.hasProperty('jarFilename')) {
+        archiveFileName = "${jarFilename}.${extension}"
+    }
 
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
@@ -125,7 +127,7 @@ jar {
         include '*.xml'
     }
 
-    destinationDir = file(".")
+    destinationDirectory = file(".")
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ plugins {
     // Maven
     id 'maven-publish'
     id 'signing'
+
+    // Spotless formatter
+    id "com.diffplug.spotless" version "6.8.0"
 }
 
 compileJava.options.encoding = "UTF-8"
@@ -93,8 +96,8 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok:1.18.24'
     annotationProcessor 'org.projectlombok:lombok:1.18.24'
-	testCompileOnly 'org.projectlombok:lombok:1.18.24'
-	testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
+    testCompileOnly 'org.projectlombok:lombok:1.18.24'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
 }
 
 configurations.all {
@@ -236,6 +239,30 @@ eclipse {
             cp.entries.add( new org.gradle.plugins.ide.eclipse.model.SourceFolder('src/generated/main/java', null) )
         }
     }
+}
+
+spotless {
+  // optional: limit format enforcement to just the files changed by this feature branch
+  ratchetFrom 'LintRatchet'
+
+  format 'misc', {
+    // define the files to apply `misc` to
+    target '*.gradle', '*.md', '.gitignore'
+
+    // define the steps to apply to those files
+    trimTrailingWhitespace()
+    indentWithSpaces() // or spaces. Takes an integer argument if you don't like 4
+    endWithNewline()
+  }
+  java {
+    // don't need to set target, it is inferred from java
+    // define the steps to apply to those files
+    trimTrailingWhitespace()
+    indentWithSpaces() // or spaces. Takes an integer argument if you don't like 4
+    endWithNewline()
+    replaceRegex('Force one space between if/etc. and ( or {', '(?<=\\b(?:if|for|while|switch|try|else|catch|finally|synchronized)) *(?=[\\(\\{])', ' ')
+    replaceRegex('Force one space between ) and {', '\\) *\\{(?!\\})', ') {')
+  }
 }
 
 signing {


### PR DESCRIPTION
## Description

Adds a github action to standardize indents to 4space and padding on `for (...) {` constructs on changed files after merging PRs.
NOTE THAT THIS REQUIRES A `LintRatchet` ref TO BE SET ON A RECENT COMMIT OR IT WILL DO THE WHOLE CODEBASE INSTEAD

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.