### PR TITLE
Fix Crafting for Mystic Enhancement Ores

### DIFF
--- a/src/main/java/emu/grasscutter/data/excels/ForgeData.java
+++ b/src/main/java/emu/grasscutter/data/excels/ForgeData.java
@@ -12,6 +12,7 @@ public class ForgeData extends GameResource {
     private int id;
     private int playerLevel;
     private int forgeType;
+    private int showItemId;
     private int resultItemId;
     private int resultItemCount;
     private int forgeTime;
@@ -64,6 +65,10 @@ public class ForgeData extends GameResource {
 
     public List<ItemParamData> getMaterialItems() {
         return materialItems;
+    }
+
+    public int getShowItemId() {
+        return showItemId;
     }
 
     @Override

--- a/src/main/java/emu/grasscutter/game/managers/forging/ForgingManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/forging/ForgingManager.java
@@ -198,8 +198,9 @@ public class ForgingManager {
 
 		// Give finished items to the player.
 		ForgeData data = GameData.getForgeDataMap().get(forge.getForgeId());
-		ItemData resultItemData = GameData.getItemDataMap().get(data.getResultItemId());
 
+		int resultId = data.getResultItemId() > 0 ? data.getResultItemId() : data.getShowItemId();
+		ItemData resultItemData = GameData.getItemDataMap().get(resultId);
 		GameItem addItem = new GameItem(resultItemData, data.getResultItemCount() * finished);
 		this.player.getInventory().addItem(addItem);
 		


### PR DESCRIPTION
## Description

Fix obtaining crafting results for Mystic Enhancement Eres crafted from Magical Crystal Chunks and Resin. You now get Mystic Enhancement Ores as the crafting result. No Adventure or Friendship EXP for now.

## Issues fixed by this PR

Fixes #1487

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.