### PR TITLE
fixed activities not showing up and some minigames showing placeholder text

### DIFF
--- a/proto/GetActivityInfoReq.proto
+++ b/proto/GetActivityInfoReq.proto
@@ -7,5 +7,5 @@ option java_package = "emu.grasscutter.net.proto";
 // EnetIsReliable: true
 // IsAllowClient: true
 message GetActivityInfoReq {
-	repeated uint32 activity_id_list = 14;
+	repeated uint32 activity_id_list = 4;
 }

--- a/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
@@ -219,6 +219,7 @@ public class EntityGadget extends EntityBaseGadget {
                 .setConfigId(this.getConfigId())
                 .setGadgetState(this.getState())
                 .setIsEnableInteract(true)
+                .setDraftId(this.metaGadget.draft_id)
                 .setAuthorityPeerId(this.getScene().getWorld().getHostPeerId());
 
         if (this.getContent() != null) {

--- a/src/main/java/emu/grasscutter/scripts/data/SceneGadget.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneGadget.java
@@ -12,6 +12,7 @@ public class SceneGadget extends SceneObject{
 	public SceneBossChest boss_chest;
 	public int interact_id;
     public boolean isOneoff;
+    public int draft_id;
 
     public void setIsOneoff(boolean isOneoff){
         this.isOneoff = isOneoff;


### PR DESCRIPTION
## Description
* fixed GetAcitivityInfoReq proto and this makes activites show up again
* added draftId to gadget Scene gadget, to let the client know the propper minigame for some world entities

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.