### PR TITLE
Fix BattlePass Null Pointer

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -1164,13 +1164,12 @@ public class Player {
         // Load from db
         this.getAvatars().loadFromDatabase();
         this.getInventory().loadFromDatabase();
+        this.loadBattlePassManager(); // Call before avatar postLoad to avoid null pointer
         this.getAvatars().postLoad(); // Needs to be called after inventory is handled
 
         this.getFriendsList().loadFromDatabase();
         this.getMailHandler().loadFromDatabase();
         this.getQuestManager().loadFromDatabase();
-
-        this.loadBattlePassManager();
     }
 
     public void onLogin() {


### PR DESCRIPTION
## Description

Fixes the load order of database fields to prevent battlepass null pointer when loading default avatar weapons.

## Issues fixed by this PR

Fixes #1871 
Fixes #1931 

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.