### PR TITLE
Fix delete account player is null bug

### DIFF
--- a/src/main/java/emu/grasscutter/database/DatabaseHelper.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseHelper.java
@@ -128,23 +128,23 @@ public final class DatabaseHelper {
             player.getSession().close();
         }
         // Delete data from collections
-        DatabaseManager.getGameDatabase().getCollection("activities").deleteMany(eq("uid",player.getUid()));
-        DatabaseManager.getGameDatabase().getCollection("homes").deleteMany(eq("ownerUid",player.getUid()));
-        DatabaseManager.getGameDatabase().getCollection("mail").deleteMany(eq("ownerUid", player.getUid()));
-        DatabaseManager.getGameDatabase().getCollection("avatars").deleteMany(eq("ownerId", player.getUid()));
-        DatabaseManager.getGameDatabase().getCollection("gachas").deleteMany(eq("ownerId", player.getUid()));
-        DatabaseManager.getGameDatabase().getCollection("items").deleteMany(eq("ownerId", player.getUid()));
-        DatabaseManager.getGameDatabase().getCollection("quests").deleteMany(eq("ownerUid", player.getUid()));
-        DatabaseManager.getGameDatabase().getCollection("battlepass").deleteMany(eq("ownerUid", player.getUid()));
+        DatabaseManager.getGameDatabase().getCollection("activities").deleteMany(eq("uid",target.getId()));
+        DatabaseManager.getGameDatabase().getCollection("homes").deleteMany(eq("ownerUid",target.getId()));
+        DatabaseManager.getGameDatabase().getCollection("mail").deleteMany(eq("ownerUid", target.getId()));
+        DatabaseManager.getGameDatabase().getCollection("avatars").deleteMany(eq("ownerId", target.getId()));
+        DatabaseManager.getGameDatabase().getCollection("gachas").deleteMany(eq("ownerId", target.getId()));
+        DatabaseManager.getGameDatabase().getCollection("items").deleteMany(eq("ownerId", target.getId()));
+        DatabaseManager.getGameDatabase().getCollection("quests").deleteMany(eq("ownerUid", target.getId()));
+        DatabaseManager.getGameDatabase().getCollection("battlepass").deleteMany(eq("ownerUid", target.getId()));
 
         // Delete friendships.
         // Here, we need to make sure to not only delete the deleted account's friendships,
         // but also all friendship entries for that account's friends.
-        DatabaseManager.getGameDatabase().getCollection("friendships").deleteMany(eq("ownerId", player.getUid()));
-        DatabaseManager.getGameDatabase().getCollection("friendships").deleteMany(eq("friendId", player.getUid()));
+        DatabaseManager.getGameDatabase().getCollection("friendships").deleteMany(eq("ownerId", target.getId()));
+        DatabaseManager.getGameDatabase().getCollection("friendships").deleteMany(eq("friendId", target.getId()));
 
         // Delete the player last.
-        DatabaseManager.getGameDatastore().find(Player.class).filter(Filters.eq("id", player.getUid())).delete();
+        DatabaseManager.getGameDatastore().find(Player.class).filter(Filters.eq("id", target.getId())).delete();
 
         // Finally, delete the account itself.
         DatabaseManager.getAccountDatastore().find(Account.class).filter(Filters.eq("id", target.getId())).delete();


### PR DESCRIPTION
## Description

An exception occurs when an account is deleted when the target player is not online.
```log
java.lang.NullPointerException: Cannot invoke "emu.grasscutter.game.player.Player.getUid()" because "player" is null
        at emu.grasscutter.database.DatabaseHelper.deleteAccount(DatabaseHelper.java:131)
        at emu.grasscutter.command.commands.AccountCommand.execute(AccountCommand.java:102)
        at emu.grasscutter.command.CommandMap.lambda$invoke$0(CommandMap.java:279)
        at emu.grasscutter.command.CommandMap.invoke(CommandMap.java:283)
        at emu.grasscutter.Grasscutter.startConsole(Grasscutter.java:342)
        at emu.grasscutter.Grasscutter.main(Grasscutter.java:166)
```

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.