### PR TITLE
Do not unload groups asked for by quests

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecRefreshGroupSuite.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecRefreshGroupSuite.java
@@ -25,6 +25,7 @@ public class ExecRefreshGroupSuite extends QuestExecHandler {
             if (!scriptManager.refreshGroupSuite(groupId, suiteId, quest)) {
                 result = false;
             }
+            scriptManager.getGroupById(groupId).dontUnload = true;
         }
 
         return result;

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -842,7 +842,7 @@ public final class Scene {
                         .collect(Collectors.toSet());
 
         for (var group : this.loadedGroups) {
-            if (!visible.contains(group.id) && !group.dynamic_load)
+            if (!visible.contains(group.id) && !group.dynamic_load && !group.dontUnload)
                 unloadGroup(scriptManager.getBlocks().get(group.block_id), group.id);
         }
 

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -266,15 +266,15 @@ public class SceneScriptManager {
                             suiteId,
                             groupId,
                             getScene().getId());
-        } else {
-            Grasscutter.getLogger().debug("Refreshing group {} suite {}", groupId, suiteId);
-            suiteId =
-                    refreshGroup(
-                            targetGroupInstance,
-                            suiteId,
-                            false); // If suiteId is zero, the value of suiteId changes
-            scene.broadcastPacket(new PacketGroupSuiteNotify(groupId, suiteId));
+            if (targetGroupInstance == null) return false;
         }
+        Grasscutter.getLogger().debug("Refreshing group {} suite {}", groupId, suiteId);
+        suiteId =
+                refreshGroup(
+                        targetGroupInstance,
+                        suiteId,
+                        false); // If suiteId is zero, the value of suiteId changes
+        scene.broadcastPacket(new PacketGroupSuiteNotify(groupId, suiteId));
 
         return true;
     }

--- a/src/main/java/emu/grasscutter/scripts/data/SceneGroup.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneGroup.java
@@ -40,6 +40,7 @@ public final class SceneGroup {
     public SceneGarbage garbages;
     public SceneInitConfig init_config;
     @Getter public boolean dynamic_load = false;
+    public boolean dontUnload = false;
 
     public SceneReplaceable is_replaceable;
 


### PR DESCRIPTION
## Description
Do not unload groups asked for by quests due to distance.

When you are too far away from a group when QUEST_EXEC_REFRESH_GROUP_SUITE happens, the group will instantly be unloaded (after patching the error in SceneScriptManager's refreshGroupSuite) and any suite information that is different from the default will be lost.

I tried saving and loading this suite information, but that just caused the suite to keep loading even after the quest was done.

Hartie talked about saving monster, gadget, quest marker, ect whereabouts, but I think a more quick solution is to just not unload these quest exec groups in the first place.

## Issues fixed by this PR
This fixes at least five bugs:

prologue act 2: tear does not appear in chest. The chest was too far away and it's default, boring contents were loaded instead.

prologue act 3: after breaking storm barrier, next quest marker doesn't load. The marker was too far away to load.

Bomber girl story quest: Enter the tavern and nothing happens. Tavern is in a different world. this means it was too far away to load the suite and keep it.

Bomber girl story quest: Nothing at the dig spot. The dig spot is way too far away from the city to load the suite and keep it.

Fire dude story quest: No attackers at the bridge. The other end of the bridge is juuust long enough to be outsize the loading zone. Hitting the trigger from the bridge side was close enough to make the suite load.


<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
