### PR TITLE
2.7+ prerendered cutscene support

### DIFF
--- a/proto/ParentQuest.proto
+++ b/proto/ParentQuest.proto
@@ -25,7 +25,7 @@ message ParentQuest {
 	ParentQuestRandomInfo random_info = 12;
 	uint32 quest_var_seq = 11;
 	repeated int32 quest_var = 14;
-	uint64 Unk2700_KHDDIJNOICK = 6;
+	uint64 cutscene_encryption_key = 6;
 	bool is_random = 13;
 	uint32 parent_quest_id = 3;
 	bool is_finished = 7;

--- a/src/main/java/emu/grasscutter/data/GameData.java
+++ b/src/main/java/emu/grasscutter/data/GameData.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.binout.*;
+import emu.grasscutter.game.quest.QuestEncryptionKey;
 import emu.grasscutter.utils.Utils;
 import emu.grasscutter.data.excels.*;
 import it.unimi.dsi.fastutil.ints.Int2ObjectLinkedOpenHashMap;
@@ -25,6 +26,7 @@ public class GameData {
 	private static final Map<String, OpenConfigEntry> openConfigEntries = new HashMap<>();
 	private static final Map<String, ScenePointEntry> scenePointEntries = new HashMap<>();
 	private static final Int2ObjectMap<MainQuestData> mainQuestData = new Int2ObjectOpenHashMap<>();
+	private static final Int2ObjectMap<QuestEncryptionKey> questsKeys = new Int2ObjectOpenHashMap<>();
 	private static final Int2ObjectMap<HomeworldDefaultSaveData> homeworldDefaultSaveData = new Int2ObjectOpenHashMap<>();
 	private static final Int2ObjectMap<SceneNpcBornData> npcBornData = new Int2ObjectOpenHashMap<>();
 
@@ -161,6 +163,10 @@ public class GameData {
 
 	public static Int2ObjectMap<MainQuestData> getMainQuestDataMap() {
 		return mainQuestData;
+	}
+
+	public static Int2ObjectMap<QuestEncryptionKey> getMainQuestEncryptionMap() {
+		return questsKeys;
 	}
 
 	public static Int2ObjectMap<HomeworldDefaultSaveData> getHomeworldDefaultSaveData() {

--- a/src/main/java/emu/grasscutter/data/ResourceLoader.java
+++ b/src/main/java/emu/grasscutter/data/ResourceLoader.java
@@ -1,5 +1,25 @@
 package emu.grasscutter.data;
 
+import com.google.gson.JsonElement;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import emu.grasscutter.Grasscutter;
+import emu.grasscutter.data.binout.*;
+import emu.grasscutter.data.binout.AbilityModifier.AbilityConfigData;
+import emu.grasscutter.data.binout.AbilityModifier.AbilityModifierAction;
+import emu.grasscutter.data.binout.AbilityModifier.AbilityModifierActionType;
+import emu.grasscutter.data.common.PointData;
+import emu.grasscutter.data.common.ScenePointConfig;
+import emu.grasscutter.game.quest.QuestEncryptionKey;
+import emu.grasscutter.game.world.SpawnDataEntry;
+import emu.grasscutter.game.world.SpawnDataEntry.GridBlockId;
+import emu.grasscutter.game.world.SpawnDataEntry.SpawnGroupEntry;
+import emu.grasscutter.scripts.SceneIndexManager;
+import emu.grasscutter.utils.Utils;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import lombok.SneakyThrows;
+import org.reflections.Reflections;
+
 import java.io.*;
 import java.lang.reflect.Type;
 import java.nio.file.Files;
@@ -9,27 +29,7 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import emu.grasscutter.data.binout.*;
-import emu.grasscutter.game.world.SpawnDataEntry;
-import emu.grasscutter.scripts.SceneIndexManager;
-import emu.grasscutter.utils.Utils;
-import lombok.SneakyThrows;
-import org.reflections.Reflections;
-
-import com.google.gson.JsonElement;
-import com.google.gson.annotations.SerializedName;
-import com.google.gson.reflect.TypeToken;
-
-import emu.grasscutter.Grasscutter;
-import emu.grasscutter.data.binout.AbilityModifier.AbilityConfigData;
-import emu.grasscutter.data.binout.AbilityModifier.AbilityModifierAction;
-import emu.grasscutter.data.binout.AbilityModifier.AbilityModifierActionType;
-import emu.grasscutter.data.common.PointData;
-import emu.grasscutter.data.common.ScenePointConfig;
-import emu.grasscutter.game.world.SpawnDataEntry.*;
-import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-
-import static emu.grasscutter.config.Configuration.*;
+import static emu.grasscutter.config.Configuration.RESOURCE;
 import static emu.grasscutter.utils.Language.translate;
 
 public class ResourceLoader {
@@ -415,6 +415,18 @@ public class ResourceLoader {
             }
 
             GameData.getMainQuestDataMap().put(mainQuest.getId(), mainQuest);
+        }
+
+        try (Reader reader = DataLoader.loadReader("QuestEncryptionKeys.json")) {
+            List<QuestEncryptionKey> keys = Grasscutter.getGsonFactory().fromJson(
+                reader,
+                TypeToken.getParameterized(List.class, QuestEncryptionKey.class).getType());
+
+            Int2ObjectMap<QuestEncryptionKey> questEncryptionMap = GameData.getMainQuestEncryptionMap();
+            keys.forEach(key -> questEncryptionMap.put(key.getMainQuestId(), key));
+            Grasscutter.getLogger().info("loaded {} quest keys.", questEncryptionMap.size());
+        } catch (Exception e) {
+            Grasscutter.getLogger().error("Unable to load quest keys.", e);
         }
 
         Grasscutter.getLogger().debug("Loaded " + GameData.getMainQuestDataMap().size() + " MainQuestDatas.");

--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -132,7 +132,8 @@ public class GameMainQuest {
 		ParentQuest.Builder proto = ParentQuest.newBuilder()
 				.setParentQuestId(getParentQuestId())
 				.setIsFinished(isFinished())
-				.setParentQuestState(getState().getValue());
+				.setParentQuestState(getState().getValue())
+            .setCutsceneEncryptionKey(QuestManager.getQuestKey(parentQuestId));
 
 		for (GameQuest quest : this.getChildQuests().values()) {
 			ChildQuest childQuest = ChildQuest.newBuilder()

--- a/src/main/java/emu/grasscutter/game/quest/QuestEncryptionKey.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestEncryptionKey.java
@@ -1,0 +1,12 @@
+package emu.grasscutter.game.quest;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class QuestEncryptionKey {
+    int mainQuestId;
+    long encryptionKey;
+}

--- a/src/main/java/emu/grasscutter/game/quest/QuestManager.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestManager.java
@@ -2,8 +2,6 @@ package emu.grasscutter.game.quest;
 
 import java.util.*;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.binout.MainQuestData;
@@ -22,6 +20,11 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 public class QuestManager extends BasePlayerManager {
     private final Int2ObjectMap<GameMainQuest> quests;
+
+    public static long getQuestKey(int mainQuestId){
+        QuestEncryptionKey questEncryptionKey = GameData.getMainQuestEncryptionMap().get(mainQuestId);
+        return questEncryptionKey != null ? questEncryptionKey.getEncryptionKey() : 0L;
+    }
 
     public QuestManager(Player player) {
         super(player);


### PR DESCRIPTION
## Description

This adds support for sending the encryptions keys needed for playing prerendered cutscenes on the client.
It reads them from the servers data directory, and [this is an example file](https://gist.github.com/Hartie95/8b035f144fa17d5c43d17665ee460ba7) containing all current keys:
The source of the keys is [this repository](https://github.com/ToaHartor/GI-cutscenes)

Example quest that instantly triggers a cutscene: 
103103 triggers Cs_LiYue_LQ10310301_BreakThroughSpace_[Boy|Girl].usm

## Issues fixed by this PR
2.7+ prerendered cutscenes not showing

## Type of changes

- [X] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.