### PR TITLE
Fix `cutscene` and `sound` permissions

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/CutsceneCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/CutsceneCommand.java
@@ -11,8 +11,8 @@ import lombok.val;
         label = "cutscene",
         aliases = {"c"},
         usage = {"[<cutsceneId>]"},
-        permission = "player.group",
-        permissionTargeted = "player.group.others")
+        permission = "player.cutscene",
+        permissionTargeted = "player.cutscene.others")
 public final class CutsceneCommand implements CommandHandler {
 
     @Override

--- a/src/main/java/emu/grasscutter/command/commands/SoundCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SoundCommand.java
@@ -14,8 +14,8 @@ import lombok.val;
         label = "sound",
         aliases = {"s", "audio"},
         usage = {"[<audioname>] [<x><y><z>]"},
-        permission = "player.group",
-        permissionTargeted = "player.group.others")
+        permission = "player.sound",
+        permissionTargeted = "player.sound.others")
 public final class SoundCommand implements CommandHandler {
 
     @Override


### PR DESCRIPTION
## Description

- Replace SoundCommand `player.group` to `player.sound`
- Replace CutsceneCommand `player.group` to `player.cutscene`

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.