### PR TITLE
Smarter NPC loading

### DIFF
--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -696,18 +696,6 @@ public final class Scene {
             npcBornEntries.addAll(loadNpcForPlayer(player));
         }
 
-        // clear the unreachable group for client
-        var toUnload =
-                this.npcBornEntrySet.stream()
-                        .filter(i -> !npcBornEntries.contains(i))
-                        .map(SceneNpcBornEntry::getGroupId)
-                        .toList();
-
-        if (toUnload.size() > 0) {
-            broadcastPacket(new PacketGroupUnloadNotify(toUnload));
-            Grasscutter.getLogger().trace("Unload NPC Group {}", toUnload);
-        }
-        // exchange the new npcBornEntry Set
         this.npcBornEntrySet = npcBornEntries;
     }
 
@@ -1160,14 +1148,24 @@ public final class Scene {
                         pos.toDoubleArray(),
                         Grasscutter.getConfig().server.game.loadEntitiesForPlayerRange);
 
-        var sceneNpcBornEntries =
+        var sceneNpcBornCanidates =
                 npcList.stream().filter(i -> !this.npcBornEntrySet.contains(i)).toList();
+
+        List<SceneNpcBornEntry> sceneNpcBornEntries = new ArrayList<>();
+        sceneNpcBornCanidates.forEach(
+            i -> {
+                var groupInstance = scriptManager.getGroupInstanceById(i.getGroupId());
+                if (groupInstance == null) return;
+                if (i.getSuiteIdList() != null && !i.getSuiteIdList().contains(groupInstance.getActiveSuiteId())) return;
+                sceneNpcBornEntries.add(i);
+            });
 
         if (sceneNpcBornEntries.size() > 0) {
             this.broadcastPacket(new PacketGroupSuiteNotify(sceneNpcBornEntries));
             Grasscutter.getLogger().trace("Loaded Npc Group Suite {}", sceneNpcBornEntries);
         }
-        return npcList;
+
+        return npcList.stream().filter(i -> this.npcBornEntrySet.contains(i) || sceneNpcBornEntries.contains(i)).toList();
     }
 
     public void loadGroupForQuest(List<QuestGroupSuite> sceneGroupSuite) {


### PR DESCRIPTION
## Description
NPCs should only be loaded if the group and suite it is associated with is loaded. There are some cool NPCs that don't have a scene group associated with them, but we'll ignore them for now.

NPCs unloading was unloading entire groups. I've removed the NPC unloading code - regular old group unloading handles NPC unloading too.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
