### PR TITLE
A solution that is compatible with both the UA Patch client and the Metadata Patch client

### DIFF
--- a/src/main/java/emu/grasscutter/server/http/dispatch/RegionHandler.java
+++ b/src/main/java/emu/grasscutter/server/http/dispatch/RegionHandler.java
@@ -11,6 +11,7 @@ import emu.grasscutter.server.event.dispatch.QueryCurrentRegionEvent;
 import emu.grasscutter.server.http.Router;
 import emu.grasscutter.server.http.objects.QueryCurRegionRspJson;
 import emu.grasscutter.utils.Crypto;
+import emu.grasscutter.utils.FileUtils;
 import emu.grasscutter.utils.Utils;
 import express.Express;
 import express.http.Request;
@@ -19,6 +20,11 @@ import io.javalin.Javalin;
 
 import javax.crypto.Cipher;
 import java.io.ByteArrayOutputStream;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.security.Signature;
@@ -139,9 +145,8 @@ public final class RegionHandler implements Router {
             try {
                 QueryCurrentRegionEvent event = new QueryCurrentRegionEvent(regionData); event.call();
 
-                if (GAME_OPTIONS.uaPatchCompatible) {
+                if (request.query("dispatchSeed") == null) {
                     // More love for UA Patch players
-
                     var rsp = new QueryCurRegionRspJson();
 
                     rsp.content = event.getRegionInfo();

--- a/src/main/java/emu/grasscutter/utils/ConfigContainer.java
+++ b/src/main/java/emu/grasscutter/utils/ConfigContainer.java
@@ -211,7 +211,6 @@ public class ConfigContainer {
             public int cap = 160;
             public int rechargeTime = 480;
         }
-        public boolean uaPatchCompatible = false;
     }
 
     public static class JoinOptions {


### PR DESCRIPTION
## Description

**From now on, UA Patch players will also need to additionally patch the `MoleMole.Miscs.GetGlobalDispatchUrl` function to remove the dispatchSeed parameter logic. Please try to search for this Pattern: `48 ?? ?? ?? ?? ?? ?? 45 33 C9 48 8B ?? ?? ?? ?? ?? 48 8B C8 4C 8B ?? ?? ?? ?? ?? 48 ?? ?? ?? ?? ?? ?? E8 ?? ?? ?? ??` and overwrite it with 0x90 (NOP) or use https://github.com/Sorapointa/Public-Patch to patch the function.**

I use the condition of the presence of the `dispatchSeed` parameter in the dispatch to distinguish between the two clients, and in the password handling logic and GetPlayerToken, if the decryption fails, the logic goes to the UA Patch client.

## Issues fixed by this PR

- Alleviates the pain of not being able to be compatible with both, the headaches caused by the two parties fighting with each other

## Type of changes

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.