### PR TITLE
Fix an edge case that breaks embryos if resources are loaded early

### DIFF
--- a/manage_languages.py
+++ b/manage_languages.py
@@ -30,6 +30,7 @@ class JsonHelpers:
     def save(filename: str, data: dict) -> None:
         with open(filename, 'w', encoding='utf-8', newline='\n') as file:
             json.dump(data, file, ensure_ascii=False, indent=INDENT)
+            file.write('\n')  # json.dump doesn't terminate last line
 
     @staticmethod
     def flatten(data: dict, prefix='') -> dict:

--- a/src/main/java/emu/grasscutter/data/ResourceLoader.java
+++ b/src/main/java/emu/grasscutter/data/ResourceLoader.java
@@ -63,7 +63,7 @@ public class ResourceLoader {
 		loadOpenConfig();
 		loadAbilityModifiers();
 		// Load resources
-		loadResources();
+		loadResources(true);
 		// Process into depots
 		GameDepot.load();
 		// Load spawn data and quests


### PR DESCRIPTION
## Description
Fixes a bug where launching GC without `data/gacha/mappings.js` (i.e. whenever you delete your data folder for testing) would make avatars unable to attack or properly use their abilities until GC was restarted.

## Issues fixed by this PR

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.