### PR TITLE
[Security][Bugfix] Fix directory traversal exploit

### DIFF
--- a/src/main/java/emu/grasscutter/server/http/handlers/AnnouncementsHandler.java
+++ b/src/main/java/emu/grasscutter/server/http/handlers/AnnouncementsHandler.java
@@ -14,7 +14,7 @@ import static emu.grasscutter.config.Configuration.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
-import java.util.StringJoiner
+import java.util.StringJoiner;
 
 /**
  * Handles requests related to the announcements page.

--- a/src/main/java/emu/grasscutter/server/http/handlers/AnnouncementsHandler.java
+++ b/src/main/java/emu/grasscutter/server/http/handlers/AnnouncementsHandler.java
@@ -14,6 +14,7 @@ import static emu.grasscutter.config.Configuration.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Objects;
+import java.util.StringJoiner
 
 /**
  * Handles requests related to the announcements page.
@@ -72,7 +73,16 @@ public final class AnnouncementsHandler implements Router {
     }
 
     private static void getPageResources(Context ctx) {
-        try (InputStream filestream = DataLoader.load(ctx.path())) {
+        // Re-Process the path - remove the first slash and prevent directory traversal
+        String[] path = ctx.path().split("/");
+        StringJoiner stringJoiner=new StringJoiner("/");
+        for (String pathName : path) {
+            // Filter the illegal payload to prevent directory traversal
+            if(!pathName.isEmpty() && !pathName.equals("..") && !pathName.contains("\\")) {
+                stringJoiner.add(pathName);
+            }
+        }
+        try (InputStream filestream = DataLoader.load(stringJoiner.toString())) {
             String possibleFilename = ctx.path();
 
             ContentType fromExtension = ContentType.getContentTypeByExtension(possibleFilename.substring(possibleFilename.lastIndexOf(".") + 1));

--- a/src/main/java/emu/grasscutter/server/http/handlers/AnnouncementsHandler.java
+++ b/src/main/java/emu/grasscutter/server/http/handlers/AnnouncementsHandler.java
@@ -73,12 +73,13 @@ public final class AnnouncementsHandler implements Router {
     }
 
     private static void getPageResources(Context ctx) {
-        // Re-Process the path - remove the first slash and prevent directory traversal
+        // Re-process the path - remove the first slash and prevent directory traversal
+        // (the first slash will act as root path when resolving local path)
         String[] path = ctx.path().split("/");
-        StringJoiner stringJoiner=new StringJoiner("/");
+        StringJoiner stringJoiner = new StringJoiner("/");
         for (String pathName : path) {
             // Filter the illegal payload to prevent directory traversal
-            if(!pathName.isEmpty() && !pathName.equals("..") && !pathName.contains("\\")) {
+            if (!pathName.isEmpty() && !pathName.equals("..") && !pathName.contains("\\")) {
                 stringJoiner.add(pathName);
             }
         }


### PR DESCRIPTION

## Description

Fix directory traversal exploit in `AnnouncementHandler` :
1. The first slash will act as root path when resolving local path, so directory traversal is possible 
2. Filter the illegal payload to prevent directory traversal 
3. This also fix the bug about not loading the files in data folder when querying  `/hk4e/announcement/`

## Issues fixed by this PR
None
<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.