### PR TITLE
fix: avatar energy transform in proudskill

### DIFF
--- a/src/main/java/emu/grasscutter/data/excels/ProudSkillData.java
+++ b/src/main/java/emu/grasscutter/data/excels/ProudSkillData.java
@@ -45,9 +45,6 @@ public class ProudSkillData extends GameResource {
 
     @Override
     public void onLoad() {
-        if (this.getOpenConfig() != null & this.getOpenConfig().length() > 0) {
-            this.openConfig = "Avatar_" + this.getOpenConfig();
-        }
         // Fight props
         ArrayList<FightPropData> parsed = new ArrayList<FightPropData>(getAddProps().length);
         for (FightPropData prop : getAddProps()) {


### PR DESCRIPTION
## Description

Some avatar passive is not working because of missing embryos.

## Issues fixed by this PR

This pr will fix some avatar's passive/proudskill not working. This mostly happens with avatars can transform energy into elemental damage (Shougun, Mona)

This issue happened because we added `Avatar_` when loading openConfig from excel. But in ConfigTalent doesn't have it.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes
<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.