### PR TITLE
Make ice dude show up

### DIFF
--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -810,7 +810,7 @@ public class SceneScriptManager {
                                 .stream()
                                 .filter(
                                         t ->
-                                                t.getCondition().contains(String.valueOf(params.param1))
+                                                t.getCondition().substring(29).equals(String.valueOf(params.param1))
                                                         && (t.getSource().isEmpty()
                                                                 || t.getSource().equals(params.getEventSource())))
                                 .collect(Collectors.toSet());

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -810,6 +810,7 @@ public class SceneScriptManager {
                                 .stream()
                                 .filter(
                                         t ->
+                                                !t.getCondition().isEmpty() &&
                                                 t.getCondition().substring(29).equals(String.valueOf(params.param1))
                                                         && (t.getSource().isEmpty()
                                                                 || t.getSource().equals(params.getEventSource())))

--- a/src/main/java/emu/grasscutter/scripts/data/SceneTrigger.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneTrigger.java
@@ -27,7 +27,7 @@ public final class SceneTrigger {
 
     @Override
     public int hashCode() {
-        return name.hashCode();
+        return (currentGroup.id+name).hashCode();
     }
 
     @Override

--- a/src/main/java/emu/grasscutter/scripts/data/SceneTrigger.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneTrigger.java
@@ -27,7 +27,7 @@ public final class SceneTrigger {
 
     @Override
     public int hashCode() {
-        return (currentGroup.id+name).hashCode();
+        return (currentGroup.id + name).hashCode();
     }
 
     @Override


### PR DESCRIPTION
## Description
ENTER_REGION names are not unique. There was a hash collision between two ENTER_REGION_68's that caused ice dude to not show up in front of his domain.

Adding the group id to the name string makes them unique.

Also, there was a string.contains() when you should be using string.equals().

## Issues fixed by this PR
Ice dude finally got his cocogoat milk and cigarettes and came back. (┬┬﹏┬┬)

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
