### PR TITLE
Remove manual autofinish for main quests.

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -182,9 +182,9 @@ public class GameMainQuest {
          * of the main quest 353 - the character will not be able to leave place
          * (return again and again)
          */
-        this.getChildQuests().values().stream()
-                .filter(p -> p.state != QuestState.QUEST_STATE_FINISHED)
-                .forEach(GameQuest::finish);
+        // this.getChildQuests().values().stream()
+        //         .filter(p -> p.state != QuestState.QUEST_STATE_FINISHED)
+        //         .forEach(GameQuest::finish);
 
         this.getOwner().getSession().send(new PacketFinishedParentQuestUpdateNotify(this));
         this.getOwner().getSession().send(new PacketCodexDataUpdateNotify(this));


### PR DESCRIPTION
## Description
Autofinish breaks quests that have rollback code. Commenting out this code does not seem to cause any bugs (including the ones described in the block text).
Commenting this out fixed two quest bugs at least.

## Issues fixed by this PR
Bunny girl's story quest when you are gliding in the city is fixed. 
Makes it so that finishing wild escape starts behind the scenes.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
