### PR TITLE
Fix boss name display.

### DIFF
--- a/src/main/java/emu/grasscutter/game/entity/EntityMonster.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityMonster.java
@@ -238,8 +238,10 @@ public class EntityMonster extends GameEntity {
             .setPoseId(this.getPoseId())
             .setBlockId(getScene().getId())
             .setBornType(MonsterBornType.MONSTER_BORN_TYPE_DEFAULT);
-
-        if (getMonsterData().getDescribeData() != null) {
+        if (metaMonster.special_name_id != 0) {
+            monsterInfo.setTitleId(metaMonster.title_id)
+                .setSpecialNameId(metaMonster.special_name_id);
+        } else if (getMonsterData().getDescribeData() != null) {
             monsterInfo.setTitleId(getMonsterData().getDescribeData().getTitleId())
                 .setSpecialNameId(getMonsterData().getSpecialNameId());
 


### PR DESCRIPTION
## Description
Fix th issue the boss may not display their names sometimes. For example, in quest fighting Dvalin. `Monster_Dragon_Dvalin_S00 - [EN] - Stormterror`

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
