### PR TITLE
Add option "all" for UnlockMap and change the default behavior for "/prop unlockmap on"

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/SetPropCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetPropCommand.java
@@ -222,6 +222,21 @@ public final class SetPropCommand implements CommandHandler {
         GameData.getScenePointsPerScene()
                 .forEach(
                         (sceneId, scenePoints) -> {
+                            for (var p : scenePoints) {
+                                var scenePointEentry =
+                                    GameData.getScenePointEntryById(sceneId, p);
+
+                                var pointData = scenePointEentry.getPointData();
+
+                                boolean forbidSimpleUnlock = pointData.isForbidSimpleUnlock();
+                                boolean sceneBuildingPointLocked =
+                                    pointData.getType().equals("SceneBuildingPoint") &&
+                                    !pointData.isUnlocked();
+
+                                if (forbidSimpleUnlock || sceneBuildingPointLocked)
+                                    scenePoints.remove(p);
+                            }
+
                             // Unlock trans points.
                             targetPlayer.getUnlockedScenePoints(sceneId).addAll(scenePoints);
 

--- a/src/main/java/emu/grasscutter/command/commands/SetPropCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetPropCommand.java
@@ -108,6 +108,7 @@ public final class SetPropCommand implements CommandHandler {
                         case "on", "true" -> 1;
                         case "off", "false" -> 0;
                         case "toggle" -> -1;
+                        case "all" -> -2;
                         default -> Integer.parseInt(valueStr);
                     };
         } catch (NumberFormatException ignored) {
@@ -127,7 +128,7 @@ public final class SetPropCommand implements CommandHandler {
                             sender, targetPlayer, prop.pseudoProp, value);
                     case SET_OPENSTATE -> this.setOpenState(targetPlayer, value, 1);
                     case UNSET_OPENSTATE -> this.setOpenState(targetPlayer, value, 0);
-                    case UNLOCK_MAP -> unlockMap(targetPlayer);
+                    case UNLOCK_MAP -> unlockMap(targetPlayer, value);
                     default -> targetPlayer.setProperty(prop.prop, value);
                 };
 
@@ -218,25 +219,30 @@ public final class SetPropCommand implements CommandHandler {
         return true;
     }
 
-    private boolean unlockMap(Player targetPlayer) {
+    private boolean unlockMap(Player targetPlayer, int value) {
         // Unlock.
         GameData.getScenePointsPerScene()
                 .forEach(
                         (sceneId, scenePoints) -> {
-                            var scenePointsBackup = new CopyOnWriteArrayList<>(scenePoints);
-                            for (var p : scenePointsBackup) {
-                                var scenePointEentry = GameData.getScenePointEntryById(sceneId, p);
-                                var pointData = scenePointEentry.getPointData();
+                            if (value == -2) {
+                                // Unlock trans points.
+                                targetPlayer.getUnlockedScenePoints(sceneId).addAll(scenePoints);
+                            } else {
+                                var scenePointsBackup = new CopyOnWriteArrayList<>(scenePoints);
+                                for (var p : scenePointsBackup) {
+                                    var scenePointEentry = GameData.getScenePointEntryById(sceneId, p);
+                                    var pointData = scenePointEentry.getPointData();
 
-                                boolean forbidSimpleUnlock = pointData.isForbidSimpleUnlock();
-                                boolean sceneBuildingPointLocked =
-                                        pointData.getType().equals("SceneBuildingPoint") && !pointData.isUnlocked();
+                                    boolean forbidSimpleUnlock = pointData.isForbidSimpleUnlock();
+                                    boolean sceneBuildingPointLocked =
+                                            pointData.getType().equals("SceneBuildingPoint") && !pointData.isUnlocked();
 
-                                if (forbidSimpleUnlock || sceneBuildingPointLocked) scenePointsBackup.remove(p);
+                                    if (forbidSimpleUnlock || sceneBuildingPointLocked) scenePointsBackup.remove(p);
+                                }
+
+                                // Unlock trans points.
+                                targetPlayer.getUnlockedScenePoints(sceneId).addAll(scenePointsBackup);
                             }
-
-                            // Unlock trans points.
-                            targetPlayer.getUnlockedScenePoints(sceneId).addAll(scenePointsBackup);
 
                             // Unlock map areas.
                             targetPlayer.getUnlockedSceneAreas(sceneId).addAll(sceneAreas);

--- a/src/main/java/emu/grasscutter/command/commands/SetPropCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetPropCommand.java
@@ -12,6 +12,7 @@ import emu.grasscutter.server.packet.send.PacketScenePointUnlockNotify;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.IntStream;
 
 @Command(
@@ -222,20 +223,23 @@ public final class SetPropCommand implements CommandHandler {
         GameData.getScenePointsPerScene()
                 .forEach(
                         (sceneId, scenePoints) -> {
-                            for (var p : scenePoints) {
-                                var scenePointEentry = GameData.getScenePointEntryById(sceneId, p);
-
+                            var scenePointsBackup = new CopyOnWriteArrayList<>(scenePoints);
+                            for (var p : scenePointsBackup) {
+                                var scenePointEentry =
+                                    GameData.getScenePointEntryById(sceneId, p);
                                 var pointData = scenePointEentry.getPointData();
 
                                 boolean forbidSimpleUnlock = pointData.isForbidSimpleUnlock();
                                 boolean sceneBuildingPointLocked =
-                                        pointData.getType().equals("SceneBuildingPoint") && !pointData.isUnlocked();
+                                        pointData.getType().equals("SceneBuildingPoint") &&
+                                        !pointData.isUnlocked();
 
-                                if (forbidSimpleUnlock || sceneBuildingPointLocked) scenePoints.remove(p);
+                                if (forbidSimpleUnlock || sceneBuildingPointLocked)
+                                    scenePointsBackup.remove(p);
                             }
 
                             // Unlock trans points.
-                            targetPlayer.getUnlockedScenePoints(sceneId).addAll(scenePoints);
+                            targetPlayer.getUnlockedScenePoints(sceneId).addAll(scenePointsBackup);
 
                             // Unlock map areas.
                             targetPlayer.getUnlockedSceneAreas(sceneId).addAll(sceneAreas);

--- a/src/main/java/emu/grasscutter/command/commands/SetPropCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetPropCommand.java
@@ -223,18 +223,15 @@ public final class SetPropCommand implements CommandHandler {
                 .forEach(
                         (sceneId, scenePoints) -> {
                             for (var p : scenePoints) {
-                                var scenePointEentry =
-                                    GameData.getScenePointEntryById(sceneId, p);
+                                var scenePointEentry = GameData.getScenePointEntryById(sceneId, p);
 
                                 var pointData = scenePointEentry.getPointData();
 
                                 boolean forbidSimpleUnlock = pointData.isForbidSimpleUnlock();
                                 boolean sceneBuildingPointLocked =
-                                    pointData.getType().equals("SceneBuildingPoint") &&
-                                    !pointData.isUnlocked();
+                                        pointData.getType().equals("SceneBuildingPoint") && !pointData.isUnlocked();
 
-                                if (forbidSimpleUnlock || sceneBuildingPointLocked)
-                                    scenePoints.remove(p);
+                                if (forbidSimpleUnlock || sceneBuildingPointLocked) scenePoints.remove(p);
                             }
 
                             // Unlock trans points.

--- a/src/main/java/emu/grasscutter/command/commands/SetPropCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetPropCommand.java
@@ -225,17 +225,14 @@ public final class SetPropCommand implements CommandHandler {
                         (sceneId, scenePoints) -> {
                             var scenePointsBackup = new CopyOnWriteArrayList<>(scenePoints);
                             for (var p : scenePointsBackup) {
-                                var scenePointEentry =
-                                    GameData.getScenePointEntryById(sceneId, p);
+                                var scenePointEentry = GameData.getScenePointEntryById(sceneId, p);
                                 var pointData = scenePointEentry.getPointData();
 
                                 boolean forbidSimpleUnlock = pointData.isForbidSimpleUnlock();
                                 boolean sceneBuildingPointLocked =
-                                        pointData.getType().equals("SceneBuildingPoint") &&
-                                        !pointData.isUnlocked();
+                                        pointData.getType().equals("SceneBuildingPoint") && !pointData.isUnlocked();
 
-                                if (forbidSimpleUnlock || sceneBuildingPointLocked)
-                                    scenePointsBackup.remove(p);
+                                if (forbidSimpleUnlock || sceneBuildingPointLocked) scenePointsBackup.remove(p);
                             }
 
                             // Unlock trans points.

--- a/src/main/java/emu/grasscutter/data/common/PointData.java
+++ b/src/main/java/emu/grasscutter/data/common/PointData.java
@@ -19,6 +19,8 @@ public final class PointData {
     @Getter private Position pos;
     @Getter private Position rot;
     @Getter private Position size;
+    @Getter private boolean forbidSimpleUnlock;
+    @Getter private boolean unlocked;
 
     @SerializedName(
             value = "dungeonIds",


### PR DESCRIPTION
## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.

## Issues fixed by this PR
Add option "all" to unlock all the scene points include unnecessary scene points
Change the behavior for "/prop unlockmap on", now that command will not unlock unnecessary scene points to  be closer to the official server. and I think most people doesn't need these scene points and it will effect gaming experience.
the "unnecessary scene points" are:
1.  forbidSimpleUnlock is true
2. scene type is "SceneBuildingPoint" and unlocked is false

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
