### PR TITLE
Change method of not ticking empty scenes

### DIFF
--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -556,10 +556,6 @@ public final class Scene {
         this.finishLoading();
         this.checkPlayerRespawn();
         if (this.tickCount++ % 10 == 0) this.broadcastPacket(new PacketSceneTimeNotify(this));
-        if (this.getPlayerCount() <= 0 && !this.dontDestroyWhenEmpty) {
-            this.getScriptManager().onDestroy();
-            this.getWorld().deregisterScene(this);
-        }
     }
 
     /** Validates a player's current position. Teleports the player if the player is out of bounds. */

--- a/src/main/java/emu/grasscutter/game/world/World.java
+++ b/src/main/java/emu/grasscutter/game/world/World.java
@@ -437,7 +437,9 @@ public class World implements Iterable<Player> {
         // Check if there are players in this world.
         if (this.getPlayerCount() == 0) return true;
         // Tick all associated scenes.
-        this.getScenes().forEach((k, scene) -> scene.onTick());
+        this.getScenes().forEach((k, scene) -> {
+            if (scene.getPlayerCount() > 0) scene.onTick();
+        });
 
         // sync time every 10 seconds
         if (this.tickCount % 10 == 0) {


### PR DESCRIPTION
## Description
Instead of deregistering a scene when there is no players, it is less buggy to just not tick scenes that don't have players.
Scenes get registered to the world scene list when world's getSceneById() is called, and this causes them to get ticked once and then deregistered.

There is a quest where an entity is added to a scene the player is not in. The entity gets added, the scene gets ticked, and then the scene gets deregistered, thus losing the entity. 

By making it so that playerless scenes don't get ticked, the entity stays in that "unloaded" scene until the player can get there.

The original scene deregistering code was added by me due to a bug where all scenes you have ever interacted with were ticking all at the same time forever. But now that code is redundant. The scenes will now still live in memory, but at least they will not take up processor time. 

## Issues fixed by this PR
During fire dude's story quest, you place slime bait outside the city walls. You are in the bar when the marker gets placed, and the marker is placed outside. The marker wouldn't be there when you went outside.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
