### PR TITLE
Remove cause of threadlock on first dragon fight

### DIFF
--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -795,7 +795,7 @@ public final class Scene {
         return true;
     }
 
-    public synchronized void checkGroups() {
+    public void checkGroups() {
         Set<Integer> visible =
                 this.players.stream()
                         .map(player -> this.getPlayerActiveGroups(player))


### PR DESCRIPTION
## Description
There's a threadlock that can happen when entering a dungeon if the scene is being checked at the same time as it is being removed. This happens to me ~1/6 of the time.

checkGroups(scene) is synchronized, removePlayer(scene) is synchonized, but also the data structure storing groups is a synchronized data structure. Between the three of them, they do a threadlock

I think the synchronized on checkGroups makes the most sense to remove since it won't matter what groups are visible or not when we remove them.

I take full responsibility for whatever future (minorer) bugs removing synchronized on checkGroups will cause.

## Issues fixed by this PR
![image](https://user-images.githubusercontent.com/1877986/235418069-8b4dc880-2ca8-43bb-8eed-214926fa7372.png)

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
