### PR TITLE
Don't over-define variables in extended classes

### DIFF
--- a/src/main/java/emu/grasscutter/scripts/data/SceneGadget.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneGadget.java
@@ -6,9 +6,7 @@ import lombok.ToString;
 @ToString
 @Setter
 public class SceneGadget extends SceneObject {
-    public int config_id;
     public int gadget_id;
-    public int level;
     public int chest_drop_id;
     public int drop_count;
     public String drop_tag;
@@ -28,7 +26,6 @@ public class SceneGadget extends SceneObject {
      */
     public boolean isOneoff;
 
-    public int area_id;
     public int draft_id;
     public int route_id;
     public boolean start_route = true;

--- a/src/main/java/emu/grasscutter/scripts/data/SceneMonster.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneMonster.java
@@ -6,10 +6,8 @@ import lombok.ToString;
 @ToString
 @Setter
 public class SceneMonster extends SceneObject {
-    public int config_id;
     public int monster_id;
     public int pose_id;
-    public int level;
     public int drop_id;
     public boolean disableWander;
     public int title_id;


### PR DESCRIPTION
## Description
Some variables in SceneGadget and SceneMonster were redefined when they should have just been left to inherit from SceneObject.

This was causing o.confing_id here in ScriptLib.java to always be 0:
![image](https://github.com/Grasscutters/Grasscutter/assets/1877986/5d78f5da-446b-47a3-b9e2-50f8d1a93407)


Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.

## Issues fixed by this PR
At the end of bombing run during "outrider style" (in bunny girl's story quest), you get killed because the avatar has config_id 0.

This also solves all the random death spots in the world. (death rock, death tree)

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
