### PR TITLE
fix dragon fight

### DIFF
--- a/src/main/java/emu/grasscutter/game/world/World.java
+++ b/src/main/java/emu/grasscutter/game/world/World.java
@@ -216,7 +216,7 @@ public class World implements Iterable<Player> {
         this.getScenes().put(scene.getId(), scene);
     }
 
-    public void deregisterScene(Scene scene) {
+    public synchronized void deregisterScene(Scene scene) {
         scene.saveGroups();
         this.getScenes().remove(scene.getId());
     }


### PR DESCRIPTION
## Description

Scene was being updated while it was being deleted. Slapped a synchronized on deregisterScene so that it doesn't run at the same time as Scene.java's checkGroups()

## Issues fixed by this PR
https://cdn.discordapp.com/attachments/1091570006464135273/1100238630011801600/buggeddvalin.mp4
After flying down to the plaza, the dragon fight cutscene would play, but then it would leave you in the overworld where you would eventually disconnect. What was happening is that the main thread was being threadlocked due to Scene.java's checkGroups running at the same time as World.java's deregisterScene

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
