### PR TITLE
Fix QuestEncryptionKeys Path

### DIFF
--- a/src/main/java/emu/grasscutter/data/DataLoader.java
+++ b/src/main/java/emu/grasscutter/data/DataLoader.java
@@ -112,7 +112,7 @@ public class DataLoader {
 
         if (!Utils.fileExists(filePath)) {
             // Check if file is in subdirectory
-            if (name.indexOf("/") != -1) {
+            if (name.contains("/")) {
                 String[] path = name.split("/");
 
                 String folder = "";

--- a/src/main/java/emu/grasscutter/data/ResourceLoader.java
+++ b/src/main/java/emu/grasscutter/data/ResourceLoader.java
@@ -413,13 +413,18 @@ public class ResourceLoader {
         }
 
         try {
-            List<QuestEncryptionKey> keys = DataLoader.loadList("QuestEncryptionKeys.json", QuestEncryptionKey.class);
-
+            List<QuestEncryptionKey> keys;
             Int2ObjectMap<QuestEncryptionKey> questEncryptionMap = GameData.getMainQuestEncryptionMap();
-            keys.forEach(key -> questEncryptionMap.put(key.getMainQuestId(), key));
+            String path = "QuestEncryptionKeys.json";
+            if (Utils.fileExists(RESOURCE(path))) {
+                keys = JsonUtils.loadToList(RESOURCE(path), QuestEncryptionKey.class);
+                keys.forEach(key -> questEncryptionMap.put(key.getMainQuestId(), key));
+            }
+            if (Utils.fileExists(DATA(path))) {
+                keys = DataLoader.loadList(path, QuestEncryptionKey.class);
+                keys.forEach(key -> questEncryptionMap.put(key.getMainQuestId(), key));
+            }
             Grasscutter.getLogger().debug("Loaded {} quest keys.", questEncryptionMap.size());
-        } catch (FileNotFoundException | NullPointerException ignored) {
-            Grasscutter.getLogger().warn("Unable to load quest keys - '" + DATA() + "QuestEncryptionKeys.json' not found.");
         } catch (Exception e) {
             Grasscutter.getLogger().error("Unable to load quest keys.", e);
         }

--- a/src/main/java/emu/grasscutter/data/ResourceLoader.java
+++ b/src/main/java/emu/grasscutter/data/ResourceLoader.java
@@ -419,7 +419,7 @@ public class ResourceLoader {
             keys.forEach(key -> questEncryptionMap.put(key.getMainQuestId(), key));
             Grasscutter.getLogger().debug("Loaded {} quest keys.", questEncryptionMap.size());
         } catch (FileNotFoundException | NullPointerException ignored) {
-            Grasscutter.getLogger().warn("Unable to load quest keys - ./resources/QuestEncryptionKeys.json not found.");
+            Grasscutter.getLogger().warn("Unable to load quest keys - '" + DATA() + "QuestEncryptionKeys.json' not found.");
         } catch (Exception e) {
             Grasscutter.getLogger().error("Unable to load quest keys.", e);
         }


### PR DESCRIPTION
## Description

Fix QuestEncryptionKeys Path

Although it says to save `QuestEncryptionKeys.json` in the `resources folder`, it should be saved in the `data folder`. This issue has been mentioned repeatedly.

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**

## Issues fixed by this PR

#1588 #1654 

<!--- Put the links of issues that may be fixed by this PR here (if any). -->

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.