### PR TITLE
Almost fully fix Chasing Shadows

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecNotifyGroupLua.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecNotifyGroupLua.java
@@ -27,27 +27,6 @@ public class ExecNotifyGroupLua extends QuestExecHandler {
         }
         scene.runWhenFinished(
                 () -> {
-                    val groupInstance = scriptManager.getGroupInstanceById(groupId);
-
-                    if (groupInstance != null) {
-                        // workaround to make sure the triggers are still there todo find better way of trigger
-                        // handling
-                        scriptManager.refreshGroup(groupInstance);
-                        Grasscutter.getLogger()
-                                .trace(
-                                        "group: {} \ncondition: {} \nparamStr {}",
-                                        groupInstance.getLuaGroup(),
-                                        condition,
-                                        paramStr);
-                    } else {
-                        Grasscutter.getLogger()
-                                .debug(
-                                        "notify, no group instance for:\n group: {} \ncondition: {} \nparamStr {}",
-                                        groupId,
-                                        condition,
-                                        paramStr);
-                    }
-
                     val eventType =
                             quest.getState() == QuestState.QUEST_STATE_FINISHED
                                     ? EventType.EVENT_QUEST_FINISH

--- a/src/main/java/emu/grasscutter/scripts/data/SceneRegion.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneRegion.java
@@ -32,9 +32,9 @@ public class SceneRegion {
     public boolean contains(Position position) {
         switch (shape) {
             case ScriptRegionShape.CUBIC:
-                return (Math.abs(pos.getX() - position.getX()) <= size.getX())
-                        && (Math.abs(pos.getY() - position.getY()) <= size.getY())
-                        && (Math.abs(pos.getZ() - position.getZ()) <= size.getZ());
+                return (Math.abs(pos.getX() - position.getX()) <= size.getX() / 2f)
+                        && (Math.abs(pos.getY() - position.getY()) <= size.getY() / 2f)
+                        && (Math.abs(pos.getZ() - position.getZ()) <= size.getZ() / 2f);
             case ScriptRegionShape.SPHERE:
                 var x = Math.pow(pos.getX() - position.getX(), 2);
                 var y = Math.pow(pos.getY() - position.getY(), 2);


### PR DESCRIPTION
## Description
The storeroom's trigger region was twice as big as it needed to be. The region was sticking into the room above it and triggering when you stepped in there.

Talking to guards was reloading all rooms to their base state. Removing this scriptManager.refreshGroup(groupInstance) fixed this. I have tested all instances of QUEST_EXEC_NOTIFY_GROUP_LUA in act 1 and see no difference for having removed it.

## Issues fixed by this PR
Chasing Shadows works a little bit better in the sense that a bike crash is better than a car crash.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
