### PR TITLE
Fix food decreasing

### DIFF
--- a/src/main/java/emu/grasscutter/game/systems/InventorySystem.java
+++ b/src/main/java/emu/grasscutter/game/systems/InventorySystem.java
@@ -851,7 +851,11 @@ public class InventorySystem extends BaseGameSystem {
                 switch (useData.getUseOp()) {
                     case ITEM_USE_ADD_SERVER_BUFF -> {
                         int buffId = Integer.parseInt(useData.getUseParam()[0]);
-                        float time = Float.parseFloat(useData.getUseParam()[1]);
+                        String timeString = useData.getUseParam()[1];
+                        float time = 0;
+                        if (!timeString.isEmpty()) {
+                            time = Float.parseFloat(timeString);
+                        }
 
                         player.getBuffManager().addBuff(buffId, time);
                     }

--- a/src/main/java/emu/grasscutter/game/systems/InventorySystem.java
+++ b/src/main/java/emu/grasscutter/game/systems/InventorySystem.java
@@ -852,10 +852,7 @@ public class InventorySystem extends BaseGameSystem {
                     case ITEM_USE_ADD_SERVER_BUFF -> {
                         int buffId = Integer.parseInt(useData.getUseParam()[0]);
                         String timeString = useData.getUseParam()[1];
-                        float time = 0;
-                        if (!timeString.isEmpty()) {
-                            time = Float.parseFloat(timeString);
-                        }
+                        float time = timeString.isEmpty() ? 0 : Float.parseFloat(timeString);
 
                         player.getBuffManager().addBuff(buffId, time);
                     }


### PR DESCRIPTION
## Description

Some food didn't reduce after use. This was because if in MaterialExcelConfigData.json, `materialType` was `MATERIAL_NOTICE_ADD_HP` and `useParam[1]` was empty.

## Issues fixed by this PR

https://github.com/Grasscutters/Grasscutter/issues/1746#issuecomment-1237249597

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.