### PR TITLE
Make Lint_Commit not fail on no commit

### DIFF
--- a/.github/workflows/lint_commit.yml
+++ b/.github/workflows/lint_commit.yml
@@ -32,10 +32,10 @@ jobs:
       # - run: git merge development
       - run: git reset --hard development
       - run: git stash pop
-      - run: git add -u
-      - run: git commit -m 'Fix whitespace [skip actions]'
+      - name: Commit any whitespace changes
+        run: git add -u && git commit -m 'Fix whitespace [skip actions]' || true
       - name: Update Languages
         run: python manage_languages.py -u
-      - run: git add -u
-      - run: git commit -m 'Update languages [skip actions]'
+      - name: Commit any language changes
+        run: git add -u && git commit -m 'Update languages [skip actions]' || true
       - run: git push --set-upstream --force origin LintRatchet


### PR DESCRIPTION
## Description
Action would fail when one of the two lint steps didn't commit any changes. Now it should pass if that happens. It might still fail if neither of the steps commit any changes, but that should be fine.

## Issues fixed by this PR

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.