### PR TITLE
Fix lock clock

### DIFF
--- a/src/main/java/emu/grasscutter/game/world/World.java
+++ b/src/main/java/emu/grasscutter/game/world/World.java
@@ -57,7 +57,7 @@ public class World implements Iterable<Player> {
         this.entity = new EntityWorld(this);
         this.worldLevel = player.getWorldLevel();
         this.isMultiplayer = isMultiplayer;
-        timeLocked = player.getProperty(PlayerProperty.PROP_IS_GAME_TIME_LOCKED) != 0;
+        this.timeLocked = player.getProperty(PlayerProperty.PROP_IS_GAME_TIME_LOCKED) != 0;
 
         this.lastUpdateTime = System.currentTimeMillis();
         this.currentWorldTime = host.getPlayerGameTime();

--- a/src/main/java/emu/grasscutter/game/world/World.java
+++ b/src/main/java/emu/grasscutter/game/world/World.java
@@ -35,7 +35,8 @@ public class World implements Iterable<Player> {
     private int nextPeerId = 0;
     private int worldLevel;
 
-    @Getter private boolean isMultiplayer, timeLocked = false;
+    @Getter private boolean isMultiplayer = false;
+    @Getter private boolean timeLocked;
 
     private long lastUpdateTime;
     @Getter private int tickCount = 0;
@@ -56,6 +57,7 @@ public class World implements Iterable<Player> {
         this.entity = new EntityWorld(this);
         this.worldLevel = player.getWorldLevel();
         this.isMultiplayer = isMultiplayer;
+        timeLocked = player.getProperty(PlayerProperty.PROP_IS_GAME_TIME_LOCKED) != 0;
 
         this.lastUpdateTime = System.currentTimeMillis();
         this.currentWorldTime = host.getPlayerGameTime();

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerClientLockGameTimeNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerClientLockGameTimeNotify.java
@@ -12,8 +12,8 @@ public final class HandlerClientLockGameTimeNotify extends PacketHandler {
     @Override
     public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
         var packet = ClientLockGameTimeNotify.parseFrom(payload);
-//        session.getPlayer().getWorld().lockTime(packet.getIsLock());
-        //TODO: figure out what to implement here
+        // session.getPlayer().getWorld().lockTime(packet.getIsLock());
+        // TODO: figure out what to implement here
         if (packet.getIsLock()) Grasscutter.getLogger().warn("Tell Nazrin to PANIK because ClientLockGameTimeNotify is TRUE!");
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerClientLockGameTimeNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerClientLockGameTimeNotify.java
@@ -1,5 +1,6 @@
 package emu.grasscutter.server.packet.recv;
 
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.net.packet.Opcodes;
 import emu.grasscutter.net.packet.PacketHandler;
 import emu.grasscutter.net.packet.PacketOpcodes;
@@ -11,6 +12,8 @@ public final class HandlerClientLockGameTimeNotify extends PacketHandler {
     @Override
     public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
         var packet = ClientLockGameTimeNotify.parseFrom(payload);
-        session.getPlayer().getWorld().lockTime(packet.getIsLock());
+//        session.getPlayer().getWorld().lockTime(packet.getIsLock());
+        //TODO: figure out what to implement here
+        if (packet.getIsLock()) Grasscutter.getLogger().warn("Tell Nazrin to PANIK because ClientLockGameTimeNotify is TRUE!");
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerClientLockGameTimeNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerClientLockGameTimeNotify.java
@@ -14,6 +14,6 @@ public final class HandlerClientLockGameTimeNotify extends PacketHandler {
         var packet = ClientLockGameTimeNotify.parseFrom(payload);
         // session.getPlayer().getWorld().lockTime(packet.getIsLock());
         // TODO: figure out what to implement here
-        if (packet.getIsLock()) Grasscutter.getLogger().warn("Tell Nazrin to PANIK because ClientLockGameTimeNotify is TRUE!");
+        if (packet.getIsLock()) Grasscutter.getLogger().warn("Invalid 'ClientLockGameTimeNotify' received; value is true. (please report to development channel)");
     }
 }


### PR DESCRIPTION
## Description
Ignores ClientLockGameTimeNotify so that lock time works correctly. Polls PROP_IS_GAME_TIME_LOCKED at login to find out if you are in the middle of a quest with time locking. Much thanks to @LloydTheGreenNinjagc and @Hartie95 

Ya, I can't make heads or tails of what ClientLockGameTimeNotify does except it always is sending a false.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
