### PR TITLE
[Bugfix] Multi-server mode

### DIFF
--- a/src/main/java/emu/grasscutter/database/DatabaseManager.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseManager.java
@@ -49,11 +49,11 @@ public final class DatabaseManager {
 	// Yes. I very dislike this method. However, this will be good for now.
 	// TODO: Add dispatch routes for player account management
 	public static Datastore getAccountDatastore() {
-		if(SERVER.runMode == ServerRunMode.GAME_ONLY) {
+		//if(SERVER.runMode == ServerRunMode.GAME_ONLY) {
 			return dispatchDatastore;
-		} else {
-			return gameDatastore;
-		}
+		//} else {
+		//	return gameDatastore;
+		//}
 	}
 	
 	public static void initialize() {
@@ -85,7 +85,7 @@ public final class DatabaseManager {
 			}
 		}
 
-		if(SERVER.runMode == ServerRunMode.GAME_ONLY) {
+		//if(SERVER.runMode == ServerRunMode.GAME_ONLY) {
 			MongoClient dispatchMongoClient = MongoClients.create(DATABASE.server.connectionUri);
 			dispatchDatastore = Morphia.createDatastore(dispatchMongoClient, DATABASE.server.collection);
 
@@ -105,7 +105,7 @@ public final class DatabaseManager {
 					dispatchDatastore.ensureIndexes();
 				}
 			}
-		}
+		//}
 	}
 
 	public static synchronized int getNextId(Class<?> c) {


### PR DESCRIPTION
## Description
The old getAccountDatastore() doesn't work properly when setting to multi-server mode. Always two datastore, one is dispatchDatastore, which is shared by all servers, and the other one is gameDatastore, which is seperated.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.