### PR TITLE
Parse dungeon entry info req from payload instead of player scene

### DIFF
--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonSystem.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonSystem.java
@@ -26,8 +26,8 @@ public class DungeonSystem extends BaseGameSystem {
         super(server);
     }
 
-    public void getEntryInfo(Player player, int pointId) {
-        ScenePointEntry entry = GameData.getScenePointEntryById(player.getScene().getId(), pointId);
+    public void getEntryInfo(Player player, int pointId, int sceneId) {
+        ScenePointEntry entry = GameData.getScenePointEntryById(sceneId, pointId);
 
         if (entry == null) {
             // Error

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerDungeonEntryInfoReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerDungeonEntryInfoReq.java
@@ -13,7 +13,7 @@ public class HandlerDungeonEntryInfoReq extends PacketHandler {
     public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
         DungeonEntryInfoReq req = DungeonEntryInfoReq.parseFrom(payload);
 
-        session.getServer().getDungeonSystem().getEntryInfo(session.getPlayer(), req.getPointId());
+        session.getServer().getDungeonSystem().getEntryInfo(session.getPlayer(), req.getPointId(), req.getSceneId());
     }
 
 }


### PR DESCRIPTION
## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
