### PR TITLE
fix /give avatars - currentTalentLevel cannot be negative

### DIFF
--- a/src/main/java/emu/grasscutter/game/avatar/Avatar.java
+++ b/src/main/java/emu/grasscutter/game/avatar/Avatar.java
@@ -895,6 +895,7 @@ public class Avatar {
 
     public boolean unlockConstellation(boolean skipPayment) {
         int currentTalentLevel = this.getCoreProudSkillLevel();
+        if (currentTalentLevel < 0) return false;
         int talentId = this.skillDepot.getTalents().get(currentTalentLevel);
         return this.unlockConstellation(talentId, skipPayment);
     }


### PR DESCRIPTION
## Description

Default travelers have no talent. They have a talent level of 0, which causes the return value of getCoreProudSkillLevel() in src\main\java\emu\grasscutter\game\avatar\Avatar.java to be -1 for no element travelers.
This is usually not a problem, but when using /give avatars, -1 is used as an index in unlockConstellation(boolean)

I had a feirce internal debate on where to put the fix, but I decided to leave getCoreProudSkillLevel as it was because the description of it as "One below the lowest locked talent, or 6 if there are no locked talents." Isn't nessisarilly bad. if you have 1 talent unlocked, it'd be 0. If you have no unlocked talents, it's -1.

I put the fix in unlockConstellation(boolean) and made it return early.


## Issues fixed by this PR

When trying to use /give avatars:
![image](https://user-images.githubusercontent.com/1877986/234263170-a11c152e-cc9b-41e1-8bb1-d1a7da74762f.png)

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
