### PR TITLE
[Bugfix] Multi-server mode

### DIFF
--- a/src/main/java/emu/grasscutter/database/DatabaseManager.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseManager.java
@@ -46,14 +46,8 @@ public final class DatabaseManager {
     	return getGameDatastore().getDatabase();
     }
 
-	// Yes. I very dislike this method. However, this will be good for now.
-	// TODO: Add dispatch routes for player account management
 	public static Datastore getAccountDatastore() {
-		if(SERVER.runMode == ServerRunMode.GAME_ONLY) {
-			return dispatchDatastore;
-		} else {
-			return gameDatastore;
-		}
+        return dispatchDatastore;
 	}
 	
 	public static void initialize() {


### PR DESCRIPTION
## Description
Older getAccountDatastore() doesn't work properly when setting to Multi-server mode. There's no necessary adding routes to this function, return dispatchDatastore directly will work fine!

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.