### PR TITLE
Fix deprecated chat references

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -798,7 +798,7 @@ public class Player {
             return;
         }
 
-        this.getServer().getChatManager().sendPrivateMessageFromServer(getUid(), message.toString());
+        this.getServer().getChatSystem().sendPrivateMessageFromServer(getUid(), message.toString());
         // this.sendPacket(new PacketPrivateChatNotify(GameConstants.SERVER_CONSOLE_UID, getUid(), message.toString()));
     }
 
@@ -810,7 +810,7 @@ public class Player {
      */
     public void sendMessage(Player sender, Object message) {
         // this.sendPacket(new PacketPrivateChatNotify(sender.getUid(), this.getUid(), message.toString()));
-        this.getServer().getChatManager().sendPrivateMessage(sender, this.getUid(), message.toString());
+        this.getServer().getChatSystem().sendPrivateMessage(sender, this.getUid(), message.toString());
     }
 
     // ---------------------MAIL------------------------
@@ -1199,7 +1199,7 @@ public class Player {
         this.hasSentLoginPackets = true;
 
         // Send server welcome chat.
-        this.getServer().getChatManager().sendServerWelcomeMessages(this);
+        this.getServer().getChatSystem().sendServerWelcomeMessages(this);
 
         // Set session state
         session.setState(SessionState.ACTIVE);
@@ -1219,7 +1219,7 @@ public class Player {
     public void onLogout() {
         try {
             // Clear chat history.
-            this.getServer().getChatManager().clearHistoryOnLogout(this);
+            this.getServer().getChatSystem().clearHistoryOnLogout(this);
 
             // stop stamina calculation
             getStaminaManager().stopSustainedStaminaHandler();

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerPlayerChatReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerPlayerChatReq.java
@@ -17,9 +17,9 @@ public class HandlerPlayerChatReq extends PacketHandler {
 		ChatInfo.ContentCase content = req.getChatInfo().getContentCase();
 		
 		if (content == ChatInfo.ContentCase.TEXT) {
-			session.getServer().getChatManager().sendTeamMessage(session.getPlayer(), req.getChannelId(), req.getChatInfo().getText());
+			session.getServer().getChatSystem().sendTeamMessage(session.getPlayer(), req.getChannelId(), req.getChatInfo().getText());
 		} else if (content == ChatInfo.ContentCase.ICON) {
-			session.getServer().getChatManager().sendTeamMessage(session.getPlayer(), req.getChannelId(), req.getChatInfo().getIcon());
+			session.getServer().getChatSystem().sendTeamMessage(session.getPlayer(), req.getChannelId(), req.getChatInfo().getIcon());
 		}
 		
 		session.send(new PacketPlayerChatRsp());

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerPrivateChatReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerPrivateChatReq.java
@@ -15,9 +15,9 @@ public class HandlerPrivateChatReq extends PacketHandler {
 		PrivateChatReq.ContentCase content = req.getContentCase();
 		
 		if (content == PrivateChatReq.ContentCase.TEXT) {
-			session.getServer().getChatManager().sendPrivateMessage(session.getPlayer(), req.getTargetUid(), req.getText());
+			session.getServer().getChatSystem().sendPrivateMessage(session.getPlayer(), req.getTargetUid(), req.getText());
 		} else if (content == PrivateChatReq.ContentCase.ICON) {
-			session.getServer().getChatManager().sendPrivateMessage(session.getPlayer(), req.getTargetUid(), req.getIcon());
+			session.getServer().getChatSystem().sendPrivateMessage(session.getPlayer(), req.getTargetUid(), req.getIcon());
 		}
 	}
 

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerPullPrivateChatReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerPullPrivateChatReq.java
@@ -14,7 +14,7 @@ public class HandlerPullPrivateChatReq extends PacketHandler {
     public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
         PullPrivateChatReq req = PullPrivateChatReq.parseFrom(payload);
 
-        session.getServer().getChatManager().handlePullPrivateChatReq(session.getPlayer(), req.getTargetUid());
+        session.getServer().getChatSystem().handlePullPrivateChatReq(session.getPlayer(), req.getTargetUid());
 
         // session.send(new PacketPullPrivateChatRsp(req.getTargetUid()));
     }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerPullRecentChatReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerPullRecentChatReq.java
@@ -10,6 +10,6 @@ import emu.grasscutter.server.packet.send.PacketPullRecentChatRsp;
 public class HandlerPullRecentChatReq extends PacketHandler {
     @Override
     public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
-        session.getServer().getChatManager().handlePullRecentChatReq(session.getPlayer());
+        session.getServer().getChatSystem().handlePullRecentChatReq(session.getPlayer());
     }
 }


### PR DESCRIPTION
## Description
Might have to disable some deprecation warning suppression to see if anything else internal is using recently deprecated methods.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.