### PR TITLE
Fix the game time is reset to 8 o'clock(or manual set time) after teleporting

### DIFF
--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -37,6 +37,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 public class Scene {
+
+    private static final int SECONDS_OF_ONE_DAY = 1440;
+
     @Getter private final World world;
     @Getter private final SceneData sceneData;
     @Getter private final List<Player> players;
@@ -50,6 +53,7 @@ public class Scene {
 
     @Getter @Setter private int autoCloseTime;
     @Getter private int time;
+    private long lastTimeUpdatedTime;
     private long startTime;
 
     @Getter private SceneScriptManager scriptManager;
@@ -65,7 +69,8 @@ public class Scene {
         this.players = new CopyOnWriteArrayList<>();
         this.entities = new ConcurrentHashMap<>();
 
-        this.time = 8 * 60;
+        this.time = new Random().nextInt(24) * 60;
+        this.lastTimeUpdatedTime = System.currentTimeMillis();
         this.startTime = System.currentTimeMillis();
         this.prevScene = 3;
 
@@ -102,7 +107,16 @@ public class Scene {
     }
 
     public void changeTime(int time) {
-        this.time = time % 1440;
+        this.time = time % SECONDS_OF_ONE_DAY;
+        this.lastTimeUpdatedTime = System.currentTimeMillis();
+    }
+
+    public long getSceneElapsedTime() {
+        return System.currentTimeMillis() - this.lastTimeUpdatedTime;
+    }
+
+    public int getTimeForNextScene() {
+        return this.time + (int)((getSceneElapsedTime() / 1000) % SECONDS_OF_ONE_DAY);
     }
 
     public int getSceneTime() {

--- a/src/main/java/emu/grasscutter/game/world/World.java
+++ b/src/main/java/emu/grasscutter/game/world/World.java
@@ -272,6 +272,7 @@ public class World implements Iterable<Player> {
 
         if (oldScene != null) {
             newScene.setPrevScene(oldScene.getId());
+            newScene.changeTime(oldScene.getTimeForNextScene());
             oldScene.setDontDestroyWhenEmpty(false);
         }
 


### PR DESCRIPTION
## Description

Fix the issue that the game time get reset every time after teleporting.
Also set the time randomly when login to the server.

I'm new to the project and don't know why it keeps resetting the time, so I made a simple fix on it.
Please let me know if there are some reasons that the game time has to be reset.
This change currently works fine in my local server, but I didn't test it for multi-player.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.