### PR TITLE
instantiate personalLineList

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -249,6 +249,7 @@ public class Player implements PlayerHook {
         this.nameCardList = new HashSet<>();
         this.flyCloakList = new HashSet<>();
         this.costumeList = new HashSet<>();
+        this.personalLineList = new HashSet<>();
         this.towerData = new TowerData();
         this.collectionRecordStore = new PlayerCollectionRecords();
         this.unlockedForgingBlueprints = new HashSet<>();


### PR DESCRIPTION
## Description
Instantiate personalLineList so that ConditionPersonalLineUnlock can return false so that it can be triggered when checking the accept conditions for quest 48601 (thanks, Jean) when 39604 completes (end of prolog act 3). Chapter 1 act 1 (100000) is checked after 48601 is checked when 39604 completes, so this whole thing failing made it not get checked.

## Issues fixed by this PR
Chapter 1 act 1 now triggers when finishing prolog act 3. 

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
