### PR TITLE
Caching TextMaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ tmp/
 .vscode
 
 # Grasscutter
+/cache
 /resources
 /logs
 /plugins

--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ tmp/
 /*.jar
 /*.sh
 
-GM Handbook.txt
+GM Handbook*.txt
 config.json
 mitmdump.exe
 mongod.exe

--- a/src/main/java/emu/grasscutter/Grasscutter.java
+++ b/src/main/java/emu/grasscutter/Grasscutter.java
@@ -94,11 +94,7 @@ public final class Grasscutter {
         boolean exitEarly = false;
         for (String arg : args) {
             switch (arg.toLowerCase()) {
-                case "-handbook" -> {
-                    Tools.createGmHandbook();
-                    exitEarly = true;
-                }
-                case "-handbooks" -> {
+                case "-handbook", "-handbooks" -> {
                     Tools.createGmHandbooks();
                     exitEarly = true;
                 }

--- a/src/main/java/emu/grasscutter/Grasscutter.java
+++ b/src/main/java/emu/grasscutter/Grasscutter.java
@@ -89,13 +89,13 @@ public final class Grasscutter {
 
     public static void main(String[] args) throws Exception {
         Crypto.loadKeys(); // Load keys from buffers.
+        Tools.createGmHandbooks();
 
         // Parse arguments.
         boolean exitEarly = false;
         for (String arg : args) {
             switch (arg.toLowerCase()) {
                 case "-handbook", "-handbooks" -> {
-                    Tools.createGmHandbooks();
                     exitEarly = true;
                 }
                 case "-dumppacketids" -> {

--- a/src/main/java/emu/grasscutter/Grasscutter.java
+++ b/src/main/java/emu/grasscutter/Grasscutter.java
@@ -95,15 +95,8 @@ public final class Grasscutter {
         boolean exitEarly = false;
         for (String arg : args) {
             switch (arg.toLowerCase()) {
-                case "-handbook", "-handbooks" -> {
-                    exitEarly = true;
-                }
                 case "-dumppacketids" -> {
                     PacketOpcodesUtils.dumpPacketIds();
-                    exitEarly = true;
-                }
-                case "-gachamap" -> {
-                    Tools.createGachaMapping(DATA("gacha_mappings.js"));
                     exitEarly = true;
                 }
                 case "-version" -> {

--- a/src/main/java/emu/grasscutter/Grasscutter.java
+++ b/src/main/java/emu/grasscutter/Grasscutter.java
@@ -98,6 +98,10 @@ public final class Grasscutter {
                     Tools.createGmHandbook();
                     exitEarly = true;
                 }
+                case "-handbooks" -> {
+                    Tools.createGmHandbooks();
+                    exitEarly = true;
+                }
                 case "-dumppacketids" -> {
                     PacketOpcodesUtils.dumpPacketIds();
                     exitEarly = true;

--- a/src/main/java/emu/grasscutter/command/CommandHandler.java
+++ b/src/main/java/emu/grasscutter/command/CommandHandler.java
@@ -3,6 +3,8 @@ package emu.grasscutter.command;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.server.event.game.ReceiveCommandFeedbackEvent;
+import emu.grasscutter.utils.Language;
+
 import static emu.grasscutter.utils.Language.translate;
 
 import java.util.List;
@@ -68,10 +70,13 @@ public interface CommandHandler {
         return this.getClass().getAnnotation(Command.class).label();
     }
 
-    default String getDescriptionString(Player player) {
+    default String getDescriptionKey() {
         Command annotation = this.getClass().getAnnotation(Command.class);
-        String key = "commands.%s.description".formatted(annotation.label());
-        return translate(player, key);
+        return "commands.%s.description".formatted(annotation.label());
+    }
+
+    default String getDescriptionString(Player player) {
+        return translate(player, getDescriptionKey());
     }
 
     /**

--- a/src/main/java/emu/grasscutter/data/ResourceLoader.java
+++ b/src/main/java/emu/grasscutter/data/ResourceLoader.java
@@ -53,7 +53,9 @@ public class ResourceLoader {
         return classList;
     }
 
+    private static boolean loadedAll = false;
     public static void loadAll() {
+        if (loadedAll) return;
         Grasscutter.getLogger().info(translate("messages.status.resources.loading"));
 
 		// Load ability lists
@@ -75,6 +77,7 @@ public class ResourceLoader {
 		loadNpcBornData();
 
         Grasscutter.getLogger().info(translate("messages.status.resources.finish"));
+        loadedAll = true;
     }
 
     public static void loadResources() {

--- a/src/main/java/emu/grasscutter/server/http/documentation/GachaMappingRequestHandler.java
+++ b/src/main/java/emu/grasscutter/server/http/documentation/GachaMappingRequestHandler.java
@@ -1,24 +1,19 @@
 package emu.grasscutter.server.http.documentation;
 
-import emu.grasscutter.data.GameData;
-import emu.grasscutter.data.excels.AvatarData;
-import emu.grasscutter.data.excels.ItemData;
+import emu.grasscutter.tools.Tools;
 import emu.grasscutter.utils.Language;
 import express.http.Request;
 import express.http.Response;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
 
 import static emu.grasscutter.config.Configuration.DOCUMENT_LANGUAGE;
 
-import java.util.ArrayList;
 import java.util.List;
 
 final class GachaMappingRequestHandler implements DocumentationHandler {
     private List<String> gachaJsons;
 
     GachaMappingRequestHandler() {
-        this.gachaJsons = createGachaMappingJsons();
+        this.gachaJsons = Tools.createGachaMappingJsons();
     }
 
     @Override
@@ -27,91 +22,5 @@ final class GachaMappingRequestHandler implements DocumentationHandler {
         response.set("Content-Type", "application/json")
                 .ctx()
                 .result(gachaJsons.get(langIdx));
-    }
-
-    private List<String> createGachaMappingJsons() {
-        final int NUM_LANGUAGES = Language.TextStrings.NUM_LANGUAGES;
-        final Language.TextStrings CHARACTER = Language.getTextMapKey(4233146695L);  // "Character" in EN
-        final Language.TextStrings WEAPON = Language.getTextMapKey(4231343903L);  // "Weapon" in EN
-        final Language.TextStrings STANDARD_WISH = Language.getTextMapKey(332935371L);  // "Standard Wish" in EN
-        final Language.TextStrings CHARACTER_EVENT_WISH = Language.getTextMapKey(2272170627L);  // "Character Event Wish" in EN
-        final Language.TextStrings CHARACTER_EVENT_WISH_2 = Language.getTextMapKey(3352513147L);  // "Character Event Wish-2" in EN
-        final Language.TextStrings WEAPON_EVENT_WISH = Language.getTextMapKey(2864268523L);  // "Weapon Event Wish" in EN
-        final List<StringBuilder> sbs = new ArrayList<>(NUM_LANGUAGES);
-        for (int langIdx = 0; langIdx < NUM_LANGUAGES; langIdx++)
-            sbs.add(new StringBuilder("{\n"));  // Web requests should never need Windows line endings
-
-        // Avatars
-        IntList list = new IntArrayList(GameData.getAvatarDataMap().keySet().intStream().sorted().toArray());
-        for (int id : list) {
-            AvatarData data = GameData.getAvatarDataMap().get(id);
-            int avatarID = data.getId();
-            if (avatarID >= 11000000) { // skip test avatar
-                continue;
-            }
-            String color = switch (data.getQualityType()) {
-                case "QUALITY_PURPLE" -> "purple";
-                case "QUALITY_ORANGE" -> "yellow";
-                case "QUALITY_BLUE" -> "blue";
-                default -> "";
-            };
-            Language.TextStrings avatarName = Language.getTextMapKey(data.getNameTextMapHash());
-            for (int langIdx = 0; langIdx < NUM_LANGUAGES; langIdx++) {
-                sbs.get(langIdx)
-                    .append("\"")
-                    .append(avatarID % 1000 + 1000)
-                    .append("\" : [\"")
-                    .append(avatarName.get(langIdx))
-                    .append("(")
-                    .append(CHARACTER.get(langIdx))
-                    .append(")\", \"")
-                    .append(color)
-                    .append("\"],\n");
-            }
-        }
-
-        list = new IntArrayList(GameData.getItemDataMap().keySet().intStream().sorted().toArray());
-
-        // Weapons
-        for (int id : list) {
-            ItemData data = GameData.getItemDataMap().get(id);
-            if (data.getId() <= 11101 || data.getId() >= 20000) {
-                continue; //skip non weapon items
-            }
-            String color = switch (data.getRankLevel()) {
-                case 3 -> "blue";
-                case 4 -> "purple";
-                case 5 -> "yellow";
-                default -> null;
-            };
-            if (color == null) continue;  // skip unnecessary entries
-            Language.TextStrings weaponName = Language.getTextMapKey(data.getNameTextMapHash());
-            for (int langIdx = 0; langIdx < NUM_LANGUAGES; langIdx++) {
-                sbs.get(langIdx)
-                    .append("\"")
-                    .append(data.getId())
-                    .append("\" : [\"")
-                    .append(weaponName.get(langIdx).replaceAll("\"", "\\\\\""))
-                    .append("(")
-                    .append(WEAPON.get(langIdx))
-                    .append(")\",\"")
-                    .append(color)
-                    .append("\"],\n");
-            }
-        }
-
-        for (int langIdx = 0; langIdx < NUM_LANGUAGES; langIdx++) {
-            sbs.get(langIdx)
-                .append("\"200\": \"")
-                .append(STANDARD_WISH.get(langIdx))
-                .append("\", \"301\": \"")
-                .append(CHARACTER_EVENT_WISH.get(langIdx))
-                .append("\", \"400\": \"")
-                .append(CHARACTER_EVENT_WISH_2.get(langIdx))
-                .append("\", \"302\": \"")
-                .append(WEAPON_EVENT_WISH.get(langIdx))
-                .append("\"\n}\n");
-        }
-        return sbs.stream().map(StringBuilder::toString).toList();
     }
 }

--- a/src/main/java/emu/grasscutter/server/http/documentation/HandbookRequestHandler.java
+++ b/src/main/java/emu/grasscutter/server/http/documentation/HandbookRequestHandler.java
@@ -1,9 +1,7 @@
 package emu.grasscutter.server.http.documentation;
 
 import static emu.grasscutter.config.Configuration.*;
-import static emu.grasscutter.utils.Language.translate;
 
-import com.google.gson.reflect.TypeToken;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.command.CommandMap;
 import emu.grasscutter.data.GameData;
@@ -12,112 +10,129 @@ import emu.grasscutter.data.excels.ItemData;
 import emu.grasscutter.data.excels.MonsterData;
 import emu.grasscutter.data.excels.SceneData;
 import emu.grasscutter.utils.FileUtils;
+import emu.grasscutter.utils.Language;
 import emu.grasscutter.utils.Utils;
 import express.http.Request;
 import express.http.Response;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.List;
 
 final class HandbookRequestHandler implements DocumentationHandler {
-
+    private List<String> handbookHtmls;
     private final String template;
-    private Map<Long, String> map;
-
 
     public HandbookRequestHandler() {
         final File templateFile = new File(Utils.toFilePath(DATA("documentation/handbook.html")));
         if (templateFile.exists()) {
-            template = new String(FileUtils.read(templateFile), StandardCharsets.UTF_8);
+            this.template = new String(FileUtils.read(templateFile), StandardCharsets.UTF_8);
+            this.handbookHtmls = generateHandbookHtmls();
         } else {
             Grasscutter.getLogger().warn("File does not exist: " + templateFile);
-            template = null;
-        }
-
-        final String textMapFile = "TextMap/TextMap" + DOCUMENT_LANGUAGE + ".json";
-        try (InputStreamReader fileReader = new InputStreamReader(new FileInputStream(
-                Utils.toFilePath(RESOURCE(textMapFile))), StandardCharsets.UTF_8)) {
-            map = Grasscutter.getGsonFactory()
-                    .fromJson(fileReader, new TypeToken<Map<Long, String>>() {
-                    }.getType());
-        } catch (IOException e) {
-            Grasscutter.getLogger().warn("Resource does not exist: " + textMapFile);
-            map = new HashMap<>();
+            this.template = null;
         }
     }
 
     @Override
     public void handle(Request request, Response response) {
+        final int langIdx = Language.TextStrings.MAP_LANGUAGES.getOrDefault(DOCUMENT_LANGUAGE, 0);  // TODO: This should really be based off the client language somehow
         if (template == null) {
             response.status(500);
-            return;
+        } else {
+            response.send(handbookHtmls.get(langIdx));
         }
+    }
 
-        final CommandMap cmdMap = new CommandMap(true);
+    private List<String> generateHandbookHtmls() {
+        final int NUM_LANGUAGES = Language.TextStrings.NUM_LANGUAGES;
+        final List<String> output = new ArrayList<>(NUM_LANGUAGES);
+        final List<Language> languages = Language.TextStrings.getLanguages();
+        final List<StringBuilder> sbs = new ArrayList<>(NUM_LANGUAGES);
+        for (int langIdx = 0; langIdx < NUM_LANGUAGES; langIdx++)
+            sbs.add(new StringBuilder(""));
+
+        // Commands table
+        new CommandMap(true).getHandlersAsList().forEach(cmd -> {
+            String label = cmd.getLabel();
+            String descKey = cmd.getDescriptionKey();
+            for (int langIdx = 0; langIdx < NUM_LANGUAGES; langIdx++)
+                sbs.get(langIdx).append("<tr><td><code>" + label + "</code></td><td>" + languages.get(langIdx).get(descKey) + "</td></tr>\n");
+        });
+        sbs.forEach(sb -> sb.setLength(sb.length()-1));  // Remove trailing \n
+        final List<String> cmdsTable = sbs.stream().map(StringBuilder::toString).toList();
+
+        // Avatars table
         final Int2ObjectMap<AvatarData> avatarMap = GameData.getAvatarDataMap();
+        sbs.forEach(sb -> sb.setLength(0));
+        avatarMap.keySet().intStream().sorted().mapToObj(avatarMap::get).forEach(data -> {
+            int id = data.getId();
+            Language.TextStrings name = Language.getTextMapKey(data.getNameTextMapHash());
+            for (int langIdx = 0; langIdx < NUM_LANGUAGES; langIdx++)
+                sbs.get(langIdx).append("<tr><td><code>" + id + "</code></td><td>" + name.get(langIdx) + "</td></tr>\n");
+        });
+        sbs.forEach(sb -> sb.setLength(sb.length()-1));  // Remove trailing \n
+        final List<String> avatarsTable = sbs.stream().map(StringBuilder::toString).toList();
+
+        // Items table
         final Int2ObjectMap<ItemData> itemMap = GameData.getItemDataMap();
+        sbs.forEach(sb -> sb.setLength(0));
+        itemMap.keySet().intStream().sorted().mapToObj(itemMap::get).forEach(data -> {
+            int id = data.getId();
+            Language.TextStrings name = Language.getTextMapKey(data.getNameTextMapHash());
+            for (int langIdx = 0; langIdx < NUM_LANGUAGES; langIdx++)
+                sbs.get(langIdx).append("<tr><td><code>" + id + "</code></td><td>" + name.get(langIdx) + "</td></tr>\n");
+        });
+        sbs.forEach(sb -> sb.setLength(sb.length()-1));  // Remove trailing \n
+        final List<String> itemsTable = sbs.stream().map(StringBuilder::toString).toList();
+
+        // Scenes table
         final Int2ObjectMap<SceneData> sceneMap = GameData.getSceneDataMap();
+        sceneMap.keySet().intStream().sorted().mapToObj(sceneMap::get).forEach(data -> {
+            int id = data.getId();
+            for (int langIdx = 0; langIdx < NUM_LANGUAGES; langIdx++)
+                sbs.get(langIdx).append("<tr><td><code>" + id + "</code></td><td>" + data.getScriptData() + "</td></tr>\n");
+        });
+        sbs.forEach(sb -> sb.setLength(sb.length()-1));  // Remove trailing \n
+        final List<String> scenesTable = sbs.stream().map(StringBuilder::toString).toList();
+
+        // Monsters table
         final Int2ObjectMap<MonsterData> monsterMap = GameData.getMonsterDataMap();
+        monsterMap.keySet().intStream().sorted().mapToObj(monsterMap::get).forEach(data -> {
+            int id = data.getId();
+            Language.TextStrings name = Language.getTextMapKey(data.getNameTextMapHash());
+            for (int langIdx = 0; langIdx < NUM_LANGUAGES; langIdx++)
+                sbs.get(langIdx).append("<tr><td><code>" + id + "</code></td><td>" + name.get(langIdx) + "</td></tr>\n");
+        });
+        sbs.forEach(sb -> sb.setLength(sb.length()-1));  // Remove trailing \n
+        final List<String> monstersTable = sbs.stream().map(StringBuilder::toString).toList();
 
         // Add translated title etc. to the page.
-        String content = template.replace("{{TITLE}}", translate("documentation.handbook.title"))
-                .replace("{{TITLE_COMMANDS}}", translate("documentation.handbook.title_commands"))
-                .replace("{{TITLE_AVATARS}}", translate("documentation.handbook.title_avatars"))
-                .replace("{{TITLE_ITEMS}}", translate("documentation.handbook.title_items"))
-                .replace("{{TITLE_SCENES}}", translate("documentation.handbook.title_scenes"))
-                .replace("{{TITLE_MONSTERS}}", translate("documentation.handbook.title_monsters"))
-                .replace("{{HEADER_ID}}", translate("documentation.handbook.header_id"))
-                .replace("{{HEADER_COMMAND}}", translate("documentation.handbook.header_command"))
-                .replace("{{HEADER_DESCRIPTION}}",
-                        translate("documentation.handbook.header_description"))
-                .replace("{{HEADER_AVATAR}}", translate("documentation.handbook.header_avatar"))
-                .replace("{{HEADER_ITEM}}", translate("documentation.handbook.header_item"))
-                .replace("{{HEADER_SCENE}}", translate("documentation.handbook.header_scene"))
-                .replace("{{HEADER_MONSTER}}", translate("documentation.handbook.header_monster"))
+        for (int langIdx = 0; langIdx < NUM_LANGUAGES; langIdx++) {
+            Language lang = languages.get(langIdx);
+            output.add(template
+                .replace("{{TITLE}}", lang.get("documentation.handbook.title"))
+                .replace("{{TITLE_COMMANDS}}", lang.get("documentation.handbook.title_commands"))
+                .replace("{{TITLE_AVATARS}}", lang.get("documentation.handbook.title_avatars"))
+                .replace("{{TITLE_ITEMS}}", lang.get("documentation.handbook.title_items"))
+                .replace("{{TITLE_SCENES}}", lang.get("documentation.handbook.title_scenes"))
+                .replace("{{TITLE_MONSTERS}}", lang.get("documentation.handbook.title_monsters"))
+                .replace("{{HEADER_ID}}", lang.get("documentation.handbook.header_id"))
+                .replace("{{HEADER_COMMAND}}", lang.get("documentation.handbook.header_command"))
+                .replace("{{HEADER_DESCRIPTION}}", lang.get("documentation.handbook.header_description"))
+                .replace("{{HEADER_AVATAR}}", lang.get("documentation.handbook.header_avatar"))
+                .replace("{{HEADER_ITEM}}", lang.get("documentation.handbook.header_item"))
+                .replace("{{HEADER_SCENE}}", lang.get("documentation.handbook.header_scene"))
+                .replace("{{HEADER_MONSTER}}", lang.get("documentation.handbook.header_monster"))
                 // Commands table
-                .replace("{{COMMANDS_TABLE}}", cmdMap.getHandlersAsList()
-                        .stream()
-                        .map(cmd -> "<tr><td><code>" + cmd.getLabel() + "</code></td><td>" +
-                                cmd.getDescriptionString(null) + "</td></tr>")
-                        .collect(Collectors.joining("\n")))
-                // Avatars table
-                .replace("{{AVATARS_TABLE}}", GameData.getAvatarDataMap().keySet()
-                        .intStream()
-                        .sorted()
-                        .mapToObj(avatarMap::get)
-                        .map(data -> "<tr><td><code>" + data.getId() + "</code></td><td>" +
-                                map.get(data.getNameTextMapHash()) + "</td></tr>")
-                        .collect(Collectors.joining("\n")))
-                // Items table
-                .replace("{{ITEMS_TABLE}}", GameData.getItemDataMap().keySet()
-                        .intStream()
-                        .sorted()
-                        .mapToObj(itemMap::get)
-                        .map(data -> "<tr><td><code>" + data.getId() + "</code></td><td>" +
-                                map.get(data.getNameTextMapHash()) + "</td></tr>")
-                        .collect(Collectors.joining("\n")))
-                // Scenes table
-                .replace("{{SCENES_TABLE}}", GameData.getSceneDataMap().keySet()
-                        .intStream()
-                        .sorted()
-                        .mapToObj(sceneMap::get)
-                        .map(data -> "<tr><td><code>" + data.getId() + "</code></td><td>" +
-                                data.getScriptData() + "</td></tr>")
-                        .collect(Collectors.joining("\n")))
-                .replace("{{MONSTERS_TABLE}}", GameData.getMonsterDataMap().keySet()
-                        .intStream()
-                        .sorted()
-                        .mapToObj(monsterMap::get)
-                        .map(data -> "<tr><td><code>" + data.getId() + "</code></td><td>" +
-                                map.get(data.getNameTextMapHash()) + "</td></tr>")
-                        .collect(Collectors.joining("\n")));
-
-        response.send(content);
+                .replace("{{COMMANDS_TABLE}}", cmdsTable.get(langIdx))
+                .replace("{{AVATARS_TABLE}}", avatarsTable.get(langIdx))
+                .replace("{{ITEMS_TABLE}}", itemsTable.get(langIdx))
+                .replace("{{SCENES_TABLE}}", scenesTable.get(langIdx))
+                .replace("{{MONSTERS_TABLE}}", monstersTable.get(langIdx))
+            );
+        }
+        return output;
     }
 }

--- a/src/main/java/emu/grasscutter/tools/Tools.java
+++ b/src/main/java/emu/grasscutter/tools/Tools.java
@@ -1,8 +1,10 @@
 package emu.grasscutter.tools;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -10,12 +12,15 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import com.google.gson.reflect.TypeToken;
 
 import emu.grasscutter.GameConstants;
 import emu.grasscutter.Grasscutter;
-import emu.grasscutter.command.Command;
 import emu.grasscutter.command.CommandHandler;
 import emu.grasscutter.command.CommandMap;
 import emu.grasscutter.data.GameData;
@@ -26,12 +31,234 @@ import emu.grasscutter.data.excels.ItemData;
 import emu.grasscutter.data.excels.MonsterData;
 import emu.grasscutter.data.excels.QuestData;
 import emu.grasscutter.data.excels.SceneData;
+import emu.grasscutter.utils.Language;
 import emu.grasscutter.utils.Utils;
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import lombok.EqualsAndHashCode;
 
 import static emu.grasscutter.config.Configuration.*;
 import static emu.grasscutter.utils.Language.translate;
 
 public final class Tools {
+    @EqualsAndHashCode public static class TextStrings {
+        public static final String[] ARR_LANGUAGES = {"EN", "CHS", "CHT", "JP", "KR", "DE", "ES", "FR", "ID", "PT", "RU", "TH", "VI"};
+        public static final String[] ARR_GC_LANGUAGES = {"en-US", "zh-CN", "zh-TW", "JP", "KR", "DE", "es-ES", "fr-FR", "ID", "PT", "ru-RU", "TH", "VI"};
+        public static final int NUM_LANGUAGES = ARR_LANGUAGES.length;
+        public static final List<String> LIST_LANGUAGES = Arrays.asList(ARR_LANGUAGES);
+        public static final Object2IntMap<String> MAP_LANGUAGES =  // Map "EN": 0, "CHS": 1, ..., "VI": 12
+            new Object2IntOpenHashMap<>(
+                IntStream.range(0, ARR_LANGUAGES.length)
+                .boxed()
+                .collect(Collectors.toMap(i -> ARR_LANGUAGES[i], i -> i)));
+        public String[] strings = new String[ARR_LANGUAGES.length];
+
+        public TextStrings() {};
+
+        public TextStrings(String init) {
+            for (int i = 0; i < NUM_LANGUAGES; i++)
+                this.strings[i] = init;
+        };
+
+        public TextStrings(Collection<String> strings) {
+            this.strings = strings.toArray(new String[0]);
+        }
+
+        public String get(String languageCode) {
+            return strings[MAP_LANGUAGES.getOrDefault(languageCode, 0)];
+        }
+
+        public boolean set(String languageCode, String string) {
+            int index = MAP_LANGUAGES.getOrDefault(languageCode, -1);
+            if (index < 0) return false;
+            strings[index] = string;
+            return true;
+        }
+    }
+
+    private static final Pattern textMapKeyValueRegex = Pattern.compile("\"(\\d+)\": \"(.+)\"");
+
+    private static Int2ObjectMap<String> loadTextMap(String language, IntSet nameHashes) {
+        Int2ObjectMap<String> output = new Int2ObjectOpenHashMap<>();
+        try (BufferedReader file = new BufferedReader(new FileReader(Utils.toFilePath(RESOURCE("TextMap/TextMap"+language+".json")), StandardCharsets.UTF_8))) {
+            Matcher matcher = textMapKeyValueRegex.matcher("");
+            return new Int2ObjectOpenHashMap<>(
+                file.lines()
+                    .sequential()
+                    .map(matcher::reset)  // Side effects, but it's faster than making a new one
+                    .filter(Matcher::find)
+                    .filter(m -> nameHashes.contains((int) Long.parseLong(m.group(1))))  // TODO: Cache this parse somehow
+                    .collect(Collectors.toMap(
+                        m -> (int) Long.parseLong(m.group(1)),
+                        m -> m.group(2))));
+        } catch (Exception e) {
+            Grasscutter.getLogger().error("Error loading textmap: " + language);
+            Grasscutter.getLogger().error(e.toString());
+        }
+        return output;
+    }
+
+    public static Int2ObjectMap<TextStrings> loadTextMaps(IntSet nameHashes) {
+        Map<Integer, Int2ObjectMap<String>> mapLanguageMaps =  // Separate step to process the textmaps in parallel
+            TextStrings.LIST_LANGUAGES.parallelStream().collect(
+            Collectors.toConcurrentMap(s -> TextStrings.MAP_LANGUAGES.getInt(s), s -> loadTextMap(s, nameHashes)));
+        List<Int2ObjectMap<String>> languageMaps = 
+            IntStream.range(0, TextStrings.NUM_LANGUAGES)
+            .mapToObj(i -> mapLanguageMaps.get(i))
+            .collect(Collectors.toList());
+
+        Map<TextStrings, TextStrings> canonicalTextStrings = new HashMap<>();
+        return new Int2ObjectOpenHashMap<TextStrings>(
+            nameHashes
+            .intStream()
+            .boxed()
+            .collect(Collectors.toMap(key -> key, key -> {
+                TextStrings t = new TextStrings(
+                    IntStream.range(0, TextStrings.NUM_LANGUAGES)
+                    .mapToObj(i -> languageMaps.get(i).getOrDefault((int) key, "[N/A] - hash key %d".formatted(key)))
+                    .collect(Collectors.toList()));
+                return canonicalTextStrings.computeIfAbsent(t, x -> t);
+                }))
+            );
+    }
+
+    public static void createGmHandbooks() throws Exception {
+        ResourceLoader.loadAll();
+        Int2IntMap avatarNames = new Int2IntOpenHashMap(GameData.getAvatarDataMap().int2ObjectEntrySet().stream().collect(Collectors.toMap(e -> (int) e.getIntKey(), e -> (int) e.getValue().getNameTextMapHash())));
+        Int2IntMap itemNames = new Int2IntOpenHashMap(GameData.getItemDataMap().int2ObjectEntrySet().stream().collect(Collectors.toMap(e -> (int) e.getIntKey(), e -> (int) e.getValue().getNameTextMapHash())));
+        Int2IntMap monsterNames = new Int2IntOpenHashMap(GameData.getMonsterDataMap().int2ObjectEntrySet().stream().collect(Collectors.toMap(e -> (int) e.getIntKey(), e -> (int) e.getValue().getNameTextMapHash())));
+        Int2IntMap mainQuestTitles = new Int2IntOpenHashMap(GameData.getMainQuestDataMap().int2ObjectEntrySet().stream().collect(Collectors.toMap(e -> (int) e.getIntKey(), e -> (int) e.getValue().getTitleTextMapHash())));
+        Int2IntMap questDescs = new Int2IntOpenHashMap(GameData.getQuestDataMap().int2ObjectEntrySet().stream().collect(Collectors.toMap(e -> (int) e.getIntKey(), e -> (int) e.getValue().getDescTextMapHash())));
+        
+        IntSet usedHashes = new IntOpenHashSet();
+        usedHashes.addAll(avatarNames.values());
+        usedHashes.addAll(itemNames.values());
+        usedHashes.addAll(monsterNames.values());
+        usedHashes.addAll(mainQuestTitles.values());
+        usedHashes.addAll(questDescs.values());
+        
+        Int2ObjectMap<TextStrings> textMaps = loadTextMaps(usedHashes);
+
+        Language savedLanguage = Grasscutter.getLanguage();
+
+        // Preamble
+        StringBuilder[] handbookBuilders = new StringBuilder[TextStrings.NUM_LANGUAGES];
+        String now = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss").format(LocalDateTime.now());
+        for (int i = 0; i < TextStrings.NUM_LANGUAGES; i++) {
+            handbookBuilders[i] = new StringBuilder()
+                .append("// Grasscutter " + GameConstants.VERSION + " GM Handbook\n")
+                .append("// Created " + now + "\n\n")
+                .append("// Commands\n");
+        }
+        // Commands
+        List<CommandHandler> cmdList = new CommandMap(true).getHandlersAsList();
+        for (CommandHandler cmd : cmdList) {
+            StringBuilder cmdName = new StringBuilder(cmd.getLabel());
+            while (cmdName.length() <= 15) {
+                cmdName.insert(0, " ");
+            }
+            for (int i = 0; i < TextStrings.NUM_LANGUAGES; i++) {
+                Grasscutter.setLanguage(Language.getLanguage(TextStrings.ARR_GC_LANGUAGES[i]));  // A bit hacky but eh whatever
+                handbookBuilders[i]
+                    .append(cmdName + " : ")
+                    .append(cmd.getDescriptionString(null).replace("\n", "\n\t\t\t\t").replace("\t", "    "))
+                    .append("\n");
+            }
+        }
+        // Avatars
+        for (int i = 0; i < TextStrings.NUM_LANGUAGES; i++) {
+            handbookBuilders[i].append("\n\n// Avatars\n");
+        }
+        avatarNames.keySet().intStream().sorted().forEach(id -> {
+            TextStrings t = textMaps.get(avatarNames.get(id));
+            for (int i = 0; i < TextStrings.NUM_LANGUAGES; i++) {
+                handbookBuilders[i]
+                    .append("%d : ".formatted(id))
+                    .append(t.strings[i])
+                    .append("\n");
+            }
+        });
+        // Items
+        for (int i = 0; i < TextStrings.NUM_LANGUAGES; i++) {
+            handbookBuilders[i].append("\n\n// Items\n");
+        }
+        itemNames.keySet().intStream().sorted().forEach(id -> {
+            TextStrings t = textMaps.get(itemNames.get(id));
+            for (int i = 0; i < TextStrings.NUM_LANGUAGES; i++) {
+                handbookBuilders[i]
+                    .append("%d : ".formatted(id))
+                    .append(t.strings[i])
+                    .append("\n");
+            }
+        });
+        // Monsters
+        for (int i = 0; i < TextStrings.NUM_LANGUAGES; i++) {
+            handbookBuilders[i].append("\n\n// Monsters\n");
+        }
+        monsterNames.keySet().intStream().sorted().forEach(id -> {
+            TextStrings t = textMaps.get(monsterNames.get(id));
+            for (int i = 0; i < TextStrings.NUM_LANGUAGES; i++) {
+                handbookBuilders[i]
+                    .append("%d : ".formatted(id))
+                    .append(t.strings[i])
+                    .append("\n");
+            }
+        });
+        // Scenes - no translations
+        for (int i = 0; i < TextStrings.NUM_LANGUAGES; i++) {
+            handbookBuilders[i].append("\n\n// Scenes\n");
+        }
+        var sceneDataMap = GameData.getSceneDataMap();
+        sceneDataMap.keySet().intStream().sorted().forEach(id -> {
+            String data = sceneDataMap.get(id).getScriptData();
+            for (int i = 0; i < TextStrings.NUM_LANGUAGES; i++) {
+                handbookBuilders[i]
+                    .append("%d : ".formatted(id))
+                    .append(data)
+                    .append("\n");
+            }
+        });
+        // Quests
+        for (int i = 0; i < TextStrings.NUM_LANGUAGES; i++) {
+            handbookBuilders[i].append("\n\n// Quests\n");
+        }
+        var questDataMap = GameData.getQuestDataMap();
+        questDataMap.keySet().intStream().sorted().forEach(id -> {
+            QuestData data = questDataMap.get(id);
+            int titleKey = (int) mainQuestTitles.get(data.getMainId());
+            int descKey = (int) data.getDescTextMapHash();
+            TextStrings title = textMaps.get(titleKey);
+            TextStrings desc = textMaps.get(descKey);
+            for (int i = 0; i < TextStrings.NUM_LANGUAGES; i++) {
+                handbookBuilders[i]
+                    .append(id)
+                    .append(" : ")
+                    .append(title.strings[i])
+                    .append(" - ")
+                    .append(desc.strings[i])
+                    .append("\n");
+            }
+        });
+        Grasscutter.setLanguage(savedLanguage);
+
+        // Write txt files
+        for (int i = 0; i < TextStrings.NUM_LANGUAGES; i++) {
+            String fileName = "./GM Handbook - %s.txt".formatted(TextStrings.ARR_LANGUAGES[i]);
+            try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(fileName), StandardCharsets.UTF_8), false)) {
+                writer.write(handbookBuilders[i].toString());
+            }
+        }
+        Grasscutter.getLogger().info("GM Handbooks generated!");
+    }
+
     public static void createGmHandbook() throws Exception {
         ToolsWithLanguageOption.createGmHandbook(getLanguageOption());
     }
@@ -115,7 +342,7 @@ final class ToolsWithLanguageOption {
                 while (cmdName.length() <= 15) {
                     cmdName.insert(0, " ");
                 }
-				writer.println(cmdName + " : " + translate(cmd.getDescriptionString(null)));
+				writer.println(cmdName + " : " + cmd.getDescriptionString(null));
             }
             writer.println();
 

--- a/src/main/java/emu/grasscutter/tools/Tools.java
+++ b/src/main/java/emu/grasscutter/tools/Tools.java
@@ -180,21 +180,15 @@ final class ToolsWithLanguageOption {
 
             // if the user made choices for language, I assume it's okay to assign his/her selected language to "en-us"
             // since it's the fallback language and there will be no difference in the gacha record page.
-            // The enduser can still modify the `gacha_mappings.js` directly to enable multilingual for the gacha record system.
+            // The enduser can still modify the `gacha/mappings.js` directly to enable multilingual for the gacha record system.
             writer.println("mappings = {\"en-us\": {");
 
             // Avatars
-            boolean first = true;
             for (Integer id : list) {
                 AvatarData data = GameData.getAvatarDataMap().get(id);
                 int avatarID = data.getId();
                 if (avatarID >= 11000000) { // skip test avatar
                     continue;
-                }
-                if (first) { // skip adding comma for the first element
-                    first = false;
-                } else {
-                    writer.print(",");
                 }
                 String color = switch (data.getQualityType()) {
                     case "QUALITY_PURPLE" -> "purple";
@@ -205,7 +199,7 @@ final class ToolsWithLanguageOption {
                 writer.println(
                     "\"" + (avatarID % 1000 + 1000) + "\" : [\""
                     + map.get(data.getNameTextMapHash()) + "(" +  map.get(4233146695L)+ ")\", \""
-                    + color + "\"]");
+                    + color + "\"],");
             }
 
             writer.println();
@@ -219,29 +213,22 @@ final class ToolsWithLanguageOption {
                 if (data.getId() <= 11101 || data.getId() >= 20000) {
                     continue; //skip non weapon items
                 }
-                String color;
-
-                switch (data.getRankLevel()) {
-                    case 3:
-                        color = "blue";
-                        break;
-                    case 4:
-                        color = "purple";
-                        break;
-                    case 5:
-                        color = "yellow";
-                        break;
-                    default:
-                        continue; // skip unnecessary entries
-                }
+                String color = switch (data.getRankLevel()) {
+                    case 3 -> "blue";
+                    case 4 -> "purple";
+                    case 5 -> "yellow";
+                    default -> null;
+                };
+                if (color == null)
+                    continue; // skip unnecessary entries
 
                 // Got the magic number 4231343903 from manually search in the json file
 
-                writer.println(",\"" + data.getId() +
-                         "\" : [\"" + map.get(data.getNameTextMapHash()).replaceAll("\"", "")
-                         + "("+ map.get(4231343903L)+")\",\""+ color + "\"]");
+                writer.println("\"" + data.getId() +
+                         "\" : [\"" + map.getOrDefault(data.getNameTextMapHash(), id.toString()).replaceAll("\"", "")
+                         + "("+ map.get(4231343903L)+")\",\""+ color + "\"],");
             }
-            writer.println(",\"200\": \""+map.get(332935371L)+"\", \"301\": \""+ map.get(2272170627L) + "\", \"302\": \""+map.get(2864268523L)+"\"");
+            writer.println("\"200\": \""+map.get(332935371L)+"\", \"301\": \""+ map.get(2272170627L) + "\", \"302\": \""+map.get(2864268523L)+"\"");
             writer.println("}\n}");
         }
 

--- a/src/main/java/emu/grasscutter/utils/Language.java
+++ b/src/main/java/emu/grasscutter/utils/Language.java
@@ -371,6 +371,8 @@ public final class Language {
     }
 
     public static TextStrings getTextMapKey(long hash) {
+        if (textMapStrings == null)
+            loadTextMaps();
         return textMapStrings.get((int) hash);
     }
 

--- a/src/main/java/emu/grasscutter/utils/Language.java
+++ b/src/main/java/emu/grasscutter/utils/Language.java
@@ -240,7 +240,7 @@ public final class Language {
     private static final int TEXTMAP_CACHE_VERSION = 0x9CCACE02;
     @EqualsAndHashCode public static class TextStrings implements Serializable {
         public static final String[] ARR_LANGUAGES = {"EN", "CHS", "CHT", "JP", "KR", "DE", "ES", "FR", "ID", "PT", "RU", "TH", "VI"};
-        public static final String[] ARR_GC_LANGUAGES = {"en-US", "zh-CN", "zh-TW", "JP", "KR", "DE", "es-ES", "fr-FR", "ID", "PT", "ru-RU", "TH", "VI"};
+        public static final String[] ARR_GC_LANGUAGES = {"en-US", "zh-CN", "zh-TW", "ja-JP", "ko-KR", "DE", "es-ES", "fr-FR", "ID", "PT", "ru-RU", "TH", "VI"};
         public static final int NUM_LANGUAGES = ARR_LANGUAGES.length;
         public static final List<String> LIST_LANGUAGES = Arrays.asList(ARR_LANGUAGES);
         public static final Object2IntMap<String> MAP_LANGUAGES =  // Map "EN": 0, "CHS": 1, ..., "VI": 12
@@ -274,6 +274,14 @@ public final class Language {
                 else
                     this.strings[i] = nullReplacement;
             }
+        }
+
+        public static List<Language> getLanguages() {
+            return Arrays.stream(ARR_GC_LANGUAGES).map(Language::getLanguage).toList();
+        }
+
+        public String get(int languageIndex) {
+            return strings[languageIndex];
         }
 
         public String get(String languageCode) {

--- a/src/main/java/emu/grasscutter/utils/Language.java
+++ b/src/main/java/emu/grasscutter/utils/Language.java
@@ -3,14 +3,43 @@ package emu.grasscutter.utils;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import emu.grasscutter.Grasscutter;
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.ResourceLoader;
 import emu.grasscutter.game.player.Player;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import lombok.EqualsAndHashCode;
 
 import javax.annotation.Nullable;
 
 import static emu.grasscutter.config.Configuration.*;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public final class Language {
@@ -206,5 +235,188 @@ public final class Language {
         public InputStream getLanguageFile() {
             return languageFile;
         }
+    }
+
+    private static final int TEXTMAP_CACHE_VERSION = 0x9CCACE02;
+    @EqualsAndHashCode public static class TextStrings implements Serializable {
+        public static final String[] ARR_LANGUAGES = {"EN", "CHS", "CHT", "JP", "KR", "DE", "ES", "FR", "ID", "PT", "RU", "TH", "VI"};
+        public static final String[] ARR_GC_LANGUAGES = {"en-US", "zh-CN", "zh-TW", "JP", "KR", "DE", "es-ES", "fr-FR", "ID", "PT", "ru-RU", "TH", "VI"};
+        public static final int NUM_LANGUAGES = ARR_LANGUAGES.length;
+        public static final List<String> LIST_LANGUAGES = Arrays.asList(ARR_LANGUAGES);
+        public static final Object2IntMap<String> MAP_LANGUAGES =  // Map "EN": 0, "CHS": 1, ..., "VI": 12
+            new Object2IntOpenHashMap<>(
+                IntStream.range(0, ARR_LANGUAGES.length)
+                .boxed()
+                .collect(Collectors.toMap(i -> ARR_LANGUAGES[i], i -> i)));
+        public String[] strings = new String[ARR_LANGUAGES.length];
+
+        public TextStrings() {};
+
+        public TextStrings(String init) {
+            for (int i = 0; i < NUM_LANGUAGES; i++)
+                this.strings[i] = init;
+        };
+
+        public TextStrings(List<String> strings, int key) {
+            // Some hashes don't have strings for some languages :(
+            String nullReplacement = "[N/A] %d".formatted((long) key & 0xFFFFFFFFL);
+            for (int i = 0; i < NUM_LANGUAGES; i++) {  // Find first non-null if there is any
+                String s = strings.get(i);
+                if (s != null) {
+                    nullReplacement = "[%s] - %s".formatted(ARR_LANGUAGES[i], s);
+                    break;
+                }
+            }
+            for (int i = 0; i < NUM_LANGUAGES; i++) {
+                String s = strings.get(i);
+                if (s != null)
+                    this.strings[i] = s;
+                else
+                    this.strings[i] = nullReplacement;
+            }
+        }
+
+        public String get(String languageCode) {
+            return strings[MAP_LANGUAGES.getOrDefault(languageCode, 0)];
+        }
+
+        public boolean set(String languageCode, String string) {
+            int index = MAP_LANGUAGES.getOrDefault(languageCode, -1);
+            if (index < 0) return false;
+            strings[index] = string;
+            return true;
+        }
+    }
+
+    private static final Pattern textMapKeyValueRegex = Pattern.compile("\"(\\d+)\": \"(.+)\"");
+
+    private static Int2ObjectMap<String> loadTextMapFile(String language, IntSet nameHashes) {
+        Int2ObjectMap<String> output = new Int2ObjectOpenHashMap<>();
+        try (BufferedReader file = new BufferedReader(new FileReader(Utils.toFilePath(RESOURCE("TextMap/TextMap"+language+".json")), StandardCharsets.UTF_8))) {
+            Matcher matcher = textMapKeyValueRegex.matcher("");
+            return new Int2ObjectOpenHashMap<>(
+                file.lines()
+                    .sequential()
+                    .map(matcher::reset)  // Side effects, but it's faster than making a new one
+                    .filter(Matcher::find)
+                    .filter(m -> nameHashes.contains((int) Long.parseLong(m.group(1))))  // TODO: Cache this parse somehow
+                    .collect(Collectors.toMap(
+                        m -> (int) Long.parseLong(m.group(1)),
+                        m -> m.group(2).replace("\\\"", "\""))));
+        } catch (Exception e) {
+            Grasscutter.getLogger().error("Error loading textmap: " + language);
+            Grasscutter.getLogger().error(e.toString());
+        }
+        return output;
+    }
+
+    private static Int2ObjectMap<TextStrings> loadTextMapFiles(IntSet nameHashes) {
+        Map<Integer, Int2ObjectMap<String>> mapLanguageMaps =  // Separate step to process the textmaps in parallel
+            TextStrings.LIST_LANGUAGES.parallelStream().collect(
+            Collectors.toConcurrentMap(s -> TextStrings.MAP_LANGUAGES.getInt(s), s -> loadTextMapFile(s, nameHashes)));
+        List<Int2ObjectMap<String>> languageMaps = 
+            IntStream.range(0, TextStrings.NUM_LANGUAGES)
+            .mapToObj(i -> mapLanguageMaps.get(i))
+            .collect(Collectors.toList());
+
+        Map<TextStrings, TextStrings> canonicalTextStrings = new HashMap<>();
+        return new Int2ObjectOpenHashMap<TextStrings>(
+            nameHashes
+            .intStream()
+            .boxed()
+            .collect(Collectors.toMap(key -> key, key -> {
+                TextStrings t = new TextStrings(
+                    IntStream.range(0, TextStrings.NUM_LANGUAGES)
+                    .mapToObj(i -> languageMaps.get(i).get((int) key))
+                    .collect(Collectors.toList()), (int) key);
+                return canonicalTextStrings.computeIfAbsent(t, x -> t);
+                }))
+            );
+    }
+
+    private static Int2ObjectMap<TextStrings> loadTextMapsCache() throws Exception {
+        try (ObjectInputStream file = new ObjectInputStream(new BufferedInputStream(Files.newInputStream(TEXTMAP_CACHE_PATH), 0x100000))) {
+            final int fileVersion = file.readInt();
+            if (fileVersion != TEXTMAP_CACHE_VERSION)
+                throw new Exception("Invalid cache version");
+            return (Int2ObjectMap<TextStrings>) file.readObject();
+        }
+    }
+
+    private static void saveTextMapsCache(Int2ObjectMap<TextStrings> input) throws IOException {
+        try {
+            Files.createDirectory(Path.of("cache"));
+        } catch (FileAlreadyExistsException ignored) {};
+        try (ObjectOutputStream file = new ObjectOutputStream(new BufferedOutputStream(Files.newOutputStream(TEXTMAP_CACHE_PATH, StandardOpenOption.CREATE), 0x100000))) {
+            file.writeInt(TEXTMAP_CACHE_VERSION);
+            file.writeObject(input);
+        }
+    }
+
+    private static Int2ObjectMap<TextStrings> textMapStrings;
+    private static final Path TEXTMAP_CACHE_PATH = Path.of(Utils.toFilePath("cache/TextMapCache.bin"));
+
+    public static Int2ObjectMap<TextStrings> getTextMapStrings() {
+        if (textMapStrings == null)
+            loadTextMaps();
+        return textMapStrings;
+    }
+
+    public static TextStrings getTextMapKey(long hash) {
+        return textMapStrings.get((int) hash);
+    }
+
+    public static void loadTextMaps() {
+        // Check system timestamps on cache and resources
+        try {
+            long cacheModified = Files.getLastModifiedTime(TEXTMAP_CACHE_PATH).toMillis();
+
+            long textmapsModified = Files.list(Path.of(RESOURCE("TextMap")))
+                .filter(path -> path.toString().endsWith(".json"))
+                .map(path -> {
+                    try {
+                        return Files.getLastModifiedTime(path).toMillis();
+                    } catch (Exception ignored) {
+                        Grasscutter.getLogger().debug("Exception while checking modified time: ", path);
+                        return Long.MAX_VALUE;  // Don't use cache, something has gone wrong
+                    }
+                })
+                .max(Long::compare)
+                .get();
+
+                Grasscutter.getLogger().debug("Cache modified %d, textmap modified %d".formatted(cacheModified, textmapsModified));
+            if (textmapsModified < cacheModified) {
+                // Try loading from cache
+                Grasscutter.getLogger().info("Loading cached TextMaps");
+                textMapStrings = loadTextMapsCache();
+                return;
+            }
+        } catch (Exception e) {
+            Grasscutter.getLogger().debug("Exception while checking cache: ", e);
+        };
+
+        // Regenerate cache
+        Grasscutter.getLogger().info("Generating TextMaps cache");
+        ResourceLoader.loadAll();
+        IntSet usedHashes = new IntOpenHashSet();
+        GameData.getAvatarDataMap().forEach((k, v) -> usedHashes.add((int) v.getNameTextMapHash()));
+        GameData.getItemDataMap().forEach((k, v) -> usedHashes.add((int) v.getNameTextMapHash()));
+        GameData.getMonsterDataMap().forEach((k, v) -> usedHashes.add((int) v.getNameTextMapHash()));
+        GameData.getMainQuestDataMap().forEach((k, v) -> usedHashes.add((int) v.getTitleTextMapHash()));
+        GameData.getQuestDataMap().forEach((k, v) -> usedHashes.add((int) v.getDescTextMapHash()));
+        // Incidental strings
+        usedHashes.add((int) 4233146695L);  // Character
+        usedHashes.add((int) 4231343903L);  // Weapon
+        usedHashes.add((int)  332935371L);  // Standard Wish
+        usedHashes.add((int) 2272170627L);  // Character Event Wish
+        usedHashes.add((int) 3352513147L);  // Character Event Wish-2
+        usedHashes.add((int) 2864268523L);  // Weapon Event Wish
+
+        textMapStrings = loadTextMapFiles(usedHashes);
+        try {
+            saveTextMapsCache(textMapStrings);
+        } catch (IOException e) {
+            Grasscutter.getLogger().error("Failed to save TextMap cache: ", e);
+        };
     }
 }


### PR DESCRIPTION
## Description
- [x] Replaces single language handbook generation with a handbook for each client language (NOT GC language)
- [x] Saves/loads a cache generated from all of the TextMaps which should only need regenerating whenever TextMaps are updated (compares file modification times) or different hashes are of interest (bump cache version)
- [x] replace remaining usages of TextMaps around the codebase (gachamappings, `HandbookRequestHandler`)
- [x] remove `-handbook` and `-gachamap` launch arguments as these are generated on startup (and `-gachamap` previously saved to the wrong file anyway)

## Issues fixed by this PR
Fixes #1539.

Probably addresses #1506, #1589, might need further testing on their end.

## Type of changes

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.