### PR TITLE
Fix battle in front of glowy stag god

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/PlayerProgress.java
+++ b/src/main/java/emu/grasscutter/game/player/PlayerProgress.java
@@ -4,10 +4,11 @@ import dev.morphia.annotations.Entity;
 import dev.morphia.annotations.Transient;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.game.quest.enums.QuestContent;
-import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -29,10 +30,10 @@ public class PlayerProgress {
     // keep track of EXEC_ADD_QUEST_PROGRESS count, will be used in CONTENT_ADD_QUEST_PROGRESS
     // not sure where to put this, this should be saved to DB but not to individual quest, since
     // it will be hard to loop and compare
-    private Map<Integer, Integer> questProgressCountMap;
+    private Map<String, Integer> questProgressCountMap;
 
     public PlayerProgress() {
-        this.questProgressCountMap = new Int2IntOpenHashMap();
+        this.questProgressCountMap = new ConcurrentHashMap<>();
         this.completedDungeons = new IntArrayList();
         this.itemHistory = new Int2ObjectOpenHashMap<>();
     }
@@ -70,15 +71,15 @@ public class PlayerProgress {
         return itemEntry.addToObtainedCount(count);
     }
 
-    public int getCurrentProgress(int progressId) {
+    public int getCurrentProgress(String progressId) {
         return questProgressCountMap.getOrDefault(progressId, -1);
     }
 
-    public int addToCurrentProgress(int progressId, int count) {
+    public int addToCurrentProgress(String progressId, int count) {
         return questProgressCountMap.merge(progressId, count, Integer::sum);
     }
 
-    public int resetCurrentProgress(int progressId) {
+    public int resetCurrentProgress(String progressId) {
         return questProgressCountMap.merge(progressId, 0, Integer::min);
     }
 

--- a/src/main/java/emu/grasscutter/game/player/PlayerProgressManager.java
+++ b/src/main/java/emu/grasscutter/game/player/PlayerProgressManager.java
@@ -300,7 +300,7 @@ public final class PlayerProgressManager extends BasePlayerDataManager {
 
     /** Quest progress */
     public void addQuestProgress(int id, int count) {
-        var newCount = player.getPlayerProgress().addToCurrentProgress(id, count);
+        var newCount = player.getPlayerProgress().addToCurrentProgress(String.valueOf(id), count);
         player.save();
         player
                 .getQuestManager()

--- a/src/main/java/emu/grasscutter/game/quest/GameQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameQuest.java
@@ -153,17 +153,30 @@ public class GameQuest {
         // TODO improve
         var oldState = state;
         if (questData.getFinishCond() != null && questData.getFinishCond().size() != 0) {
+            for(var condition : questData.getFinishCond()) {
+                if(condition.getType() == QuestContent.QUEST_CONTENT_LUA_NOTIFY) {
+                    this.getOwner().getPlayerProgress().resetCurrentProgress(condition.getParamStr());
+                }
+            }
             this.finishProgressList = new int[questData.getFinishCond().size()];
         }
 
         if (questData.getFailCond() != null && questData.getFailCond().size() != 0) {
+            for(var condition : questData.getFailCond()) {
+                if(condition.getType() == QuestContent.QUEST_CONTENT_LUA_NOTIFY) {
+                    this.getOwner().getPlayerProgress().resetCurrentProgress(condition.getParamStr());
+                }
+            }
             this.failProgressList = new int[questData.getFailCond().size()];
         }
+
+        this.getOwner().getPlayerProgress().resetCurrentProgress(String.valueOf(this.subQuestId));
+
         setState(QuestState.QUEST_STATE_UNSTARTED);
         finishTime = 0;
         acceptTime = 0;
         startTime = 0;
-        this.getOwner().getPlayerProgress().resetCurrentProgress(this.subQuestId);
+
         if (oldState == QuestState.QUEST_STATE_UNSTARTED) {
             return false;
         }

--- a/src/main/java/emu/grasscutter/game/quest/GameQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameQuest.java
@@ -51,10 +51,12 @@ public class GameQuest {
         this.state = QuestState.QUEST_STATE_UNSTARTED;
         this.triggerData = new HashMap<>();
         this.triggers = new HashMap<>();
+        this.finishProgressList = new int[questData.getFinishCond().size()];
+        this.failProgressList = new int[questData.getFailCond().size()];
+        this.finishTime = 0;
     }
 
     public void start() {
-        this.clearProgress(false);
         this.acceptTime = Utils.getCurrentSeconds();
         this.startTime = this.acceptTime;
         this.startGameDay = getOwner().getWorld().getTotalGameTimeDays();

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentAddQuestProgress.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentAddQuestProgress.java
@@ -14,7 +14,7 @@ public class ContentAddQuestProgress extends BaseContent {
     public boolean execute(
             GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
         val progressId = condition.getParam()[0];
-        val currentCount = quest.getOwner().getPlayerProgress().getCurrentProgress(progressId);
+        val currentCount = quest.getOwner().getPlayerProgress().getCurrentProgress(String.valueOf(progressId));
 
         // if the condition count is 0 I think it is safe to assume that the
         // condition count from EXEC only needs to be 1

--- a/src/main/java/emu/grasscutter/game/quest/content/ContentLuaNotify.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentLuaNotify.java
@@ -12,6 +12,6 @@ public class ContentLuaNotify extends BaseContent {
     @Override
     public boolean execute(
             GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
-        return condition.getParamStr().equals(paramStr);
+        return condition.getParamStr().equals(paramStr) && condition.getCount() <= quest.getOwner().getPlayerProgress().getCurrentProgress(paramStr);
     }
 }

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -667,6 +667,7 @@ public class ScriptLib {
             var1);
 
         for(var player : getSceneScriptManager().getScene().getPlayers()){
+            player.getPlayerProgress().addToCurrentProgress(var1, 1);
             player.getQuestManager().queueEvent(QuestCond.QUEST_COND_LUA_NOTIFY, var1);
             player.getQuestManager().queueEvent(QuestContent.QUEST_CONTENT_LUA_NOTIFY, var1);
         }


### PR DESCRIPTION
## Description
When fighting in front of the glowy stag god, the battle used to end when you defeated even one enemy. It turns out that QUEST_CONTENT_LUA_NOTIFY needs to track occurrences until it reaches its count variable. It doesn't always trigger on the first notice. "count"s more than 1 are rare for QUEST_CONTENT_LUA_NOTIFY.

I've added QUEST_CONTENT_LUA_NOTIFY tracking to PlayerProgress's questProgressCountMap, which I converted from a Map<Integer, Integer> to a Map<String, Integer>.

I've added rollback functionality as well.

I've tested it by failing the quest (dying) this reset the count properly. Relogging also reset the count properly. relevant sections of Act1 and act 3 are unaffected.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
