### PR TITLE
Some fix about scene script and quest

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -132,14 +132,16 @@ public class GameMainQuest {
 
         // Add rewards
         MainQuestData mainQuestData = GameData.getMainQuestDataMap().get(this.getParentQuestId());
-        for (int rewardId : mainQuestData.getRewardIdList()) {
-            RewardData rewardData = GameData.getRewardDataMap().get(rewardId);
+        if (mainQuestData != null && mainQuestData.getRewardIdList() != null) {
+            for (int rewardId : mainQuestData.getRewardIdList()) {
+                RewardData rewardData = GameData.getRewardDataMap().get(rewardId);
 
-            if (rewardData == null) {
-                continue;
+                if (rewardData == null) {
+                    continue;
+                }
+
+                getOwner().getInventory().addItemParamDatas(rewardData.getRewardItemList(), ActionReason.QuestReward);
             }
-
-            getOwner().getInventory().addItemParamDatas(rewardData.getRewardItemList(), ActionReason.QuestReward);
         }
 
         // handoff main quest

--- a/src/main/java/emu/grasscutter/game/quest/QuestManager.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestManager.java
@@ -272,6 +272,7 @@ public class QuestManager extends BasePlayerManager {
             case QUEST_CONTENT_INTERACT_GADGET:
             case QUEST_CONTENT_TRIGGER_FIRE:
             case QUEST_CONTENT_UNLOCK_TRANS_POINT:
+            case QUEST_CONTENT_SKILL:
                 for (GameMainQuest mainQuest : checkMainQuests) {
                     mainQuest.tryFinishSubQuests(condType, paramStr, params);
                 }

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentSkill.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentSkill.java
@@ -1,0 +1,14 @@
+package emu.grasscutter.game.quest.content;
+
+import emu.grasscutter.data.excels.QuestData;
+import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.quest.QuestValue;
+import emu.grasscutter.game.quest.enums.QuestTrigger;
+
+@QuestValue(QuestTrigger.QUEST_CONTENT_SKILL)
+public class ContentSkill extends BaseContent{
+    @Override
+    public boolean execute(GameQuest quest, QuestData.QuestCondition condition, String paramStr, int... params) {
+        return (condition.getParam()[0] == params[0]) && (condition.getParam()[1] == params[1]);
+    }
+}

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentSkill.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentSkill.java
@@ -6,7 +6,7 @@ import emu.grasscutter.game.quest.QuestValue;
 import emu.grasscutter.game.quest.enums.QuestTrigger;
 
 @QuestValue(QuestTrigger.QUEST_CONTENT_SKILL)
-public class ContentSkill extends BaseContent{
+public class ContentSkill extends BaseContent {
     @Override
     public boolean execute(GameQuest quest, QuestData.QuestCondition condition, String paramStr, int... params) {
         return (condition.getParam()[0] == params[0]) && (condition.getParam()[1] == params[1]);

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -104,6 +104,9 @@ public class SceneScriptManager {
         currentTriggers.put(eventId, new HashSet<>());
     }
     public void refreshGroup(SceneGroup group, int suiteIndex) {
+        if (group == null) {
+            return;
+        }
         var suite = group.getSuiteByIndex(suiteIndex);
         if (suite == null) {
             return;

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -107,16 +107,19 @@ public class SceneScriptManager {
         if (group == null) {
             return;
         }
+
         var suite = group.getSuiteByIndex(suiteIndex);
         if (suite == null) {
             return;
         }
+
         if (suite.sceneTriggers.size() > 0) {
             for (var trigger : suite.sceneTriggers) {
                 resetTriggers(trigger.event);
                 this.currentTriggers.get(trigger.event).add(trigger);
             }
         }
+
         spawnMonstersInGroup(group, suite);
         spawnGadgetsInGroup(group, suite);
     }

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -1,11 +1,13 @@
 package emu.grasscutter.scripts;
 
+import emu.grasscutter.database.DatabaseHelper;
 import emu.grasscutter.game.dungeons.challenge.DungeonChallenge;
 import emu.grasscutter.game.entity.EntityGadget;
 import emu.grasscutter.game.entity.EntityMonster;
 import emu.grasscutter.game.entity.GameEntity;
 import emu.grasscutter.game.entity.gadget.GadgetWorktop;
 import emu.grasscutter.game.dungeons.challenge.factory.ChallengeFactory;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.EntityType;
 import emu.grasscutter.game.quest.enums.QuestState;
 import emu.grasscutter.game.quest.enums.QuestTrigger;
@@ -89,14 +91,14 @@ public class ScriptLib {
 				.filter(e -> e instanceof EntityGadget)
 				.map(e -> (EntityGadget)e)
 				.forEach(e -> e.updateState(gadgetState));
-		
+
 		return 0;
 	}
-	
+
 	public int SetWorktopOptionsByGroupId(int groupId, int configId, int[] options) {
 		logger.debug("[LUA] Call SetWorktopOptionsByGroupId with {},{},{}",
 				groupId,configId,options);
-		
+
 		Optional<GameEntity> entity = getSceneScriptManager().getScene().getEntities().values().stream()
 				.filter(e -> e.getConfigId() == configId && e.getGroupId() == groupId).findFirst();
 
@@ -108,10 +110,10 @@ public class ScriptLib {
 		if (!(gadget.getContent() instanceof GadgetWorktop worktop)) {
 			return 1;
 		}
-		
+
 		worktop.addWorktopOptions(options);
 		getSceneScriptManager().getScene().broadcastPacket(new PacketWorktopOptionNotify(gadget));
-		
+
 		return 0;
 	}
 
@@ -133,13 +135,13 @@ public class ScriptLib {
 		if (!(gadget.getContent() instanceof GadgetWorktop worktop)) {
 			return 1;
 		}
-		
+
 		worktop.removeWorktopOption(option);
 		getSceneScriptManager().getScene().broadcastPacket(new PacketWorktopOptionNotify(gadget));
-		
+
 		return 0;
 	}
-	
+
 	// Some fields are guessed
 	public int AutoMonsterTide(int challengeIndex, int groupId, Integer[] ordersConfigId, int tideCount, int sceneLimit, int param6) {
 		logger.debug("[LUA] Call AutoMonsterTide with {},{},{},{},{},{}",
@@ -152,15 +154,15 @@ public class ScriptLib {
 		}
 
 		this.getSceneScriptManager().startMonsterTideInGroup(group, ordersConfigId, tideCount, sceneLimit);
-		
+
 		return 0;
 	}
-	
+
 	public int AddExtraGroupSuite(int groupId, int suite) {
 		logger.debug("[LUA] Call AddExtraGroupSuite with {},{}",
 				groupId,suite);
 		SceneGroup group = getSceneScriptManager().getGroupById(groupId);
-		
+
 		if (group == null || group.monsters == null) {
 			return 1;
 		}
@@ -263,7 +265,7 @@ public class ScriptLib {
 		challenge.start();
 		return 0;
 	}
-	
+
 	public int GetGroupMonsterCountByGroupId(int groupId) {
 		logger.debug("[LUA] Call GetGroupMonsterCountByGroupId with {}",
 				groupId);
@@ -271,20 +273,20 @@ public class ScriptLib {
 								.filter(e -> e instanceof EntityMonster && e.getGroupId() == groupId)
 								.count();
 	}
-	
+
 	public int GetGroupVariableValue(String var) {
 		logger.debug("[LUA] Call GetGroupVariableValue with {}",
 				var);
 		return getSceneScriptManager().getVariables().getOrDefault(var, 0);
 	}
-	
+
 	public int SetGroupVariableValue(String var, int value) {
 		logger.debug("[LUA] Call SetGroupVariableValue with {},{}",
 				var, value);
 		getSceneScriptManager().getVariables().put(var, value);
 		return 0;
 	}
-	
+
 	public LuaValue ChangeGroupVariableValue(String var, int value) {
 		logger.debug("[LUA] Call ChangeGroupVariableValue with {},{}",
 				var, value);
@@ -302,15 +304,15 @@ public class ScriptLib {
 		// Kill and Respawn?
 		int groupId = table.get("group_id").toint();
 		int suite = table.get("suite").toint();
-		
+
 		SceneGroup group = getSceneScriptManager().getGroupById(groupId);
-		
+
 		if (group == null || group.monsters == null) {
 			return 1;
 		}
-		
+
 		getSceneScriptManager().refreshGroup(group, suite);
-		
+
 		return 0;
 	}
 
@@ -430,14 +432,14 @@ public class ScriptLib {
 		var configId = table.get("config_id").toint();
 
 		var group = getCurrentGroup();
-		
+
 		if (group.isEmpty()) {
 			return 1;
 		}
-		
+
 		var gadget = group.get().gadgets.get(configId);
 		var entity = getSceneScriptManager().createGadget(group.get().id, group.get().block_id, gadget);
-		
+
 		getSceneScriptManager().addEntity(entity);
 
 		return 0;
@@ -515,6 +517,11 @@ public class ScriptLib {
     public int GetEntityType(int entityId){
         var entity = getSceneScriptManager().getScene().getEntityById(entityId);
         if(entity == null){
+            // check players
+            Player player = DatabaseHelper.getPlayerByUid(entityId);
+            if (player != null) {
+                return EntityType.Avatar.getValue();
+            }
             return EntityType.None.getValue();
         }
 

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -522,6 +522,7 @@ public class ScriptLib {
             if (player != null) {
                 return EntityType.Avatar.getValue();
             }
+
             return EntityType.None.getValue();
         }
 

--- a/src/main/java/emu/grasscutter/scripts/data/Explore.java
+++ b/src/main/java/emu/grasscutter/scripts/data/Explore.java
@@ -5,8 +5,7 @@ import lombok.ToString;
 
 @ToString
 @Setter
-public class SceneInitConfig {
-	public int suite;
-	public int end_suite;
-	public boolean rand_suite;
+public class Explore {
+    public String name;
+    public int exp;
 }

--- a/src/main/java/emu/grasscutter/scripts/data/SceneGadget.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneGadget.java
@@ -13,6 +13,13 @@ public class SceneGadget extends SceneObject{
     public int interact_id;
     public boolean isOneoff;
     public int draft_id;
+    public String drop_tag;
+    public boolean persistent;
+    public int mark_flag;
+    public int route_id;
+    public Explore explore;
+    public int trigger_count;
+    public boolean showcutscene;
 
     public void setIsOneoff(boolean isOneoff) {
         this.isOneoff = isOneoff;

--- a/src/main/java/emu/grasscutter/scripts/data/SceneMonster.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneMonster.java
@@ -9,4 +9,11 @@ public class SceneMonster extends SceneObject{
 	public int monster_id;
 	public int pose_id;
 	public int drop_id;
+    public int special_name_id;
+    public String drop_tag;
+    public int climate_area_id;
+    public boolean disableWander;
+    public int title_id;
+    public int[] affix;
+    public int mark_flag;
 }

--- a/src/main/java/emu/grasscutter/scripts/data/SceneRegion.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneRegion.java
@@ -4,6 +4,8 @@ import emu.grasscutter.scripts.constants.ScriptRegionShape;
 import emu.grasscutter.utils.Position;
 import lombok.Setter;
 
+import java.util.List;
+
 
 @Setter
 public class SceneRegion {
@@ -16,7 +18,7 @@ public class SceneRegion {
     public int radius;
     public int area_id;
     public float height;
-    public Position point_array;
+    public List<Position> point_array;
 
     public transient SceneGroup group;
     public boolean contains(Position position) {

--- a/src/main/java/emu/grasscutter/scripts/data/SceneRegion.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneRegion.java
@@ -14,6 +14,9 @@ public class SceneRegion {
     public Position size;
     // for SPHERE
     public int radius;
+    public int area_id;
+    public float height;
+    public Position point_array;
 
     public transient SceneGroup group;
     public boolean contains(Position position) {

--- a/src/main/java/emu/grasscutter/scripts/data/SceneSuite.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneSuite.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 @ToString
 @Setter
 public class SceneSuite {
-    // make it refer the default empty list to avoid NPE caused by some group 
+    // make it refer the default empty list to avoid NPE caused by some group
 	public List<Integer> monsters = List.of();
 	public List<Integer> gadgets = List.of();
 	public List<String> triggers = List.of();
@@ -22,7 +22,7 @@ public class SceneSuite {
     public transient List<SceneRegion> sceneRegions = List.of();
 
     public void init(SceneGroup sceneGroup) {
-        if(sceneGroup.monsters != null){
+        if(sceneGroup.monsters != null && this.monsters != null){
             this.sceneMonsters = new ArrayList<>(
                 this.monsters.stream()
                     .filter(sceneGroup.monsters::containsKey)
@@ -31,7 +31,7 @@ public class SceneSuite {
             );
         }
 
-        if(sceneGroup.gadgets != null){
+        if(sceneGroup.gadgets != null && this.gadgets != null){
             this.sceneGadgets = new ArrayList<>(
                 this.gadgets.stream()
                     .filter(sceneGroup.gadgets::containsKey)
@@ -40,7 +40,7 @@ public class SceneSuite {
             );
         }
 
-        if(sceneGroup.triggers != null) {
+        if(sceneGroup.triggers != null && this.triggers != null) {
             this.sceneTriggers = new ArrayList<>(
                 this.triggers.stream()
                     .filter(sceneGroup.triggers::containsKey)
@@ -48,7 +48,7 @@ public class SceneSuite {
                     .toList()
             );
         }
-        if(sceneGroup.regions != null) {
+        if(sceneGroup.regions != null && this.regions != null) {
             this.sceneRegions = new ArrayList<>(
                 this.regions.stream()
                     .filter(sceneGroup.regions::containsKey)

--- a/src/main/java/emu/grasscutter/scripts/data/SceneSuite.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneSuite.java
@@ -15,6 +15,7 @@ public class SceneSuite {
 	public List<String> triggers = List.of();
     public List<Integer> regions = List.of();
     public int rand_weight;
+    public int[] npcs;
 
 	public transient List<SceneMonster> sceneMonsters = List.of();
 	public transient List<SceneGadget> sceneGadgets = List.of();

--- a/src/main/java/emu/grasscutter/scripts/data/SceneTrigger.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneTrigger.java
@@ -10,6 +10,9 @@ public class SceneTrigger {
 	public String source;
 	public String condition;
 	public String action;
+    public boolean forbid_guest;
+    public int trigger_count;
+    public String tlog_tag;
 
 	public transient SceneGroup currentGroup;
 	@Override
@@ -34,6 +37,8 @@ public class SceneTrigger {
 				", source='" + source + '\'' +
 				", condition='" + condition + '\'' +
 				", action='" + action + '\'' +
+				", forbid_guest='" + forbid_guest + '\'' +
+				", trigger_count='" + trigger_count + '\'' +
 				'}';
 	}
 }

--- a/src/main/java/emu/grasscutter/scripts/data/SceneVar.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneVar.java
@@ -9,4 +9,5 @@ public class SceneVar {
 	public String name;
 	public int value;
 	public boolean no_refresh;
+    public int configId;
 }

--- a/src/main/java/emu/grasscutter/scripts/serializer/LuaTableJacksonSerializer.java
+++ b/src/main/java/emu/grasscutter/scripts/serializer/LuaTableJacksonSerializer.java
@@ -22,12 +22,12 @@ public class LuaTableJacksonSerializer extends JsonSerializer<LuaTable> implemen
     public LuaTableJacksonSerializer() {
         if (objectMapper == null) {
             objectMapper = new ObjectMapper();
-            objectMapper.configure(MapperFeature.PROPAGATE_TRANSIENT_MARKER,true);
+            objectMapper.configure(MapperFeature.PROPAGATE_TRANSIENT_MARKER, true);
             // Some properties in Lua table but not in java field
-            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,false);
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             objectMapper.configOverride(List.class).setSetterInfo(JsonSetter.Value.forContentNulls(Nulls.AS_EMPTY));
             SimpleModule luaSerializeModule = new SimpleModule();
-            luaSerializeModule.addSerializer(LuaTable.class,this);
+            luaSerializeModule.addSerializer(LuaTable.class, this);
             objectMapper.registerModule(luaSerializeModule);
         }
     }
@@ -38,6 +38,7 @@ public class LuaTableJacksonSerializer extends JsonSerializer<LuaTable> implemen
             gen.writeNull();
             return;
         }
+
         // Detect table type
         boolean isArray = false;
         LuaValue[] keys = value.keys();
@@ -45,62 +46,66 @@ public class LuaTableJacksonSerializer extends JsonSerializer<LuaTable> implemen
             gen.writeNull();
             return;
         }
+
         int count = 0;
         for (int i = 0; i < keys.length; i++) {
             if (!keys[i].isint() || (i + 1) != keys[i].toint()) {
                 break;
-            }else {
-                 count ++;
+            } else {
+                count++;
             }
         }
+
         if (count == keys.length) {
             isArray = true;
         }
+
         if (isArray) {
             gen.writeStartArray();
             for (LuaValue key : keys) {
                 LuaValue luaValue = value.get(key);
                 if (luaValue.isnil()) {
                     gen.writeNull();
-                }else if (luaValue.isboolean()) {
+                } else if (luaValue.isboolean()) {
                     gen.writeBoolean(luaValue.toboolean());
-                }else if (luaValue.isint()) {
+                } else if (luaValue.isint()) {
                     gen.writeNumber(luaValue.toint());
-                }else if (luaValue.islong()) {
+                } else if (luaValue.islong()) {
                     gen.writeNumber(luaValue.tolong());
-                }else if (luaValue.isnumber()) {
+                } else if (luaValue.isnumber()) {
                     gen.writeNumber(luaValue.tofloat());
-                }else if (luaValue.isstring()) {
+                } else if (luaValue.isstring()) {
                     gen.writeString(luaValue.tojstring());
-                }else if (luaValue.istable()) {
-                    serialize(luaValue.checktable(),gen,serializers);
+                } else if (luaValue.istable()) {
+                    serialize(luaValue.checktable(), gen, serializers);
                 }
             }
             gen.writeEndArray();
-        }else {
+        } else {
             gen.writeStartObject();
             for (LuaValue key : keys) {
                 String keyStr = key.toString();
                 LuaValue luaValue = value.get(key);
                 if (luaValue.isnil()) {
                     gen.writeNullField(keyStr);
-                }else if (luaValue.isboolean()) {
-                    gen.writeBooleanField(keyStr,luaValue.toboolean());
-                }else if (luaValue.isint()) {
-                    gen.writeNumberField(keyStr,luaValue.toint());
-                }else if (luaValue.islong()) {
-                    gen.writeNumberField(keyStr,luaValue.tolong());
-                }else if (luaValue.isnumber()) {
+                } else if (luaValue.isboolean()) {
+                    gen.writeBooleanField(keyStr, luaValue.toboolean());
+                } else if (luaValue.isint()) {
+                    gen.writeNumberField(keyStr, luaValue.toint());
+                } else if (luaValue.islong()) {
+                    gen.writeNumberField(keyStr, luaValue.tolong());
+                } else if (luaValue.isnumber()) {
                     gen.writeNumberField(keyStr, luaValue.tofloat());
-                }else if (luaValue.isstring()) {
-                    gen.writeStringField(keyStr,luaValue.tojstring());
-                }else if (luaValue.istable()) {
+                } else if (luaValue.isstring()) {
+                    gen.writeStringField(keyStr, luaValue.tojstring());
+                } else if (luaValue.istable()) {
                     gen.writeFieldName(keyStr);
-                    serialize(luaValue.checktable(),gen,serializers);
+                    serialize(luaValue.checktable(), gen, serializers);
                 }
             }
             gen.writeEndObject();
         }
+
         gen.flush();
         gen.close();
     }
@@ -114,7 +119,7 @@ public class LuaTableJacksonSerializer extends JsonSerializer<LuaTable> implemen
 
         CollectionType collectionType = objectMapper.getTypeFactory().constructCollectionType(ArrayList.class, type);
         JsonNode jsonNode = objectMapper.valueToTree(luaTable);
-        Grasscutter.getLogger().trace("[LuaTableToList] className={},data={}",type.getCanonicalName(),jsonNode.toString());
+        Grasscutter.getLogger().trace("[LuaTableToList] className={},data={}", type.getCanonicalName(), jsonNode.toString());
         if (jsonNode.isEmpty()) {
             return list;
         }
@@ -127,14 +132,14 @@ public class LuaTableJacksonSerializer extends JsonSerializer<LuaTable> implemen
             } catch (JsonProcessingException e) {
                 e.printStackTrace();
             }
-        }else if (jsonNode.isObject()) {
+        } else if (jsonNode.isObject()) {
             Iterator<Map.Entry<String, JsonNode>> fields = jsonNode.fields();
             List<JsonNode> nodes = new ArrayList<>();
             while (fields.hasNext()) {
                 Map.Entry<String, JsonNode> next = fields.next();
                 nodes.add(next.getValue());
             }
-            list = objectMapper.convertValue(nodes,collectionType);
+            list = objectMapper.convertValue(nodes, collectionType);
         }
         return list;
     }
@@ -144,10 +149,11 @@ public class LuaTableJacksonSerializer extends JsonSerializer<LuaTable> implemen
         if (!(obj instanceof LuaTable luaTable) || luaTable.isnil()) {
             return null;
         }
+
         JsonNode jsonNode = objectMapper.valueToTree(luaTable);
-        Grasscutter.getLogger().trace("[LuaTableToObject] className={},data={}",type.getCanonicalName(),jsonNode.toString());
+        Grasscutter.getLogger().trace("[LuaTableToObject] className={},data={}", type.getCanonicalName(), jsonNode.toString());
         try {
-            return objectMapper.treeToValue(jsonNode,type);
+            return objectMapper.treeToValue(jsonNode, type);
         } catch (JsonProcessingException e) {
             e.printStackTrace();
         }
@@ -163,7 +169,7 @@ public class LuaTableJacksonSerializer extends JsonSerializer<LuaTable> implemen
 
         MapType mapStringType = objectMapper.getTypeFactory().constructMapType(HashMap.class, String.class, type);
         JsonNode jsonNode = objectMapper.valueToTree(luaTable);
-        Grasscutter.getLogger().trace("[LuaTableToMap] className={},data={}",type.getCanonicalName(),jsonNode.toString());
+        Grasscutter.getLogger().trace("[LuaTableToMap] className={},data={}", type.getCanonicalName(), jsonNode.toString());
         try {
             Object o = objectMapper.treeToValue(jsonNode, mapStringType);
             if (o != null) {

--- a/src/main/java/emu/grasscutter/scripts/serializer/LuaTableJacksonSerializer.java
+++ b/src/main/java/emu/grasscutter/scripts/serializer/LuaTableJacksonSerializer.java
@@ -1,0 +1,177 @@
+package emu.grasscutter.scripts.serializer;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import com.fasterxml.jackson.databind.type.MapType;
+import emu.grasscutter.Grasscutter;
+import org.luaj.vm2.LuaTable;
+import org.luaj.vm2.LuaValue;
+
+import java.io.IOException;
+import java.util.*;
+
+public class LuaTableJacksonSerializer extends JsonSerializer<LuaTable> implements Serializer {
+
+    private static ObjectMapper objectMapper;
+
+    public LuaTableJacksonSerializer() {
+        if (objectMapper == null) {
+            objectMapper = new ObjectMapper();
+            objectMapper.configure(MapperFeature.PROPAGATE_TRANSIENT_MARKER,true);
+            // Some properties in Lua table but not in java field
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,false);
+            objectMapper.configOverride(List.class).setSetterInfo(JsonSetter.Value.forContentNulls(Nulls.AS_EMPTY));
+            SimpleModule luaSerializeModule = new SimpleModule();
+            luaSerializeModule.addSerializer(LuaTable.class,this);
+            objectMapper.registerModule(luaSerializeModule);
+        }
+    }
+
+    @Override
+    public void serialize(LuaTable value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (value == null || value.isnil()) {
+            gen.writeNull();
+            return;
+        }
+        // Detect table type
+        boolean isArray = false;
+        LuaValue[] keys = value.keys();
+        if (keys.length == 0) {
+            gen.writeNull();
+            return;
+        }
+        int count = 0;
+        for (int i = 0; i < keys.length; i++) {
+            if (!keys[i].isint() || (i + 1) != keys[i].toint()) {
+                break;
+            }else {
+                 count ++;
+            }
+        }
+        if (count == keys.length) {
+            isArray = true;
+        }
+        if (isArray) {
+            gen.writeStartArray();
+            for (LuaValue key : keys) {
+                LuaValue luaValue = value.get(key);
+                if (luaValue.isnil()) {
+                    gen.writeNull();
+                }else if (luaValue.isboolean()) {
+                    gen.writeBoolean(luaValue.toboolean());
+                }else if (luaValue.isint()) {
+                    gen.writeNumber(luaValue.toint());
+                }else if (luaValue.islong()) {
+                    gen.writeNumber(luaValue.tolong());
+                }else if (luaValue.isnumber()) {
+                    gen.writeNumber(luaValue.tofloat());
+                }else if (luaValue.isstring()) {
+                    gen.writeString(luaValue.tojstring());
+                }else if (luaValue.istable()) {
+                    serialize(luaValue.checktable(),gen,serializers);
+                }
+            }
+            gen.writeEndArray();
+        }else {
+            gen.writeStartObject();
+            for (LuaValue key : keys) {
+                String keyStr = key.toString();
+                LuaValue luaValue = value.get(key);
+                if (luaValue.isnil()) {
+                    gen.writeNullField(keyStr);
+                }else if (luaValue.isboolean()) {
+                    gen.writeBooleanField(keyStr,luaValue.toboolean());
+                }else if (luaValue.isint()) {
+                    gen.writeNumberField(keyStr,luaValue.toint());
+                }else if (luaValue.islong()) {
+                    gen.writeNumberField(keyStr,luaValue.tolong());
+                }else if (luaValue.isnumber()) {
+                    gen.writeNumberField(keyStr, luaValue.tofloat());
+                }else if (luaValue.isstring()) {
+                    gen.writeStringField(keyStr,luaValue.tojstring());
+                }else if (luaValue.istable()) {
+                    gen.writeFieldName(keyStr);
+                    serialize(luaValue.checktable(),gen,serializers);
+                }
+            }
+            gen.writeEndObject();
+        }
+        gen.flush();
+        gen.close();
+    }
+
+    @Override
+    public <T> List<T> toList(Class<T> type, Object obj) {
+        List<T> list = new ArrayList<>();
+        if (!(obj instanceof LuaTable luaTable) || luaTable.isnil()) {
+            return list;
+        }
+
+        CollectionType collectionType = objectMapper.getTypeFactory().constructCollectionType(ArrayList.class, type);
+        JsonNode jsonNode = objectMapper.valueToTree(luaTable);
+        Grasscutter.getLogger().trace("[LuaTableToList] className={},data={}",type.getCanonicalName(),jsonNode.toString());
+        if (jsonNode.isEmpty()) {
+            return list;
+        }
+        if (jsonNode.isArray()) {
+            try {
+                Object o = objectMapper.treeToValue(jsonNode, collectionType);
+                if (o != null) {
+                    list = (ArrayList<T>) o;
+                }
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+        }else if (jsonNode.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> fields = jsonNode.fields();
+            List<JsonNode> nodes = new ArrayList<>();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> next = fields.next();
+                nodes.add(next.getValue());
+            }
+            list = objectMapper.convertValue(nodes,collectionType);
+        }
+        return list;
+    }
+
+    @Override
+    public <T> T toObject(Class<T> type, Object obj) {
+        if (!(obj instanceof LuaTable luaTable) || luaTable.isnil()) {
+            return null;
+        }
+        JsonNode jsonNode = objectMapper.valueToTree(luaTable);
+        Grasscutter.getLogger().trace("[LuaTableToObject] className={},data={}",type.getCanonicalName(),jsonNode.toString());
+        try {
+            return objectMapper.treeToValue(jsonNode,type);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @Override
+    public <T> Map<String, T> toMap(Class<T> type, Object obj) {
+        HashMap<String, T> map = new HashMap<>();
+        if (!(obj instanceof LuaTable luaTable) || luaTable.isnil()) {
+            return map;
+        }
+
+        MapType mapStringType = objectMapper.getTypeFactory().constructMapType(HashMap.class, String.class, type);
+        JsonNode jsonNode = objectMapper.valueToTree(luaTable);
+        Grasscutter.getLogger().trace("[LuaTableToMap] className={},data={}",type.getCanonicalName(),jsonNode.toString());
+        try {
+            Object o = objectMapper.treeToValue(jsonNode, mapStringType);
+            if (o != null) {
+                return (HashMap<String, T>) o;
+            }
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        return map;
+    }
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtDoSkillSuccNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtDoSkillSuccNotify.java
@@ -1,5 +1,6 @@
 package emu.grasscutter.server.packet.recv;
 
+import emu.grasscutter.game.quest.enums.QuestTrigger;
 import emu.grasscutter.net.packet.Opcodes;
 import emu.grasscutter.net.packet.PacketHandler;
 import emu.grasscutter.net.packet.PacketOpcodes;
@@ -23,5 +24,6 @@ public class HandlerEvtDoSkillSuccNotify extends PacketHandler {
         // Handle skill notify in other managers.
         player.getStaminaManager().handleEvtDoSkillSuccNotify(session, skillId, casterId);
         player.getEnergyManager().handleEvtDoSkillSuccNotify(session, skillId, casterId);
+        player.getQuestManager().triggerEvent(QuestTrigger.QUEST_CONTENT_SKILL,skillId,0);
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtDoSkillSuccNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtDoSkillSuccNotify.java
@@ -24,6 +24,6 @@ public class HandlerEvtDoSkillSuccNotify extends PacketHandler {
         // Handle skill notify in other managers.
         player.getStaminaManager().handleEvtDoSkillSuccNotify(session, skillId, casterId);
         player.getEnergyManager().handleEvtDoSkillSuccNotify(session, skillId, casterId);
-        player.getQuestManager().triggerEvent(QuestTrigger.QUEST_CONTENT_SKILL,skillId,0);
+        player.getQuestManager().triggerEvent(QuestTrigger.QUEST_CONTENT_SKILL, skillId, 0);
     }
 }


### PR DESCRIPTION
## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.
And, **Do not make a pull request to merge into stable unless it is a hotfix. Use the development branch instead.**
- [ScriptLib] Query player when not get entity from scene
Q351 will use the ScriptLib.GetEntityType as finish condition
The script will put userId and want to get **EntityType.Avatar** as result
And TODO maybe account id length should be limit as the official to 9 to avoid conflict other entity id.
- Fix NPE when doing quests
- Add QUEST_CONTENT_SKILL trigger
Q352 need it.
- Add a lua table serializer implement with jackson
This is not going to replace the default one, but provide an alternative. 
When using the default one, it throws some exceptions, but I can not figure out why
````
> java.lang.RuntimeException: Class cannot be created (missing no-arg constructor): sun.reflect.generics.reflectiveObjects.TypeVariableImpl
	at com.esotericsoftware.reflectasm.ConstructorAccess.get(ConstructorAccess.java:68)
	at emu.grasscutter.scripts.serializer.LuaSerializer.cacheType(LuaSerializer.java:191)
	at emu.grasscutter.scripts.serializer.LuaSerializer.serialize(LuaSerializer.java:139)
	at emu.grasscutter.scripts.serializer.LuaSerializer.serializeList(LuaSerializer.java:97)
	at emu.grasscutter.scripts.serializer.LuaSerializer.serialize(LuaSerializer.java:130)
	at emu.grasscutter.scripts.serializer.LuaSerializer.serialize(LuaSerializer.java:161)
	at emu.grasscutter.scripts.serializer.LuaSerializer.serializeMap(LuaSerializer.java:54)
	at emu.grasscutter.scripts.serializer.LuaSerializer.toMap(LuaSerializer.java:35)
	at emu.grasscutter.game.quest.GameMainQuest.addRewindPoints(GameMainQuest.java:208)
	at emu.grasscutter.game.quest.GameMainQuest.<init>(GameMainQuest.java:79)
	at emu.grasscutter.game.quest.QuestManager.addMainQuest(QuestManager.java:178)
	at emu.grasscutter.game.quest.QuestManager.addQuest(QuestManager.java:197)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at emu.grasscutter.game.quest.QuestManager.startMainQuest(QuestManager.java:226)
	at java.base/java.util.Spliterators$IntArraySpliterator.forEachRemaining(Spliterators.java:1076)
	at java.base/java.util.stream.IntPipeline$Head.forEach(IntPipeline.java:617)
	at emu.grasscutter.game.quest.GameMainQuest.finish(GameMainQuest.java:150)
	at emu.grasscutter.game.quest.GameQuest.finish(GameQuest.java:142)
	at emu.grasscutter.game.quest.GameMainQuest.tryFinishSubQuests(GameMainQuest.java:337)
	at emu.grasscutter.game.quest.QuestManager.triggerEvent(QuestManager.java:276)
	at emu.grasscutter.game.quest.QuestManager.triggerEvent(QuestManager.java:229)
	at emu.grasscutter.server.packet.recv.HandlerAddQuestContentProgressReq.handle(HandlerAddQuestContentProgressReq.java:29)
	at emu.grasscutter.server.game.GameServerPacketHandler.handle(GameServerPacketHandler.java:93)
	at emu.grasscutter.server.game.GameSession.handleReceive(GameSession.java:222)
	at emu.grasscutter.server.game.GameSessionManager$1.lambda$handleReceive$0(GameSessionManager.java:72)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
	at io.netty.channel.DefaultEventLoop.run(DefaultEventLoop.java:54)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.NoSuchMethodException: sun.reflect.generics.reflectiveObjects.TypeVariableImpl.<init>()
	at java.base/java.lang.Class.getConstructor0(Class.java:3585)
	at java.base/java.lang.Class.getDeclaredConstructor(Class.java:2754)
	at com.esotericsoftware.reflectasm.ConstructorAccess.get(ConstructorAccess.java:65)
	... 30 more
````
, so I reimplement one using jackson, it works well.
And the scene script is ugly, difficult to read, make lua table to json and then to Java object can help to log the script data 
- Add some missing fields that contain in scene scripts
This is the jackson serializer above helps me

**Happy Lantern Rite and Spring Festival**
## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.