### PR TITLE
Hide resin from map when disabled

### DIFF
--- a/src/main/java/emu/grasscutter/server/packet/send/PacketOpenStateUpdateNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketOpenStateUpdateNotify.java
@@ -1,5 +1,7 @@
 package emu.grasscutter.server.packet.send;
 
+import static emu.grasscutter.config.Configuration.GAME_OPTIONS;
+
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.excels.OpenStateData;
 import emu.grasscutter.game.player.Player;
@@ -19,17 +21,21 @@ public class PacketOpenStateUpdateNotify extends BasePacket {
 
         OpenStateUpdateNotify.Builder proto = OpenStateUpdateNotify.newBuilder();
 
-        for (OpenStateData state : GameData.getOpenStateList()) {
+        GameData.getOpenStateList().stream().map(OpenStateData::getId).forEach(id -> {
+            if ((id == 45) && !GAME_OPTIONS.resinOptions.resinUsage) {
+                proto.putOpenStateMap(45, 0);  // Remove resin from map
+                return;
+            }
             // If the player has an open state stored in their map, then it would always override any default value
-            if (player.getOpenStates().containsKey(state.getId())) {
-                proto.putOpenStateMap(state.getId(), player.getProgressManager().getOpenState(state.getId()));
+            if (player.getOpenStates().containsKey(id)) {
+                proto.putOpenStateMap(id, player.getProgressManager().getOpenState(id));
             }
             // Otherwise, add the state if it is contained in the set of default open states. 
-            else if (PlayerProgressManager.DEFAULT_OPEN_STATES.contains(state.getId())) {
-                proto.putOpenStateMap(state.getId(), 1);
+            else if (PlayerProgressManager.DEFAULT_OPEN_STATES.contains(id)) {
+                proto.putOpenStateMap(id, 1);
             }
-        }
-        
+        });
+
         this.setData(proto);
     }
 }


### PR DESCRIPTION
## Description
When `resinUsage = false`, seeing `160/160` on the map screen traumatises me.
For whatever reason, setting the resin openstate to 0 hides it from the map screen without breaking any blossom reward prompts. Well, I've only tested against leyline blossoms though since domains aren't working for me, so there's that.

## Issues fixed by this PR
## Type of changes

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.