### PR TITLE
small nullpointer fix in EntityGadget, in case meta gadget is not set

### DIFF
--- a/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
@@ -219,8 +219,11 @@ public class EntityGadget extends EntityBaseGadget {
                 .setConfigId(this.getConfigId())
                 .setGadgetState(this.getState())
                 .setIsEnableInteract(true)
-                .setDraftId(this.metaGadget.draft_id)
                 .setAuthorityPeerId(this.getScene().getWorld().getHostPeerId());
+
+        if(this.metaGadget != null) {
+            gadgetInfo.setDraftId(this.metaGadget.draft_id);
+        }
 
         if (this.getContent() != null) {
             this.getContent().onBuildProto(gadgetInfo);


### PR DESCRIPTION
## Description

Fixes a NullPointerException when scripts are not enabled.

## Issues fixed by this PR

## Type of changes

- [X] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My pull request is unique and no other pull requests have been opened for these changes
- [X] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [X] I am responsible for any copyright issues with my code if it occurs in the future.