### PR TITLE
Improve message formatting to clients

### DIFF
--- a/src/main/java/emu/grasscutter/command/CommandHandler.java
+++ b/src/main/java/emu/grasscutter/command/CommandHandler.java
@@ -28,7 +28,7 @@ public interface CommandHandler {
         if (player == null) {
             Grasscutter.getLogger().info(event.getMessage());
         } else {
-            player.dropMessage(event.getMessage());
+            player.dropMessage(event.getMessage().replace("\n\t", "\n\n"));
         }
     }
 
@@ -43,6 +43,9 @@ public interface CommandHandler {
         for (String alias : annotation.aliases()) {
             if (alias.length() < command.length())
                 command = alias;
+        }
+        if (player != null) {
+            command = "/" + command;
         }
         String target = switch (annotation.targetRequirement()) {
             case NONE -> "";


### PR DESCRIPTION
## Description
Replaces tab indents with an extra linebreak. - **Note that this applies to all messages sent via** `CommandHandler.sendMessage`, if there's any edge cases you think may be harmed by replacing `\n\t` with `\n\n`, feel free to bring them up.

Also adds / to the start of command usage.

Neither of these changes affect messages to the server console log.

Old:
![image](https://user-images.githubusercontent.com/5397662/181409745-f416de7f-84b7-4dd3-94cb-5da2c7ee9193.png)

New:
![image](https://user-images.githubusercontent.com/5397662/181409810-704b1415-8119-427e-8406-61cbcf578009.png)
![image](https://user-images.githubusercontent.com/5397662/181409842-b7eb902a-7237-42d8-86f4-325160ea4acd.png)

Server console log unchanged:
![image](https://user-images.githubusercontent.com/5397662/181410002-7281fcef-26c8-4bc9-9b38-3b207d59f40e.png)


## Issues fixed by this PR
## Type of changes

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.