### PR TITLE
Set Constellation Command

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/SetConstCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetConstCommand.java
@@ -1,10 +1,18 @@
 package emu.grasscutter.command.commands;
 
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.command.Command;
 import emu.grasscutter.command.CommandHandler;
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.excels.AvatarTalentData;
 import emu.grasscutter.game.avatar.Avatar;
 import emu.grasscutter.game.entity.EntityAvatar;
 import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.world.Scene;
+import emu.grasscutter.game.world.World;
+import emu.grasscutter.server.packet.send.*;
+import emu.grasscutter.utils.Position;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 import java.util.List;
 import java.util.Set;
@@ -33,7 +41,8 @@ public final class SetConstCommand implements CommandHandler {
             EntityAvatar entity = targetPlayer.getTeamManager().getCurrentAvatarEntity();
             if (entity == null) return;
             Avatar avatar = entity.getAvatar();
-            this.setConstellation(avatar, constLevel);
+
+            this.setConstellation(targetPlayer, avatar, constLevel);
 
             CommandHandler.sendTranslatedMessage(sender, "commands.setConst.success", avatar.getAvatarData().getName(), constLevel);
         } catch (NumberFormatException ignored) {
@@ -41,15 +50,36 @@ public final class SetConstCommand implements CommandHandler {
         }
     }
 
-    private void setConstellation(Avatar avatar, int constLevel) {
-        List<Integer> talentIds = avatar.getSkillDepot().getTalents();
+    private void setConstellation(Player player, Avatar avatar, int constLevel) {
+        int currentConstLevel = avatar.getCoreProudSkillLevel();
+        IntArrayList talentIds = new IntArrayList(avatar.getSkillDepot().getTalents());
         Set<Integer> talentIdList = avatar.getTalentIdList();
 
         talentIdList.clear();
-        talentIdList.addAll(talentIds.stream().limit(constLevel).toList());
+        avatar.setCoreProudSkillLevel(0);
 
-        avatar.setCoreProudSkillLevel(constLevel);
-        avatar.recalcStats();
+        for(int talent = 0; talent < constLevel; talent++) {
+            AvatarTalentData talentData = GameData.getAvatarTalentDataMap().get(talentIds.getInt(talent));
+            int mainCostItemId = talentData.getMainCostItemId();
+
+            player.getInventory().addItem(mainCostItemId);
+            Grasscutter.getGameServer().getInventorySystem().unlockAvatarConstellation(player, avatar.getGuid());
+        }
+
+        // force player to reload scene when necessary
+        if (constLevel < currentConstLevel) {
+            World world = player.getWorld();
+            Scene scene = player.getScene();
+            Position pos = player.getPosition();
+
+            world.transferPlayerToScene(player, 1, pos);
+            world.transferPlayerToScene(player, scene.getId(), pos);
+            scene.broadcastPacket(new PacketSceneEntityAppearNotify(player));
+        }
+
+        // ensure that all changes are visible to the player
+        avatar.recalcConstellations();
+        avatar.recalcStats(true);
         avatar.save();
     }
 }

--- a/src/main/java/emu/grasscutter/command/commands/SetConstCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetConstCommand.java
@@ -20,7 +20,7 @@ import java.util.Set;
 @Command(
     label = "setConst",
     aliases = {"setconstellation"},
-    usage = "<constellation level>",
+    usage = {"<constellation level>"},
     permission = "player.setconstellation",
     permissionTargeted = "player.setconstellation.others")
 public final class SetConstCommand implements CommandHandler {

--- a/src/main/java/emu/grasscutter/command/commands/SetConstCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetConstCommand.java
@@ -6,13 +6,24 @@ import emu.grasscutter.game.avatar.Avatar;
 import emu.grasscutter.game.entity.EntityAvatar;
 import emu.grasscutter.game.player.Player;
 
+import java.util.List;
+
 import static emu.grasscutter.utils.Language.translate;
 
 @Command(
     label = "setConst",
     aliases = {"setconstellation"},
     usage = "<constellation level>",
-    permission = "player.setconstellation")
+    permission = "player.setconstellation",
+    permissionTargeted = "player.setconstellation.others")
 public final class SetConstCommand implements CommandHandler {
+    @Override
+    public void execute(Player sender, Player targetPlayer, List<String> args) {
+        if (args.size() != 1) {
+            sendUsageMessage(sender);
+            return;
+        }
 
+        CommandHandler.sendMessage(sender, args.get(0));
+    }
 }

--- a/src/main/java/emu/grasscutter/command/commands/SetConstCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetConstCommand.java
@@ -1,0 +1,18 @@
+package emu.grasscutter.command.commands;
+
+import emu.grasscutter.command.Command;
+import emu.grasscutter.command.CommandHandler;
+import emu.grasscutter.game.avatar.Avatar;
+import emu.grasscutter.game.entity.EntityAvatar;
+import emu.grasscutter.game.player.Player;
+
+import static emu.grasscutter.utils.Language.translate;
+
+@Command(
+    label = "setConst",
+    aliases = {"setconstellation"},
+    usage = "<constellation level>",
+    permission = "player.setconstellation")
+public final class SetConstCommand implements CommandHandler {
+
+}

--- a/src/main/java/emu/grasscutter/command/commands/SetConstCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetConstCommand.java
@@ -7,8 +7,7 @@ import emu.grasscutter.game.entity.EntityAvatar;
 import emu.grasscutter.game.player.Player;
 
 import java.util.List;
-
-import static emu.grasscutter.utils.Language.translate;
+import java.util.Set;
 
 @Command(
     label = "setConst",
@@ -19,11 +18,38 @@ import static emu.grasscutter.utils.Language.translate;
 public final class SetConstCommand implements CommandHandler {
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (args.size() != 1) {
+        if (args.size() < 1) {
             sendUsageMessage(sender);
             return;
         }
 
-        CommandHandler.sendMessage(sender, args.get(0));
+        try {
+            int constLevel = Integer.parseInt(args.get(0));
+            if (constLevel < 0 || constLevel > 6) {
+                CommandHandler.sendTranslatedMessage(sender, "commands.setConst.range_error");
+                return;
+            }
+
+            EntityAvatar entity = targetPlayer.getTeamManager().getCurrentAvatarEntity();
+            if (entity == null) return;
+            Avatar avatar = entity.getAvatar();
+            this.setConstellation(avatar, constLevel);
+
+            CommandHandler.sendTranslatedMessage(sender, "commands.setConst.success", avatar.getAvatarData().getName(), constLevel);
+        } catch (NumberFormatException ignored) {
+            CommandHandler.sendTranslatedMessage(sender, "commands.setConst.level_error");
+        }
+    }
+
+    private void setConstellation(Avatar avatar, int constLevel) {
+        List<Integer> talentIds = avatar.getSkillDepot().getTalents();
+        Set<Integer> talentIdList = avatar.getTalentIdList();
+
+        talentIdList.clear();
+        talentIdList.addAll(talentIds.stream().limit(constLevel).toList());
+
+        avatar.setCoreProudSkillLevel(constLevel);
+        avatar.recalcStats();
+        avatar.save();
     }
 }

--- a/src/main/resources/languages/en-US.json
+++ b/src/main/resources/languages/en-US.json
@@ -258,7 +258,7 @@
     },
     "setConst": {
       "range_error": "Constellation level must be between 0 and 6.",
-      "level_error": "Invalid constellation level",
+      "level_error": "Invalid constellation level.",
       "description": "Sets constellation level for your current active character"
     },
     "setFetterLevel": {

--- a/src/main/resources/languages/en-US.json
+++ b/src/main/resources/languages/en-US.json
@@ -256,6 +256,11 @@
       "success": "Message sent.",
       "description": "Sends a message to a player as the server. If used with no target, sends to all players on the server."
     },
+    "setConst": {
+      "range_error": "Constellation level must be between 0 and 6.",
+      "level_error": "Invalid constellation level",
+      "description": "Sets constellation level for your current active character"
+    },
     "setFetterLevel": {
       "range_error": "Fetter level must be between 0 and 10.",
       "success": "Fetter level set to %s.",

--- a/src/main/resources/languages/en-US.json
+++ b/src/main/resources/languages/en-US.json
@@ -259,7 +259,9 @@
     "setConst": {
       "range_error": "Constellation level must be between 0 and 6.",
       "level_error": "Invalid constellation level.",
-      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "fail": "Failed to set constellation.",
+      "failed_success": "Constellations for %s have been set to %s. Please reload scene to see changes.",
+      "success": "Constellations for %s have been set to %s.",
       "description": "Sets constellation level for your current active character"
     },
     "setFetterLevel": {

--- a/src/main/resources/languages/en-US.json
+++ b/src/main/resources/languages/en-US.json
@@ -259,6 +259,7 @@
     "setConst": {
       "range_error": "Constellation level must be between 0 and 6.",
       "level_error": "Invalid constellation level.",
+      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
       "description": "Sets constellation level for your current active character"
     },
     "setFetterLevel": {

--- a/src/main/resources/languages/es-ES.json
+++ b/src/main/resources/languages/es-ES.json
@@ -256,6 +256,12 @@
       "success": "Mensaje enviado.",
       "description": "Envía un mensaje a un jugador como servidor. Si se usa sin un objetivo fijado, lo envía a todos los jugadores del servidor."
     },
+    "setConst": {
+      "range_error": "Constellation level must be between 0 and 6.",
+      "level_error": "Invalid constellation level.",
+      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "description": "Sets constellation level for your current active character"
+    },
     "setFetterLevel": {
       "range_error": "El nivel de amistad debe estar entre 0 y 10.",
       "success": "Nivel de amistad establecido a %s.",

--- a/src/main/resources/languages/es-ES.json
+++ b/src/main/resources/languages/es-ES.json
@@ -259,7 +259,9 @@
     "setConst": {
       "range_error": "Constellation level must be between 0 and 6.",
       "level_error": "Invalid constellation level.",
-      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "fail": "Failed to set constellation.",
+      "failed_success": "Constellations for %s have been set to %s. Please reload scene to see changes.",
+      "success": "Constellations for %s have been set to %s.",
       "description": "Sets constellation level for your current active character"
     },
     "setFetterLevel": {

--- a/src/main/resources/languages/fr-FR.json
+++ b/src/main/resources/languages/fr-FR.json
@@ -256,6 +256,12 @@
       "success": "Message envoyé.",
       "description": "Envoie un message au joueur spécifié en tant que Serveur"
     },
+    "setConst": {
+      "range_error": "Constellation level must be between 0 and 6.",
+      "level_error": "Invalid constellation level.",
+      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "description": "Sets constellation level for your current active character"
+    },
     "setFetterLevel": {
       "range_error": "Le niveau d'affinité doit être compris entre 0 et 10.",
       "success": "Niveau d'affinité défini à %s.",

--- a/src/main/resources/languages/fr-FR.json
+++ b/src/main/resources/languages/fr-FR.json
@@ -259,7 +259,9 @@
     "setConst": {
       "range_error": "Constellation level must be between 0 and 6.",
       "level_error": "Invalid constellation level.",
-      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "fail": "Failed to set constellation.",
+      "failed_success": "Constellations for %s have been set to %s. Please reload scene to see changes.",
+      "success": "Constellations for %s have been set to %s.",
       "description": "Sets constellation level for your current active character"
     },
     "setFetterLevel": {

--- a/src/main/resources/languages/pl-PL.json
+++ b/src/main/resources/languages/pl-PL.json
@@ -259,7 +259,9 @@
     "setConst": {
       "range_error": "Constellation level must be between 0 and 6.",
       "level_error": "Invalid constellation level.",
-      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "fail": "Failed to set constellation.",
+      "failed_success": "Constellations for %s have been set to %s. Please reload scene to see changes.",
+      "success": "Constellations for %s have been set to %s.",
       "description": "Sets constellation level for your current active character"
     },
     "setFetterLevel": {

--- a/src/main/resources/languages/pl-PL.json
+++ b/src/main/resources/languages/pl-PL.json
@@ -256,6 +256,12 @@
       "success": "Wiadomość wysłana.",
       "description": "Wyślij wiadomość do gracza jako serwer. Jeśli nie określono celu, wysyła do wszystkich graczy na serwerze."
     },
+    "setConst": {
+      "range_error": "Constellation level must be between 0 and 6.",
+      "level_error": "Invalid constellation level.",
+      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "description": "Sets constellation level for your current active character"
+    },
     "setFetterLevel": {
       "range_error": "Poziom przyjaźni musi być pomiędzy 0 a 10.",
       "success": "Poziom przyjaźni został pomyślnie ustawiony na %s.",

--- a/src/main/resources/languages/ro-RO.json
+++ b/src/main/resources/languages/ro-RO.json
@@ -256,6 +256,12 @@
       "success": "Mesaj trimis.",
       "description": "Trimite un mesaj unui jucător în calitate de server. Dacă este utilizat fără țintă, trimite mesajul către toți jucătorii de pe server."
     },
+    "setConst": {
+      "range_error": "Constellation level must be between 0 and 6.",
+      "level_error": "Invalid constellation level.",
+      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "description": "Sets constellation level for your current active character"
+    },
     "setFetterLevel": {
       "range_error": "Nivelul Fetter trebuie să fie între 0 și 10.",
       "success": "Nivelul Fetter setat ca %s.",

--- a/src/main/resources/languages/ro-RO.json
+++ b/src/main/resources/languages/ro-RO.json
@@ -259,7 +259,9 @@
     "setConst": {
       "range_error": "Constellation level must be between 0 and 6.",
       "level_error": "Invalid constellation level.",
-      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "fail": "Failed to set constellation.",
+      "failed_success": "Constellations for %s have been set to %s. Please reload scene to see changes.",
+      "success": "Constellations for %s have been set to %s.",
       "description": "Sets constellation level for your current active character"
     },
     "setFetterLevel": {

--- a/src/main/resources/languages/ru-RU.json
+++ b/src/main/resources/languages/ru-RU.json
@@ -256,6 +256,12 @@
       "success": "Сообщение было отправлено.",
       "description": "Отправляет сообщение выбранному игроку от имени сервера. При отсутствии конкретной цели, отправляет сообщение всем игрокам на сервере."
     },
+    "setConst": {
+      "range_error": "Constellation level must be between 0 and 6.",
+      "level_error": "Invalid constellation level.",
+      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "description": "Sets constellation level for your current active character"
+    },
     "setFetterLevel": {
       "range_error": "Значение уровня дружбы должно быть между 0 и 10.",
       "success": "Уровень дружбы стал равен %s.",

--- a/src/main/resources/languages/ru-RU.json
+++ b/src/main/resources/languages/ru-RU.json
@@ -259,7 +259,9 @@
     "setConst": {
       "range_error": "Constellation level must be between 0 and 6.",
       "level_error": "Invalid constellation level.",
-      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "fail": "Failed to set constellation.",
+      "failed_success": "Constellations for %s have been set to %s. Please reload scene to see changes.",
+      "success": "Constellations for %s have been set to %s.",
       "description": "Sets constellation level for your current active character"
     },
     "setFetterLevel": {

--- a/src/main/resources/languages/zh-CN.json
+++ b/src/main/resources/languages/zh-CN.json
@@ -256,6 +256,12 @@
       "success": "消息已发送。",
       "description": "向玩家以服务器的身份发送消息。如果没有指定目标，则向服务器的全部玩家发送"
     },
+    "setConst": {
+      "range_error": "Constellation level must be between 0 and 6.",
+      "level_error": "Invalid constellation level.",
+      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "description": "Sets constellation level for your current active character"
+    },
     "setFetterLevel": {
       "range_error": "好感度等级必须在 0-10 之间。",
       "success": "好感度已设为 %s 级。",

--- a/src/main/resources/languages/zh-CN.json
+++ b/src/main/resources/languages/zh-CN.json
@@ -259,7 +259,9 @@
     "setConst": {
       "range_error": "Constellation level must be between 0 and 6.",
       "level_error": "Invalid constellation level.",
-      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "fail": "Failed to set constellation.",
+      "failed_success": "Constellations for %s have been set to %s. Please reload scene to see changes.",
+      "success": "Constellations for %s have been set to %s.",
       "description": "Sets constellation level for your current active character"
     },
     "setFetterLevel": {

--- a/src/main/resources/languages/zh-TW.json
+++ b/src/main/resources/languages/zh-TW.json
@@ -259,7 +259,9 @@
     "setConst": {
       "range_error": "Constellation level must be between 0 and 6.",
       "level_error": "Invalid constellation level.",
-      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "fail": "Failed to set constellation.",
+      "failed_success": "Constellations for %s have been set to %s. Please reload scene to see changes.",
+      "success": "Constellations for %s have been set to %s.",
       "description": "Sets constellation level for your current active character"
     },
     "setFetterLevel": {

--- a/src/main/resources/languages/zh-TW.json
+++ b/src/main/resources/languages/zh-TW.json
@@ -256,6 +256,12 @@
       "success": "訊息已發送。",
       "description": "向指定玩家發送訊息。"
     },
+    "setConst": {
+      "range_error": "Constellation level must be between 0 and 6.",
+      "level_error": "Invalid constellation level.",
+      "success": "Constellations for %s have been set to %s. Please relog to see changes.",
+      "description": "Sets constellation level for your current active character"
+    },
     "setFetterLevel": {
       "range_error": "好感度必須在 0 到 10 之間。",
       "success": "好感等級已設定為 %s",


### PR DESCRIPTION
## Description

Does exactly what it says on the tin. Unlike `resetConst`, a relog is *not* required for the effect to be visible.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.