### PR TITLE
Fix being unable to attack

### DIFF
--- a/src/main/java/emu/grasscutter/data/ResourceLoader.java
+++ b/src/main/java/emu/grasscutter/data/ResourceLoader.java
@@ -137,9 +137,6 @@ public final class ResourceLoader {
         var textMaps = ResourceLoader.runAsync(Language::loadTextMaps);
         // Load 'BinOutput'.
         var binOutput = ResourceLoader.loadConfigData();
-        // Load 'ExcelBinOutput'.
-        var errors = new ConcurrentLinkedQueue<Pair<String, Exception>>();
-        var excelBinOutput = ResourceLoader.loadResources(true, errors);
         // Load ability lists.
         var abilities =
                 ResourceLoader.runAsync(
@@ -148,6 +145,9 @@ public final class ResourceLoader {
                             ResourceLoader.loadOpenConfig();
                             ResourceLoader.loadAbilityModifiers();
                         });
+        // Load 'ExcelBinOutput'.
+        var errors = new ConcurrentLinkedQueue<Pair<String, Exception>>();
+        var excelBinOutput = ResourceLoader.loadResources(true, errors);
         // Load spawn data and quests.
         var scene =
                 ResourceLoader.runAsync(


### PR DESCRIPTION
## Description

Despite resources beling loaded asynchronously, loading order for ExcelBinOutput seems to still matter.
When it is loaded before abilities, the player can't use attacks. Loading it after abilities like it was before resource async code was in place fixes the issue.

## Issues fixed by this PR

The player coundn't use attacks. No sword comes out and using abilites freezes the model of the player.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
