### PR TITLE
fix:command player said to server won't be shown at chat history

### DIFF
--- a/src/main/java/emu/grasscutter/game/managers/chat/ChatManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/chat/ChatManager.java
@@ -136,11 +136,6 @@ public class ChatManager implements ChatManagerHandler {
         // Get target.
         Player target = getServer().getPlayerByUid(targetUid);
 
-        // Check if command
-        if (tryInvokeCommand(player, target, message)) {
-            return;
-        }
-
         if (target == null && targetUid != GameConstants.SERVER_CONSOLE_UID) {
             return;
         }
@@ -156,6 +151,8 @@ public class ChatManager implements ChatManagerHandler {
             target.sendPacket(packet);
             putInHistory(targetUid, player.getUid(), packet.getChatInfo());
         }
+        // Check if command
+        tryInvokeCommand(player, target, message);
     }
 
     public void sendPrivateMessage(Player player, int targetUid, int emote) {

--- a/src/main/java/emu/grasscutter/game/managers/chat/ChatManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/chat/ChatManager.java
@@ -147,12 +147,13 @@ public class ChatManager implements ChatManagerHandler {
         player.sendPacket(packet);
         putInHistory(player.getUid(), targetUid, packet.getChatInfo());
 
-        if (target != null) {
+        // Check if command
+        boolean isCommand = tryInvokeCommand(player, target, message);
+
+        if ((target != null) && (!isCommand)) {
             target.sendPacket(packet);
             putInHistory(targetUid, player.getUid(), packet.getChatInfo());
         }
-        // Check if command
-        tryInvokeCommand(player, target, message);
     }
 
     public void sendPrivateMessage(Player player, int targetUid, int emote) {


### PR DESCRIPTION
## Description
fix:the command that player said to the server won't be shown at the chat history.
now:what the player said to the server(whether it is a command or not) will be shown at the history list.
It can help remind the player what command did he typed.

## Issues fixed by this PR
when fixed:
![Screenshot_2022-08-11-12-19-18-743_org GenshinImp](https://user-images.githubusercontent.com/52032586/184064391-16b63c67-a086-433b-8e17-4c2bd69b3d12.jpg)


<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.