### PR TITLE
make it possible to disable fishhook map mark tp

### DIFF
--- a/src/main/java/emu/grasscutter/config/ConfigContainer.java
+++ b/src/main/java/emu/grasscutter/config/ConfigContainer.java
@@ -191,6 +191,7 @@ public class ConfigContainer {
         public boolean enableShopItems = true;
         public boolean staminaUsage = true;
         public boolean energyUsage = false;
+        public boolean fishhookTeleport = true;
         public ResinOptions resinOptions = new ResinOptions();
         public Rates rates = new Rates();
 

--- a/src/main/java/emu/grasscutter/game/managers/mapmark/MapMarksManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/mapmark/MapMarksManager.java
@@ -1,5 +1,6 @@
 package emu.grasscutter.game.managers.mapmark;
 
+import emu.grasscutter.config.Configuration;
 import emu.grasscutter.game.player.BasePlayerManager;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.net.proto.MapMarkPointTypeOuterClass.MapMarkPointType;
@@ -29,7 +30,7 @@ public class MapMarksManager extends BasePlayerManager {
             case OPERATION_ADD -> {
                 MapMark createMark = new MapMark(req.getMark());
                 // keep teleporting functionality on fishhook mark.
-                if (createMark.getMapMarkPointType() == MapMarkPointType.MAP_MARK_POINT_TYPE_FISH_POOL) {
+                if (Configuration.GAME_OPTIONS.fishhookTeleport && createMark.getMapMarkPointType() == MapMarkPointType.MAP_MARK_POINT_TYPE_FISH_POOL) {
                     this.teleport(player, createMark);
                     return;
                 }


### PR DESCRIPTION
## Description
make it possible to disable the fishhook map mark tp feature.
with this pr,we can disable this function in config.json via add `"fishhookTeleport"=false`in gameOptions.


## Issues fixed by this PR
#1627 
<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.