### PR TITLE
Fix a typo I left in Player.java

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -707,15 +707,16 @@ public class Player implements PlayerHook, FieldFetch {
     }
 
     public void onEnterRegion(SceneRegion region) {
+        var enterRegionName = "ENTER_REGION_" + region.config_id;
         this.getQuestManager().forEachActiveQuest(quest -> {
             if (quest.getTriggerData() != null &&
-                quest.getTriggers().containsKey("ENTER_REGION_"+ region.config_id) &&
-                    region.getGroupId() == quest.getTriggerData().get("ENTER_REGION_" + region.config_id).getGroupId()) {
+                quest.getTriggers().containsKey(enterRegionName) &&
+                    region.getGroupId() == quest.getTriggerData().get(enterRegionName).getGroupId()) {
                 // If trigger hasn't been fired yet
-                if (!Boolean.TRUE.equals(quest.getTriggers().put("ENTER_REGION_" + region.config_id, true))) {
+                if (!Boolean.TRUE.equals(quest.getTriggers().put(enterRegionName, true))) {
                     this.getSession().send(new PacketServerCondMeetQuestListUpdateNotify());
                     this.getQuestManager().queueEvent(QuestContent.QUEST_CONTENT_TRIGGER_FIRE,
-                        quest.getTriggerData().get("ENTER_REGION_" + region.config_id).getId(), 0);
+                        quest.getTriggerData().get(enterRegionName).getId(), 0);
                 }
             }
         });
@@ -723,14 +724,15 @@ public class Player implements PlayerHook, FieldFetch {
     }
 
     public void onLeaveRegion(SceneRegion region) {
+        var leaveRegionName = "LEAVE_REGION_" + region.config_id;
         this.getQuestManager().forEachActiveQuest(quest -> {
-            if (quest.getTriggers().containsKey("LEAVE_REGION_" + region.config_id) &&
-                region.getGroupId() == quest.getTriggerData().get("ENTER_REGION_" + region.config_id).getGroupId()) {
+            if (quest.getTriggers().containsKey(leaveRegionName) &&
+                region.getGroupId() == quest.getTriggerData().get(leaveRegionName).getGroupId()) {
                 // If trigger hasn't been fired yet
-                if (!Boolean.TRUE.equals(quest.getTriggers().put("LEAVE_REGION_" + region.config_id, true))) {
+                if (!Boolean.TRUE.equals(quest.getTriggers().put(leaveRegionName, true))) {
                     this.getSession().send(new PacketServerCondMeetQuestListUpdateNotify());
                     this.getQuestManager().queueEvent(QuestContent.QUEST_CONTENT_TRIGGER_FIRE,
-                        quest.getTriggerData().get("LEAVE_REGION_" + region.config_id).getId(), 0);
+                        quest.getTriggerData().get(leaveRegionName).getId(), 0);
                 }
             }
         });


### PR DESCRIPTION
ENTER_REGION_ -> LEAVE_REGION_
Went ahead and did some optimizing so we only have to calculate that string once.

Thanks to Hartie for pointing out the mistake.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
