### PR TITLE
Fix Cooking Compound Retrieval

### DIFF
--- a/src/main/java/emu/grasscutter/data/excels/CompoundData.java
+++ b/src/main/java/emu/grasscutter/data/excels/CompoundData.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class CompoundData extends GameResource {
     @Getter(onMethod = @__(@Override))
     private int id;
-    private int groupId;
+    private int groupID;
     private int rankLevel;
     private boolean isDefaultUnlocked;
     private int costTime;

--- a/src/main/java/emu/grasscutter/game/managers/cooking/CookingCompoundManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/cooking/CookingCompoundManager.java
@@ -38,7 +38,7 @@ public class CookingCompoundManager extends BasePlayerManager {
             if (compound.isDefaultUnlocked()) {
                 defaultUnlockedCompounds.add(id);
             }
-            compoundGroups.computeIfAbsent(compound.getGroupId(), gid -> new HashSet<>()).add(id);
+            compoundGroups.computeIfAbsent(compound.getGroupID(), gid -> new HashSet<>()).add(id);
         });
         //TODO:Because we haven't implemented fishing feature,unlock all compounds related to fish.Besides,it should be bound to player rather than manager.
         unlocked = new HashSet<>(defaultUnlockedCompounds);


### PR DESCRIPTION
## Description

Fixes typo in data field name which resulted in invalid group ids for cooking components, which led to null pointers when trying to retrieve from the menus.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.