### PR TITLE
fixed gadget hp properties and invincibility handling

### DIFF
--- a/src/main/java/emu/grasscutter/data/GameData.java
+++ b/src/main/java/emu/grasscutter/data/GameData.java
@@ -29,6 +29,7 @@ public class GameData {
     private static final Int2ObjectMap<QuestEncryptionKey> questsKeys = new Int2ObjectOpenHashMap<>();
     private static final Int2ObjectMap<HomeworldDefaultSaveData> homeworldDefaultSaveData = new Int2ObjectOpenHashMap<>();
     private static final Int2ObjectMap<SceneNpcBornData> npcBornData = new Int2ObjectOpenHashMap<>();
+    @Getter private static final Map<String, ConfigGadget> gadgetConfigData = new HashMap<>();
 
     // ExcelConfigs
     private static final Int2ObjectMap<PlayerLevelData> playerLevelDataMap = new Int2ObjectOpenHashMap<>();

--- a/src/main/java/emu/grasscutter/data/ResourceLoader.java
+++ b/src/main/java/emu/grasscutter/data/ResourceLoader.java
@@ -68,6 +68,7 @@ public class ResourceLoader {
         // Process into depots
         GameDepot.load();
         // Load spawn data and quests
+        loadGadgetConfigData();
         loadSpawnData();
         loadQuests();
         loadScriptSceneData();
@@ -491,6 +492,31 @@ public class ResourceLoader {
         });
 
         Grasscutter.getLogger().debug("Loaded " + GameData.getSceneNpcBornData().size() + " SceneNpcBornDatas.");
+    }
+
+    @SneakyThrows
+    private static void loadGadgetConfigData() {
+        Files.list(Path.of(RESOURCE("BinOutput/Gadget/"))).forEach(filePath -> {
+            var file = filePath.toFile();
+            if (file.isDirectory() || !file.getName().endsWith("json")) {
+                return;
+            }
+
+            Map<String, ConfigGadget> config;
+
+            try {
+                config = JsonUtils.loadToMap(filePath.toString(), String.class, ConfigGadget.class);
+            } catch (Exception e) {
+                Grasscutter.getLogger().error("failed to load ConfigGadget entries for "+filePath, e);
+                return;
+            }
+
+            for (Entry<String, ConfigGadget> e : config.entrySet()) {
+                GameData.getGadgetConfigData().put(e.getKey(), e.getValue());
+            }
+        });
+
+        Grasscutter.getLogger().debug("Loaded {} ConfigGadget entries.", GameData.getGadgetConfigData().size());
     }
 
     @SneakyThrows

--- a/src/main/java/emu/grasscutter/data/binout/ConfigGadget.java
+++ b/src/main/java/emu/grasscutter/data/binout/ConfigGadget.java
@@ -1,0 +1,15 @@
+package emu.grasscutter.data.binout;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+import javax.annotation.Nullable;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ConfigGadget {
+    // There are more values that can be added that might be useful in the json
+    @Nullable
+    ConfigGadgetCombat combat;
+}

--- a/src/main/java/emu/grasscutter/data/binout/ConfigGadgetCombat.java
+++ b/src/main/java/emu/grasscutter/data/binout/ConfigGadgetCombat.java
@@ -1,0 +1,12 @@
+package emu.grasscutter.data.binout;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ConfigGadgetCombat {
+    // There are more values that can be added that might be useful in the json
+    ConfigGadgetCombatProperty property;
+}

--- a/src/main/java/emu/grasscutter/data/binout/ConfigGadgetCombatProperty.java
+++ b/src/main/java/emu/grasscutter/data/binout/ConfigGadgetCombatProperty.java
@@ -1,0 +1,19 @@
+package emu.grasscutter.data.binout;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ConfigGadgetCombatProperty {
+    float HP;
+    boolean isLockHP;
+    boolean isInvincible;
+    boolean isGhostToAllied;
+    float attack;
+    float defence;
+    float weight;
+    boolean useCreatorProperty;
+}

--- a/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
@@ -81,9 +81,11 @@ public class EntityGadget extends EntityBaseGadget {
 
         var targetHp = combatProperties.getHP();
         setFightProperty(FightProperty.FIGHT_PROP_MAX_HP, targetHp);
+        if (combatProperties.isInvincible()) {
             targetHp = Float.POSITIVE_INFINITY;
         }
         setFightProperty(FightProperty.FIGHT_PROP_CUR_HP, targetHp);
+        setLockHP(combatProperties.isLockHP());
     }
 
     public GadgetData getGadgetData() {

--- a/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
@@ -1,21 +1,20 @@
 package emu.grasscutter.game.entity;
 
 import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.binout.ConfigGadget;
 import emu.grasscutter.data.excels.GadgetData;
 import emu.grasscutter.game.entity.gadget.*;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.EntityIdType;
 import emu.grasscutter.game.props.EntityType;
-import emu.grasscutter.game.props.LifeState;
+import emu.grasscutter.game.props.FightProperty;
 import emu.grasscutter.game.props.PlayerProperty;
 import emu.grasscutter.game.world.Scene;
-import emu.grasscutter.game.world.SpawnDataEntry;
 import emu.grasscutter.net.proto.AbilitySyncStateInfoOuterClass.AbilitySyncStateInfo;
 import emu.grasscutter.net.proto.AnimatorParameterValueInfoPairOuterClass.AnimatorParameterValueInfoPair;
 import emu.grasscutter.net.proto.EntityAuthorityInfoOuterClass.EntityAuthorityInfo;
 import emu.grasscutter.net.proto.EntityClientDataOuterClass.EntityClientData;
 import emu.grasscutter.net.proto.EntityRendererChangedInfoOuterClass.EntityRendererChangedInfo;
-import emu.grasscutter.net.proto.FightPropPairOuterClass.FightPropPair;
 import emu.grasscutter.net.proto.GadgetInteractReqOuterClass.GadgetInteractReq;
 import emu.grasscutter.net.proto.MotionInfoOuterClass.MotionInfo;
 import emu.grasscutter.net.proto.PropPairOuterClass.PropPair;
@@ -24,17 +23,17 @@ import emu.grasscutter.net.proto.SceneEntityAiInfoOuterClass.SceneEntityAiInfo;
 import emu.grasscutter.net.proto.SceneEntityInfoOuterClass.SceneEntityInfo;
 import emu.grasscutter.net.proto.SceneGadgetInfoOuterClass.SceneGadgetInfo;
 import emu.grasscutter.net.proto.VectorOuterClass.Vector;
-import emu.grasscutter.net.proto.VisionTypeOuterClass.VisionType;
 import emu.grasscutter.scripts.constants.EventType;
 import emu.grasscutter.scripts.data.SceneGadget;
 import emu.grasscutter.scripts.data.ScriptArgs;
 import emu.grasscutter.server.packet.send.PacketGadgetStateNotify;
-import emu.grasscutter.server.packet.send.PacketLifeStateChangeNotify;
 import emu.grasscutter.utils.Position;
 import emu.grasscutter.utils.ProtoHelper;
-import it.unimi.dsi.fastutil.ints.Int2FloatMap;
 import it.unimi.dsi.fastutil.ints.Int2FloatOpenHashMap;
+import lombok.Getter;
 import lombok.ToString;
+
+import javax.annotation.Nullable;
 
 @ToString(callSuper = true)
 public class EntityGadget extends EntityBaseGadget {
@@ -48,14 +47,20 @@ public class EntityGadget extends EntityBaseGadget {
     private GadgetContent content;
     private Int2FloatOpenHashMap fightProp;
     private SceneGadget metaGadget;
+    @Nullable @Getter
+    private ConfigGadget configGadget;
 
     public EntityGadget(Scene scene, int gadgetId, Position pos, Position rot) {
         super(scene);
         this.data = GameData.getGadgetDataMap().get(gadgetId);
+        if(data!=null && data.getJsonName()!=null) {
+            this.configGadget = GameData.getGadgetConfigData().get(data.getJsonName());
+        }
         this.id = getScene().getWorld().getNextEntityId(EntityIdType.GADGET);
         this.gadgetId = gadgetId;
         this.pos = pos.clone();
         this.rot = rot != null ? rot.clone() : new Position();
+        fillFightProps();
     }
 
     public EntityGadget(Scene scene, int gadgetId, Position pos) {
@@ -65,6 +70,20 @@ public class EntityGadget extends EntityBaseGadget {
     public EntityGadget(Scene scene, int gadgetId, Position pos, Position rot, GadgetContent content) {
         this(scene, gadgetId, pos, rot);
         this.content = content;
+    }
+
+    private void fillFightProps() {
+        if (configGadget == null || configGadget.getCombat() == null) {
+            return;
+        }
+        var combatData = configGadget.getCombat();
+        var combatProperties = combatData.getProperty();
+
+        var targetHp = combatProperties.getHP();
+        setFightProperty(FightProperty.FIGHT_PROP_MAX_HP, targetHp);
+            targetHp = Float.POSITIVE_INFINITY;
+        }
+        setFightProperty(FightProperty.FIGHT_PROP_CUR_HP, targetHp);
     }
 
     public GadgetData getGadgetData() {

--- a/src/main/java/emu/grasscutter/game/entity/GameEntity.java
+++ b/src/main/java/emu/grasscutter/game/entity/GameEntity.java
@@ -106,6 +106,10 @@ public abstract class GameEntity {
         return this.getFightProperties().getOrDefault(prop.getId(), 0f);
     }
 
+    public boolean hasFightProperty(FightProperty prop) {
+        return this.getFightProperties().containsKey(prop.getId());
+    }
+
     public void addAllFightPropsToEntityInfo(SceneEntityInfo.Builder entityInfo) {
         for (Int2FloatMap.Entry entry : this.getFightProperties().int2FloatEntrySet()) {
             if (entry.getIntKey() == 0) {
@@ -153,7 +157,7 @@ public abstract class GameEntity {
 
     public void damage(float amount, int killerId) {
         // Check if the entity has properties.
-        if (this.getFightProperties() == null) {
+        if (this.getFightProperties() == null || !hasFightProperty(FightProperty.FIGHT_PROP_CUR_HP)) {
             return;
         }
 

--- a/src/main/java/emu/grasscutter/game/entity/GameEntity.java
+++ b/src/main/java/emu/grasscutter/game/entity/GameEntity.java
@@ -37,6 +37,8 @@ public abstract class GameEntity {
     @Getter @Setter private int lastMoveSceneTimeMs;
     @Getter @Setter private int lastMoveReliableSeq;
 
+    @Getter @Setter private boolean lockHP;
+
     // Abilities
     private Object2FloatMap<String> metaOverrideMap;
     private Int2ObjectMap<String> metaModifiers;
@@ -168,9 +170,10 @@ public abstract class GameEntity {
             return; // If the event is canceled, do not damage the entity.
         }
 
-        if (getFightProperty(FightProperty.FIGHT_PROP_CUR_HP) != Float.POSITIVE_INFINITY) {
-          // Add negative HP to the current HP property.
-          this.addFightProperty(FightProperty.FIGHT_PROP_CUR_HP, -(event.getDamage()));
+        float curHp = getFightProperty(FightProperty.FIGHT_PROP_CUR_HP);
+        if (curHp != Float.POSITIVE_INFINITY && !lockHP || lockHP && curHp <= event.getDamage()) {
+            // Add negative HP to the current HP property.
+            this.addFightProperty(FightProperty.FIGHT_PROP_CUR_HP, -(event.getDamage()));
         }
 
         // Check if dead


### PR DESCRIPTION
## Description
Some gadgets, including chests, didn't have fightingProperties for hp, so they would just disapear when hit by an attack.
This merge requests reads the ConfigGadget definitions from from the json files in `/BinOutput/Gadget/` and applies the `HP`, `isLockHP` and `isInvincible` properties from combat.properties of those json objects.
The config to use is defined by GadgetData.jsonName.

## Issues fixed by this PR
#1476
#1405

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.