### PR TITLE
Fix Mail SendToAll Freeze

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/SendMailCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SendMailCommand.java
@@ -79,7 +79,7 @@ public final class SendMailCommand implements CommandHandler {
                                 Grasscutter.getGameServer().getPlayerByUid(mailBuilder.recipient, true).sendMail(mailBuilder.mail);
                                 CommandHandler.sendMessage(sender, translate(sender, "commands.sendMail.send_done", mailBuilder.recipient));
                             } else {
-                                DatabaseHelper.getAllPlayers().forEach(player -> {
+                                DatabaseHelper.getByGameClass(Player.class).forEach(player -> {
                                     var onlinePlayer = Grasscutter.getGameServer().getPlayerByUid(player.getUid(), false);
                                     Objects.requireNonNullElse(onlinePlayer, player).sendMail(mailBuilder.mail);
                                 });

--- a/src/main/java/emu/grasscutter/command/commands/SendMailCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SendMailCommand.java
@@ -79,10 +79,10 @@ public final class SendMailCommand implements CommandHandler {
                                 Grasscutter.getGameServer().getPlayerByUid(mailBuilder.recipient, true).sendMail(mailBuilder.mail);
                                 CommandHandler.sendMessage(sender, translate(sender, "commands.sendMail.send_done", mailBuilder.recipient));
                             } else {
-                                for (Player player : DatabaseHelper.getAllPlayers()) {
+                                DatabaseHelper.getAllPlayers().forEach(player -> {
                                     var onlinePlayer = Grasscutter.getGameServer().getPlayerByUid(player.getUid(), false);
                                     Objects.requireNonNullElse(onlinePlayer, player).sendMail(mailBuilder.mail);
-                                }
+                                });
                                 CommandHandler.sendMessage(sender, translate(sender, "commands.sendMail.send_all_done"));
                             }
                             mailBeingConstructed.remove(senderId);

--- a/src/main/java/emu/grasscutter/command/commands/SendMailCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SendMailCommand.java
@@ -9,6 +9,7 @@ import emu.grasscutter.game.player.Player;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 
 import static emu.grasscutter.utils.Language.translate;
 
@@ -79,7 +80,8 @@ public final class SendMailCommand implements CommandHandler {
                                 CommandHandler.sendMessage(sender, translate(sender, "commands.sendMail.send_done", mailBuilder.recipient));
                             } else {
                                 for (Player player : DatabaseHelper.getAllPlayers()) {
-                                    Grasscutter.getGameServer().getPlayerByUid(player.getUid(), true).sendMail(mailBuilder.mail);
+                                    var onlinePlayer = Grasscutter.getGameServer().getPlayerByUid(player.getUid(), false);
+                                    Objects.requireNonNullElse(onlinePlayer, player).sendMail(mailBuilder.mail);
                                 }
                                 CommandHandler.sendMessage(sender, translate(sender, "commands.sendMail.send_all_done"));
                             }

--- a/src/main/java/emu/grasscutter/database/DatabaseHelper.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseHelper.java
@@ -1,6 +1,7 @@
 package emu.grasscutter.database;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import com.mongodb.client.result.DeleteResult;
 
@@ -154,8 +155,8 @@ public final class DatabaseHelper {
         DatabaseManager.getAccountDatastore().find(Account.class).filter(Filters.eq("id", target.getId())).delete();
     }
 
-    public static List<Player> getAllPlayers() {
-        return DatabaseManager.getGameDatastore().find(Player.class).stream().toList();
+    public static Stream<Player> getAllPlayers() {
+        return DatabaseManager.getGameDatastore().find(Player.class).stream();
     }
 
     public static Player getPlayerByUid(int id) {

--- a/src/main/java/emu/grasscutter/database/DatabaseHelper.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseHelper.java
@@ -159,6 +159,7 @@ public final class DatabaseHelper {
         return DatabaseManager.getGameDatastore().find(classType).stream();
     }
 
+    @Deprecated(forRemoval = true)
     public static List<Player> getAllPlayers() {
         return DatabaseManager.getGameDatastore().find(Player.class).stream().toList();
     }

--- a/src/main/java/emu/grasscutter/database/DatabaseHelper.java
+++ b/src/main/java/emu/grasscutter/database/DatabaseHelper.java
@@ -155,8 +155,12 @@ public final class DatabaseHelper {
         DatabaseManager.getAccountDatastore().find(Account.class).filter(Filters.eq("id", target.getId())).delete();
     }
 
-    public static Stream<Player> getAllPlayers() {
-        return DatabaseManager.getGameDatastore().find(Player.class).stream();
+    public static <T> Stream<T> getByGameClass(Class<T> classType) {
+        return DatabaseManager.getGameDatastore().find(classType).stream();
+    }
+
+    public static List<Player> getAllPlayers() {
+        return DatabaseManager.getGameDatastore().find(Player.class).stream().toList();
     }
 
     public static Player getPlayerByUid(int id) {


### PR DESCRIPTION
## Description

> Sending an mail to everyone in a 4h8g server with 3316 accounts would cause the server to use up all resources and then crash.

Calling the `DatabaseHelper.getAllPlayers()` method is too expensive, changing to a `Stream` has a significant improvement.

## Type of changes

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.