### PR TITLE
Partially fix Chasing Shadows

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/PlayerProgress.java
+++ b/src/main/java/emu/grasscutter/game/player/PlayerProgress.java
@@ -78,6 +78,10 @@ public class PlayerProgress {
         return questProgressCountMap.merge(progressId, count, Integer::sum);
     }
 
+    public int resetCurrentProgress(int progressId) {
+        return questProgressCountMap.merge(progressId,0,Integer::min);
+    }
+
     @Entity
     @NoArgsConstructor
     public static class ItemEntry {

--- a/src/main/java/emu/grasscutter/game/quest/GameQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameQuest.java
@@ -173,13 +173,13 @@ public class GameQuest {
         finishTime = 0;
         acceptTime = 0;
         startTime = 0;
+        this.getOwner().getPlayerProgress().resetCurrentProgress(this.subQuestId);
         if (oldState == QuestState.QUEST_STATE_UNSTARTED) {
             return false;
         }
         if (notifyDelete) {
             getOwner().sendPacket(new PacketDelQuestNotify(getSubQuestId()));
         }
-        this.getOwner().getPlayerProgress().resetCurrentProgress(this.subQuestId);
         save();
         return true;
     }

--- a/src/main/java/emu/grasscutter/game/quest/GameQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameQuest.java
@@ -179,6 +179,7 @@ public class GameQuest {
         if (notifyDelete) {
             getOwner().sendPacket(new PacketDelQuestNotify(getSubQuestId()));
         }
+        this.getOwner().getPlayerProgress().resetCurrentProgress(this.subQuestId);
         save();
         return true;
     }

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentFinishPlot.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentFinishPlot.java
@@ -16,7 +16,7 @@ public class ContentFinishPlot extends BaseContent {
         MainQuestData.TalkData talkData =
                 quest.getMainQuest().getTalks().get(Integer.valueOf(params[0]));
         GameQuest subQuest = quest.getMainQuest().getChildQuestById(params[0]);
-        return talkData != null && subQuest != null
-                || condition.getParamStr().equals(paramStr) && condition.getParam()[0] == params[0];
+        return (talkData != null && subQuest != null
+                || condition.getParamStr().equals(paramStr)) && condition.getParam()[0] == params[0];
     }
 }


### PR DESCRIPTION
## Description
When you talked to one of the guards, most of the quest line would be marked finished. This was due to a bug in how QUEST_CONTENT_FINISH_PLOT was handled.

In a separate bug, 2010140 was being finished early because quest progress was not being cleared during rewind in clearProgress().


## Issues fixed by this PR
Chasing Shadows works a little bit better in the sense that a car crash is better than a train crash.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
