### PR TITLE
Remove garbages from Scene.java

### DIFF
--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -963,7 +963,7 @@ public final class Scene {
                 groupInstance = cachedInstance;
             }
 
-            // Load garbages
+            /* Don't load garbages
             var garbageGadgets = group.getGarbageGadgets();
 
             if (garbageGadgets != null) {
@@ -973,7 +973,7 @@ public final class Scene {
                                 .filter(Objects::nonNull)
                                 .toList());
             }
-
+            */
             // Load suites
             // int suite = group.findInitSuiteIndex(0);
             this.getScriptManager()


### PR DESCRIPTION
## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.

## Issues fixed by this PR

In the world, some plant collectables are doubled. I tracked them down to the server loading "garbages" gadgets from resources (marked 废弃数据 (Obsolete data)). I believe this is an error with the server code and garbages should not be loaded.

Without fix:
![image](https://user-images.githubusercontent.com/1877986/234110620-9a49c70b-df48-46e7-8cc0-3deca4ea6708.png)


With fix:
![image](https://user-images.githubusercontent.com/1877986/234109696-d71046ec-fd0a-4d7f-9e3e-04990b1d857e.png)


<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
