### PR TITLE
Partially fix fairy clock

### DIFF
--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerSkipPlayerGameTimeReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerSkipPlayerGameTimeReq.java
@@ -16,7 +16,7 @@ public class HandlerSkipPlayerGameTimeReq extends PacketHandler {
         var req = SkipPlayerGameTimeReq.parseFrom(payload);
         var player = session.getPlayer();
 
-        var newTime = req.getGameTime() * 1000L;
+        var newTime = req.getGameTime() * 1000L + player.getPlayerGameTime() - (player.getPlayerGameTime() % 1440000);
         player.updatePlayerGameTime(newTime);
         player.getScene().broadcastPacket(new PacketPlayerGameTimeNotify(player));
         player.sendPacket(new PacketSkipPlayerGameTimeRsp(req));


### PR DESCRIPTION
## Description
updatePlayerGameTime() expects time since game start not since day start.

There's a second bug where the clock does not stop ticking if you cross midnight, but this PR does not cause or fix that bug.

## Issues fixed by this PR

This every time you use the clock without crossing midnight until you relog:
![image](https://user-images.githubusercontent.com/1877986/236416564-336fc7d7-f15c-4795-ad87-40eae17417a9.png)


<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
