### PR TITLE
Fix issues with regions

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -709,7 +709,8 @@ public class Player implements PlayerHook, FieldFetch {
     public void onEnterRegion(SceneRegion region) {
         this.getQuestManager().forEachActiveQuest(quest -> {
             if (quest.getTriggerData() != null &&
-                quest.getTriggers().containsKey("ENTER_REGION_"+ region.config_id)) {
+                quest.getTriggers().containsKey("ENTER_REGION_"+ region.config_id) &&
+                    region.getGroupId() == quest.getTriggerData().get("ENTER_REGION_" + region.config_id).getGroupId()) {
                 // If trigger hasn't been fired yet
                 if (!Boolean.TRUE.equals(quest.getTriggers().put("ENTER_REGION_" + region.config_id, true))) {
                     this.getSession().send(new PacketServerCondMeetQuestListUpdateNotify());
@@ -723,7 +724,8 @@ public class Player implements PlayerHook, FieldFetch {
 
     public void onLeaveRegion(SceneRegion region) {
         this.getQuestManager().forEachActiveQuest(quest -> {
-            if (quest.getTriggers().containsKey("LEAVE_REGION_" + region.config_id)) {
+            if (quest.getTriggers().containsKey("LEAVE_REGION_" + region.config_id) &&
+                region.getGroupId() == quest.getTriggerData().get("ENTER_REGION_" + region.config_id).getGroupId()) {
                 // If trigger hasn't been fired yet
                 if (!Boolean.TRUE.equals(quest.getTriggers().put("LEAVE_REGION_" + region.config_id, true))) {
                     this.getSession().send(new PacketServerCondMeetQuestListUpdateNotify());


### PR DESCRIPTION
## Description
Ice guy being missing in front of his dungeon has plagued us for many moons. 
Today, we finally have a solution.

In TriggerExcelConfigData, some region numbers are repeated. This causes the game to get confused about which region it is entering. We now differentiate them based on group ID as well.

Luckily, SceneRegion and TriggerExcelConfigData both have group numbers, so we can use those to differentiate regions!

## Issues fixed by this PR
Ice guy shows up!!! No need to relog for the entirety of act 1.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
