### PR TITLE
dungeon drop implementation

### DIFF
--- a/src/main/java/emu/grasscutter/data/excels/dungeon/DungeonData.java
+++ b/src/main/java/emu/grasscutter/data/excels/dungeon/DungeonData.java
@@ -32,6 +32,7 @@ public class DungeonData extends GameResource {
     @Getter private int passRewardPreviewID;
     @Getter private int statueCostID;
     @Getter private int statueCostCount;
+    @Getter private int statueDrop;
 
     // not part of DungeonExcelConfigData
     @Getter private RewardPreviewData rewardPreviewData;

--- a/src/main/java/emu/grasscutter/game/drop/DropSystem.java
+++ b/src/main/java/emu/grasscutter/game/drop/DropSystem.java
@@ -80,6 +80,14 @@ public final class DropSystem extends BaseGameSystem {
         return dropData.getDropId();
     }
 
+    public List<GameItem> handleDungeonRewardDrop(int dropId, boolean doubleReward) {
+        if (!dropTable.containsKey(dropId)) return List.of();
+        var dropData = dropTable.get(dropId);
+        List<GameItem> items = new ArrayList<>();
+        processDrop(dropData, doubleReward ? 2 : 1, items);
+        return items;
+    }
+
     public boolean handleMonsterDrop(EntityMonster monster) {
         int dropId;
         int level = monster.getLevel();

--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
@@ -137,7 +137,7 @@ public final class DungeonManager {
         List<GameItem> rewards = player.getServer().getDropSystem().handleDungeonRewardDrop(dungeonData.getStatueDrop(), useCondensed);
         if (rewards.isEmpty()) {
             //fallback to legacy drop system
-            Grasscutter.getLogger().warn("dungeon drop failed for {}", dungeonData.getId());
+            Grasscutter.getLogger().debug("dungeon drop failed for {}", dungeonData.getId());
             rewards = new ArrayList<>(this.rollRewards(useCondensed));
         }
         // Add rewards to player and send notification.

--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
@@ -134,7 +134,12 @@ public final class DungeonManager {
         }
 
         // Get and roll rewards.
-        List<GameItem> rewards = new ArrayList<>(this.rollRewards(useCondensed));
+        List<GameItem> rewards = player.getServer().getDropSystem().handleDungeonRewardDrop(dungeonData.getStatueDrop(), useCondensed);
+        if (rewards.isEmpty()) {
+            //fallback to legacy drop system
+            Grasscutter.getLogger().warn("dungeon drop failed for {}", dungeonData.getId());
+            rewards = new ArrayList<>(this.rollRewards(useCondensed));
+        }
         // Add rewards to player and send notification.
         player.getInventory().addItems(rewards, ActionReason.DungeonStatueDrop);
         player.sendPacket(new PacketGadgetAutoPickDropInfoNotify(rewards));
@@ -187,7 +192,7 @@ public final class DungeonManager {
                     amount += Utils.drawRandomListElement(candidateAmounts, entry.getProbabilities());
                 }
 
-                // Double rewards in multiplay mode, if specified.
+                // Double rewards in multiply mode, if specified.
                 if (entry.isMpDouble() && this.getScene().getPlayerCount() > 1) {
                     amount *= 2;
                 }

--- a/src/main/java/emu/grasscutter/game/entity/gadget/GadgetRewardStatue.java
+++ b/src/main/java/emu/grasscutter/game/entity/gadget/GadgetRewardStatue.java
@@ -1,5 +1,6 @@
 package emu.grasscutter.game.entity.gadget;
 
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.game.dungeons.challenge.DungeonChallenge;
 import emu.grasscutter.game.entity.EntityGadget;
 import emu.grasscutter.game.player.Player;


### PR DESCRIPTION
## Description

The reward of reliquary dungeons were determined by custom-defined json file in the past, now we can switch to the new drop system to handle it.

The new drop system can provide a more accurate reward.

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
