### PR TITLE
Fix showing ban message box

### DIFF
--- a/src/main/java/emu/grasscutter/server/game/GameServerPacketHandler.java
+++ b/src/main/java/emu/grasscutter/server/game/GameServerPacketHandler.java
@@ -4,6 +4,7 @@ import static emu.grasscutter.config.Configuration.*;
 
 import java.util.Set;
 
+import emu.grasscutter.game.Account;
 import emu.grasscutter.server.event.game.ReceivePacketEvent;
 import org.reflections.Reflections;
 
@@ -57,6 +58,8 @@ public class GameServerPacketHandler {
     public void handle(GameSession session, int opcode, byte[] header, byte[] payload) {
         PacketHandler handler = this.handlers.get(opcode);
 
+        Account account = session.getAccount();
+
         if (handler != null) {
             try {
                 // Make sure session is ready for packets
@@ -68,6 +71,9 @@ public class GameServerPacketHandler {
                     if (state != SessionState.WAITING_FOR_TOKEN) {
                         return;
                     }
+                } else if (account.isBanned()) {
+                    session.close();
+                    return;
                 } else if (opcode == PacketOpcodes.PlayerLoginReq) {
                     if (state != SessionState.WAITING_FOR_LOGIN) {
                         return;

--- a/src/main/java/emu/grasscutter/server/game/GameServerPacketHandler.java
+++ b/src/main/java/emu/grasscutter/server/game/GameServerPacketHandler.java
@@ -58,8 +58,6 @@ public class GameServerPacketHandler {
     public void handle(GameSession session, int opcode, byte[] header, byte[] payload) {
         PacketHandler handler = this.handlers.get(opcode);
 
-        Account account = session.getAccount();
-
         if (handler != null) {
             try {
                 // Make sure session is ready for packets
@@ -71,7 +69,7 @@ public class GameServerPacketHandler {
                     if (state != SessionState.WAITING_FOR_TOKEN) {
                         return;
                     }
-                } else if (account.isBanned()) {
+                } else if (state == SessionState.ACCOUNT_BANNED) {
                     session.close();
                     return;
                 } else if (opcode == PacketOpcodes.PlayerLoginReq) {
@@ -89,7 +87,8 @@ public class GameServerPacketHandler {
                 }
 
                 // Invoke event.
-                ReceivePacketEvent event = new ReceivePacketEvent(session, opcode, payload); event.call();
+                ReceivePacketEvent event = new ReceivePacketEvent(session, opcode, payload);
+                event.call();
                 if (!event.isCanceled()) // If event is not canceled, continue.
                     handler.handle(session, header, event.getPacketData());
             } catch (Exception ex) {

--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -3,6 +3,7 @@ package emu.grasscutter.server.game;
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.Set;
+
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.Grasscutter.ServerDebugMode;
 import emu.grasscutter.game.Account;
@@ -47,7 +48,7 @@ public class GameSession implements GameSessionManager.KcpChannel {
     public InetSocketAddress getAddress() {
         try {
             return tunnel.getAddress();
-        }catch (Throwable ignore) {
+        } catch (Throwable ignore) {
             return null;
         }
     }
@@ -125,10 +126,11 @@ public class GameSession implements GameSessionManager.KcpChannel {
         send(basePacket);
     }
 
-    public void logPacket( String sendOrRecv, int opcode, byte[] payload) {
+    public void logPacket(String sendOrRecv, int opcode, byte[] payload) {
         Grasscutter.getLogger().info(sendOrRecv + ": " + PacketOpcodesUtils.getOpcodeName(opcode) + " (" + opcode + ")");
         System.out.println(Utils.bytesToHex(payload));
     }
+
     public void send(BasePacket packet) {
         // Test
         if (packet.getOpcode() <= 0) {
@@ -154,21 +156,23 @@ public class GameSession implements GameSessionManager.KcpChannel {
                     logPacket("SEND", packet.getOpcode(), packet.getData());
                 }
             }
-            case WHITELIST-> {
+            case WHITELIST -> {
                 if (SERVER.debugWhitelist.contains(packet.getOpcode())) {
                     logPacket("SEND", packet.getOpcode(), packet.getData());
                 }
             }
-            case BLACKLIST-> {
+            case BLACKLIST -> {
                 if (!SERVER.debugBlacklist.contains(packet.getOpcode())) {
                     logPacket("SEND", packet.getOpcode(), packet.getData());
                 }
             }
-            default -> {}
+            default -> {
+            }
         }
 
         // Invoke event.
-        SendPacketEvent event = new SendPacketEvent(this, packet); event.call();
+        SendPacketEvent event = new SendPacketEvent(this, packet);
+        event.call();
         if (!event.isCanceled()) { // If event is not cancelled, continue.
             tunnel.writeData(event.getPacket().build());
         }
@@ -201,7 +205,7 @@ public class GameSession implements GameSessionManager.KcpChannel {
                 int const1 = packet.readShort();
                 if (const1 != 17767) {
                     if (allDebug) {
-                        Grasscutter.getLogger().error("Bad Data Package Received: got {} ,expect 17767",const1);
+                        Grasscutter.getLogger().error("Bad Data Package Received: got {} ,expect 17767", const1);
                     }
                     return; // Bad packet
                 }
@@ -218,7 +222,7 @@ public class GameSession implements GameSessionManager.KcpChannel {
                 int const2 = packet.readShort();
                 if (const2 != -30293) {
                     if (allDebug) {
-                        Grasscutter.getLogger().error("Bad Data Package Received: got {} ,expect -30293",const2);
+                        Grasscutter.getLogger().error("Bad Data Package Received: got {} ,expect -30293", const2);
                     }
                     return; // Bad packet
                 }
@@ -227,20 +231,21 @@ public class GameSession implements GameSessionManager.KcpChannel {
                 switch (GAME_INFO.logPackets) {
                     case ALL -> {
                         if (!PacketOpcodesUtils.LOOP_PACKETS.contains(opcode)) {
-                            logPacket("RECV",opcode, payload);
+                            logPacket("RECV", opcode, payload);
                         }
                     }
-                    case WHITELIST-> {
+                    case WHITELIST -> {
                         if (SERVER.debugWhitelist.contains(opcode)) {
-                            logPacket("RECV",opcode, payload);
+                            logPacket("RECV", opcode, payload);
                         }
                     }
-                    case BLACKLIST-> {
+                    case BLACKLIST -> {
                         if (!(SERVER.debugBlacklist.contains(opcode))) {
-                            logPacket("RECV",opcode, payload);
+                            logPacket("RECV", opcode, payload);
                         }
                     }
-                    default -> {}
+                    default -> {
+                    }
                 }
 
                 // Handle
@@ -267,8 +272,8 @@ public class GameSession implements GameSessionManager.KcpChannel {
         }
         try {
             send(new BasePacket(PacketOpcodes.ServerDisconnectClientNotify));
-        }catch (Throwable ignore) {
-            Grasscutter.getLogger().warn("closing {} error",getAddress().getAddress().getHostAddress());
+        } catch (Throwable ignore) {
+            Grasscutter.getLogger().warn("closing {} error", getAddress().getAddress().getHostAddress());
         }
         tunnel = null;
     }
@@ -286,6 +291,7 @@ public class GameSession implements GameSessionManager.KcpChannel {
         WAITING_FOR_TOKEN,
         WAITING_FOR_LOGIN,
         PICKING_CHARACTER,
-        ACTIVE
+        ACTIVE,
+        ACCOUNT_BANNED
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerTokenReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerTokenReq.java
@@ -88,7 +88,6 @@ public class HandlerGetPlayerTokenReq extends PacketHandler {
         // Checks if the player is banned
         if (session.getAccount().isBanned()) {
             session.send(new PacketGetPlayerTokenRsp(session, 21, "FORBID_CHEATING_PLUGINS", session.getAccount().getBanEndTime()));
-            session.close();
             return;
         }
 

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerTokenReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetPlayerTokenReq.java
@@ -67,7 +67,8 @@ public class HandlerGetPlayerTokenReq extends PacketHandler {
         }
 
         // Call creation event.
-        PlayerCreationEvent event = new PlayerCreationEvent(session, Player.class); event.call();
+        PlayerCreationEvent event = new PlayerCreationEvent(session, Player.class);
+        event.call();
 
         // Get player.
         Player player = DatabaseHelper.getPlayerByAccount(account, event.getPlayerClass());
@@ -87,6 +88,7 @@ public class HandlerGetPlayerTokenReq extends PacketHandler {
 
         // Checks if the player is banned
         if (session.getAccount().isBanned()) {
+            session.setState(SessionState.ACCOUNT_BANNED);
             session.send(new PacketGetPlayerTokenRsp(session, 21, "FORBID_CHEATING_PLUGINS", session.getAccount().getBanEndTime()));
             return;
         }
@@ -131,8 +133,7 @@ public class HandlerGetPlayerTokenReq extends PacketHandler {
 
                 session.send(new PacketGetPlayerTokenRsp(session, base64str, "bm90aGluZyBoZXJl"));
             }
-        }
-        else {
+        } else {
             // Send packet
             session.send(new PacketGetPlayerTokenRsp(session));
         }


### PR DESCRIPTION
## Description
I have tested and found that, if we close the session right before sending the response packet, the client will show a "Disconnected" message instead of a ban. So I removed it.
After the client press OK or a time, the client would automatically close the session and disconnect.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.