### PR TITLE
Fix race condition with worktops

### DIFF
--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -152,18 +152,17 @@ public class ScriptLib {
         logger.debug("[LUA] Call SetWorktopOptions with {}", printTable(table));
         var callParams = this.callParams.getIfExists();
         var group = this.currentGroup.getIfExists();
-        if(callParams == null || group == null){
+        if (callParams == null || group == null) {
             return 1;
         }
         var configId = callParams.param1;
         var entity = getSceneScriptManager().getScene().getEntityByConfigId(configId);
 
-
-        int[] worktopOptions = new int[table.length()];
-        for(int i = 1 ;i<=table.length() ;i++){
+        var worktopOptions = new int[table.length()];
+        for (int i = 1; i<=table.length(); i++) {
             worktopOptions[i-1] = table.get(i).optint(-1);
         }
-        if(!(entity instanceof EntityGadget gadget)|| worktopOptions.length == 0){
+        if (!(entity instanceof EntityGadget gadget) || worktopOptions.length == 0) {
             return 2;
         }
 
@@ -172,10 +171,8 @@ public class ScriptLib {
         }
 
         worktop.addWorktopOptions(worktopOptions);
-
-        var scene = getSceneScriptManager().getScene();
         // Done in order to synchronize with addEntities in Scene.class.
-        synchronized (getSceneScriptManager().getScene()) {
+        synchronized (this.getSceneScriptManager().getScene()) {
             scene.broadcastPacket(new PacketWorktopOptionNotify(gadget));
         }
         return 0;

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -174,7 +174,10 @@ public class ScriptLib {
         worktop.addWorktopOptions(worktopOptions);
 
         var scene = getSceneScriptManager().getScene();
-        scene.broadcastPacket(new PacketWorktopOptionNotify(gadget));
+        //Done in order to synchronize with addEntities in Scene.class
+        synchronized (getSceneScriptManager().getScene()) {
+            scene.broadcastPacket(new PacketWorktopOptionNotify(gadget));
+        }
         return 0;
     }
 

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -174,7 +174,7 @@ public class ScriptLib {
         worktop.addWorktopOptions(worktopOptions);
 
         var scene = getSceneScriptManager().getScene();
-        //Done in order to synchronize with addEntities in Scene.class
+        // Done in order to synchronize with addEntities in Scene.class.
         synchronized (getSceneScriptManager().getScene()) {
             scene.broadcastPacket(new PacketWorktopOptionNotify(gadget));
         }


### PR DESCRIPTION
## Description
Worktop in Ice Dude's dungeon would sometimes (due to a recent change all the time) not display the ability to open the door.
I found that the packets were running into a race condition: The SceneEntityAppearNotify packet would start gathering information, the WorktopOptionNotify packet would start, finish, and send, and then the SceneEntityAppearNotify packet would send, overwriting the new worktop information. 

If one teleported or respawned, the room would read that the entity had a worktop option, and send that proper information to the client. 


## Issues fixed by this PR
Old bug that resurfaced. Glad to see it gone.


## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
