### PR TITLE
Fix typo in last commit

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/PlayerProgress.java
+++ b/src/main/java/emu/grasscutter/game/player/PlayerProgress.java
@@ -6,7 +6,6 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.util.Map;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -21,7 +20,7 @@ public class PlayerProgress {
      * A list of dungeon IDs which have been completed.
      * This only applies to one-time dungeons.
      */
-    @Getter private IntList completedDungeons;
+    @Getter private IntArrayList completedDungeons;
 
     // keep track of EXEC_ADD_QUEST_PROGRESS count, will be used in CONTENT_ADD_QUEST_PROGRESS
     // not sure where to put this, this should be saved to DB but not to individual quest, since


### PR DESCRIPTION
## Description
Couldn't relog after the last commit 916db0f408e01b853a0b23199dd8bca2a3ef0b4f. Found that in PlayerProgress.java that IntList and IntArrayList were being used on the same variable. Type mismatch!
Changing IntList to IntArrayList on line 24 fixes the relog issue.

## Issues fixed by this PR
![image](https://user-images.githubusercontent.com/1877986/235427587-d0e19a7a-99dc-40ac-aab1-5bf3dc4619ab.png)

(text version of this can be found on the discord)
916db0f408e01b853a0b23199dd8bca2a3ef0b4f
<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
