### PR TITLE
Triggers should only trigger triggers they were triggered for.

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/content/ContentClearGroupMonster.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentClearGroupMonster.java
@@ -14,7 +14,7 @@ public class ContentClearGroupMonster extends BaseContent {
     public boolean execute(
             GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
         val groupId = condition.getParam()[0];
-
+        if (groupId != params[0]) return false;
         return quest.getOwner().getScene().getScriptManager().isClearedGroupMonsters(groupId);
     }
 }

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentEnterMyWorld.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentEnterMyWorld.java
@@ -12,6 +12,8 @@ public class ContentEnterMyWorld extends BaseContent {
     @Override
     public boolean execute(
             GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
+        var sceneId = condition.getParam()[0];
+        if (sceneId != params[0]) return false;
         return quest.getOwner().getSceneId() == params[0];
     }
 }

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentFinishDungeon.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentFinishDungeon.java
@@ -14,6 +14,7 @@ public class ContentFinishDungeon extends BaseContent {
     public boolean execute(
             GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
         var dungeonId = condition.getParam()[0];
+        if (dungeonId != params[0]) return false;
         return quest.getOwner().getPlayerProgress().getCompletedDungeons().contains(dungeonId);
     }
 }

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentLeaveScene.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentLeaveScene.java
@@ -12,6 +12,6 @@ public class ContentLeaveScene extends BaseContent {
     @Override
     public boolean execute(
             GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
-        return quest.getOwner().getScene().getPrevScene() == params[0];
+        return condition.getParam()[0] == params[0] && quest.getOwner().getScene().getPrevScene() == params[0];
     }
 }

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentNotFinishPlot.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentNotFinishPlot.java
@@ -19,6 +19,7 @@ public class ContentNotFinishPlot extends BaseContent {
             return true;
         }
         val talkData = checkMainQuest.getTalks().get(talkId);
+        if (talkId != params[0]) return false;
         return talkData == null;
     }
 }

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentQuestStateEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentQuestStateEqual.java
@@ -12,7 +12,9 @@ public class ContentQuestStateEqual extends BaseContent {
     @Override
     public boolean execute(
             GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
-        GameQuest checkQuest = quest.getOwner().getQuestManager().getQuestById(condition.getParam()[0]);
+        var questId = condition.getParam()[0];
+        if(questId != params[0]) return false;
+        GameQuest checkQuest = quest.getOwner().getQuestManager().getQuestById(questId);
         if (checkQuest == null) {
             return false;
         }

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentQuestStateNotEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentQuestStateNotEqual.java
@@ -12,7 +12,9 @@ public class ContentQuestStateNotEqual extends BaseContent {
     @Override
     public boolean execute(
             GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
-        GameQuest checkQuest = quest.getOwner().getQuestManager().getQuestById(params[0]);
+        var questId = condition.getParam()[0];
+        if(questId != params[0]) return false;
+        GameQuest checkQuest = quest.getOwner().getQuestManager().getQuestById(questId);
 
         if (checkQuest != null) {
             return checkQuest.getState().getValue() != params[1];

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentTimeVarMoreOrEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentTimeVarMoreOrEqual.java
@@ -13,6 +13,7 @@ public class ContentTimeVarMoreOrEqual extends BaseContent {
             GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
         val mainQuestId = condition.getParam()[0];
         val timeVarIndex = condition.getParam()[1];
+        if(mainQuestId != params[0]) return false;
         val minTime = Integer.parseInt(condition.getParamStr());
 
         val mainQuest = quest.getOwner().getQuestManager().getMainQuestById(mainQuestId);

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentTimeVarPassDay.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentTimeVarPassDay.java
@@ -13,6 +13,7 @@ public class ContentTimeVarPassDay extends BaseContent {
             GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
         val mainQuestId = condition.getParam()[0];
         val timeVarIndex = condition.getParam()[1];
+        if(mainQuestId != params[0]) return false;
         val minDays = Integer.parseInt(condition.getParamStr());
 
         val mainQuest = quest.getOwner().getQuestManager().getMainQuestById(mainQuestId);

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentTriggerFire.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentTriggerFire.java
@@ -12,6 +12,7 @@ public class ContentTriggerFire extends BaseContent {
     @Override
     public boolean execute(
             GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
+        if(condition.getParam()[0] != params[0]) return false;
         if (quest.getTriggers().containsKey(quest.getTriggerNameById(params[0]))) {
             // We don't want to put a new key here
             return quest.getTriggers().get(quest.getTriggerNameById(params[0]));

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentUnlockTransPoint.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentUnlockTransPoint.java
@@ -12,6 +12,7 @@ public class ContentUnlockTransPoint extends BaseContent {
     public boolean execute(
             GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
         var sceneId = condition.getParam()[0];
+        if(sceneId != params[0]) return false;
         var scenePointId = condition.getParam()[1];
         var scenePoints = quest.getOwner().getUnlockedScenePoints().get(sceneId);
         return scenePoints != null && scenePoints.contains(scenePointId);


### PR DESCRIPTION
## Description
The stuff that caused a trigger should always be looked at when deciding if another quest content should also trigger.
otherwise, quests could trigger again for an unrelated, but same category of trigger.
For example, all quests were checked if they are in their trigger region any time the player enters any region even if it's an unrelated region. This could cause a unrelated event to fire twice.


## Issues fixed by this PR

Unfortunately, I couldn't find any specific bug this fixed. Technically it would have fixed the "Quest {} doesn't have trigger {} registered." spam?

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
