### PR TITLE
Changed charset of FileReader in loadConfig from default to utf-8.

### DIFF
--- a/src/main/java/emu/grasscutter/Grasscutter.java
+++ b/src/main/java/emu/grasscutter/Grasscutter.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 
 import static emu.grasscutter.config.Configuration.DATA;
@@ -203,7 +204,7 @@ public final class Grasscutter {
         }
 
         // If the file already exists, we attempt to load it.
-        try (FileReader file = new FileReader(configFile)) {
+        try (FileReader file = new FileReader(configFile, StandardCharsets.UTF_8)) {
             config = gson.fromJson(file, ConfigContainer.class);
         } catch (Exception exception) {
             getLogger().error("There was an error while trying to load the configuration from config.json. Please make sure that there are no syntax errors. If you want to start with a default configuration, delete your existing config.json.");


### PR DESCRIPTION
## Description
see pr #1600 .pr 1600 only modified ConfigContainer.java ,but when gc read config file,it will still use the default charset,which lead to disorderly code in welcome mail.
![qq_pic_merged_1660190211789](https://user-images.githubusercontent.com/52032586/184062504-dff03e41-78b3-4138-b688-236ea091eed0.jpg)


Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->


- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.