### PR TITLE
Fix Librarian Story Quest

### DIFF
--- a/src/main/java/emu/grasscutter/game/entity/GameEntity.java
+++ b/src/main/java/emu/grasscutter/game/entity/GameEntity.java
@@ -53,7 +53,7 @@ public abstract class GameEntity {
     public abstract void initAbilities();
 
     public int getEntityType() {
-        return this.getId() >> 24;
+        return EntityIdType.toEntityType(this.getId() >> 24);
     }
 
     public abstract int getEntityTypeId();

--- a/src/main/java/emu/grasscutter/game/entity/GameEntity.java
+++ b/src/main/java/emu/grasscutter/game/entity/GameEntity.java
@@ -52,7 +52,7 @@ public abstract class GameEntity {
 
     public abstract void initAbilities();
 
-    public int getEntityType() {
+    public EntityType getEntityType() {
         return EntityIdType.toEntityType(this.getId() >> 24);
     }
 

--- a/src/main/java/emu/grasscutter/game/entity/gadget/GadgetGatherObject.java
+++ b/src/main/java/emu/grasscutter/game/entity/gadget/GadgetGatherObject.java
@@ -14,6 +14,8 @@ import emu.grasscutter.net.proto.GadgetInteractReqOuterClass.GadgetInteractReq;
 import emu.grasscutter.net.proto.GatherGadgetInfoOuterClass.GatherGadgetInfo;
 import emu.grasscutter.net.proto.InteractTypeOuterClass.InteractType;
 import emu.grasscutter.net.proto.SceneGadgetInfoOuterClass.SceneGadgetInfo;
+import emu.grasscutter.scripts.constants.EventType;
+import emu.grasscutter.scripts.data.ScriptArgs;
 import emu.grasscutter.server.packet.send.PacketGadgetInteractRsp;
 import emu.grasscutter.utils.Utils;
 
@@ -56,6 +58,12 @@ public final class GadgetGatherObject extends GadgetContent {
 
         GameItem item = new GameItem(itemData, 1);
         player.getInventory().addItem(item, ActionReason.Gather);
+
+        getGadget()
+                .getScene()
+                .getScriptManager()
+                .callEvent(
+                        new ScriptArgs(getGadget().getGroupId(), EventType.EVENT_GATHER, getGadget().getConfigId()));
 
         getGadget()
                 .getScene()

--- a/src/main/java/emu/grasscutter/game/props/EntityIdType.java
+++ b/src/main/java/emu/grasscutter/game/props/EntityIdType.java
@@ -1,5 +1,8 @@
 package emu.grasscutter.game.props;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public enum EntityIdType {
     AVATAR(0x01),
     MONSTER(0x02),
@@ -12,8 +15,25 @@ public enum EntityIdType {
 
     private final int id;
 
+    private static final Map<Integer, EntityType> map = new HashMap<>();
+
+    static {
+        map.put(EntityIdType.AVATAR.getId(),EntityType.Avatar);
+        map.put(EntityIdType.MONSTER.getId(),EntityType.Monster);
+        map.put(EntityIdType.NPC.getId(),EntityType.NPC);
+        map.put(EntityIdType.GADGET.getId(),EntityType.Gadget);
+        map.put(EntityIdType.REGION.getId(),EntityType.Region);
+        map.put(EntityIdType.WEAPON.getId(),EntityType.Equip);
+        map.put(EntityIdType.TEAM.getId(),EntityType.Team);
+        map.put(EntityIdType.MPLEVEL.getId(),EntityType.MPLevel);
+    }
+
     EntityIdType(int id) {
         this.id = id;
+    }
+
+    public static int toEntityType(int entityId) {
+        return map.getOrDefault(entityId, EntityType.None).getValue();
     }
 
     public int getId() {

--- a/src/main/java/emu/grasscutter/game/props/EntityIdType.java
+++ b/src/main/java/emu/grasscutter/game/props/EntityIdType.java
@@ -32,8 +32,8 @@ public enum EntityIdType {
         this.id = id;
     }
 
-    public static int toEntityType(int entityId) {
-        return map.getOrDefault(entityId, EntityType.None).getValue();
+    public static EntityType toEntityType(int entityId) {
+        return map.getOrDefault(entityId, EntityType.None);
     }
 
     public int getId() {

--- a/src/main/java/emu/grasscutter/game/props/EntityType.java
+++ b/src/main/java/emu/grasscutter/game/props/EntityType.java
@@ -75,7 +75,7 @@ public enum EntityType implements IntValueEnum {
     Screen(64),
     EchoShell(65),
     UIInteractGadget(66),
-    Region(67),
+    Region(98),
     PlaceHolder(99);
 
     private static final Int2ObjectMap<EntityType> map = new Int2ObjectOpenHashMap<>();

--- a/src/main/java/emu/grasscutter/game/props/EntityType.java
+++ b/src/main/java/emu/grasscutter/game/props/EntityType.java
@@ -75,6 +75,7 @@ public enum EntityType implements IntValueEnum {
     Screen(64),
     EchoShell(65),
     UIInteractGadget(66),
+    Region(67),
     PlaceHolder(99);
 
     private static final Int2ObjectMap<EntityType> map = new Int2ObjectOpenHashMap<>();

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -508,7 +508,7 @@ public final class Scene {
         }
 
         // Remove entity from world
-        this.removeEntity(target);
+        this.removeEntity(target,VisionType.VISION_TYPE_DIE);
 
         // Death event
         target.onDeath(attackerId);

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -401,7 +401,7 @@ public final class Scene {
     }
 
     public void removeEntity(GameEntity entity) {
-        this.removeEntity(entity, VisionType.VISION_TYPE_REMOVE);
+        this.removeEntity(entity, VisionType.VISION_TYPE_DIE);
     }
 
     public synchronized void removeEntity(GameEntity entity, VisionType visionType) {
@@ -508,7 +508,7 @@ public final class Scene {
         }
 
         // Remove entity from world
-        this.removeEntity(target,VisionType.VISION_TYPE_DIE);
+        this.removeEntity(target);
 
         // Death event
         target.onDeath(attackerId);

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -401,7 +401,7 @@ public final class Scene {
     }
 
     public void removeEntity(GameEntity entity) {
-        this.removeEntity(entity, VisionType.VISION_TYPE_DIE);
+        this.removeEntity(entity, VisionType.VISION_TYPE_REMOVE);
     }
 
     public synchronized void removeEntity(GameEntity entity, VisionType visionType) {

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -629,7 +629,7 @@ public class SceneScriptManager {
                     getScene().getEntities().values().stream()
                             .filter(
                                     e ->
-                                            e.getEntityType() == EntityType.Avatar.getValue()
+                                            e.getEntityType() == EntityType.Avatar
                                                     && region.getMetaRegion().contains(e.getPosition()))
                             .toList();
             entities.forEach(region::addEntity);

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -610,6 +610,10 @@ public class ScriptLib {
         logger.debug("[LUA] Call CreateGadget with {}",
             printTable(table));
         var configId = table.get("config_id").toint();
+        //TODO: figure out what creating gadget configId 0 does
+        if (configId == 0){
+            return 0;
+        }
 
         var group = getCurrentGroup();
 

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -613,6 +613,7 @@ public class ScriptLib {
         var configId = table.get("config_id").toint();
         //TODO: figure out what creating gadget configId 0 does
         if (configId == 0){
+            Grasscutter.getLogger().warn("Tried to CreateGadget with config_id 0: {}", printTable(table));
             return 0;
         }
 

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -18,6 +18,7 @@ import emu.grasscutter.game.quest.enums.QuestContent;
 import emu.grasscutter.game.quest.enums.QuestState;
 import emu.grasscutter.game.world.SceneGroupInstance;
 import emu.grasscutter.net.proto.EnterTypeOuterClass;
+import emu.grasscutter.net.proto.VisionTypeOuterClass.VisionType;
 import emu.grasscutter.scripts.constants.EventType;
 import emu.grasscutter.scripts.constants.GroupKillPolicy;
 import emu.grasscutter.scripts.data.SceneGroup;

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -747,7 +747,7 @@ public class ScriptLib {
             return 1;
         }
 
-        getSceneScriptManager().getScene().removeEntity(entity);
+        getSceneScriptManager().getScene().removeEntity(entity, VisionType.VISION_TYPE_REMOVE);
 
         return 0;
     }

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -710,7 +710,7 @@ public class ScriptLib {
             return EntityType.None.getValue();
         }
 
-        return entity.getEntityType();
+        return entity.getEntityType().getValue();
     }
 
     public int GetQuestState(int entityId, int questId){
@@ -745,7 +745,7 @@ public class ScriptLib {
 
         val entity = getSceneScriptManager().getScene().getEntityByConfigId(configId, groupId);
 
-        if(entity == null || entity.getEntityType() != entityType){
+        if(entity == null || entity.getEntityType().getValue() != entityType){
             return 1;
         }
 
@@ -825,7 +825,7 @@ public class ScriptLib {
     }
     public int IsPlayerAllAvatarDie(int sceneUid){
         logger.warn("[LUA] Call unimplemented IsPlayerAllAvatarDie {}", sceneUid);
-        var playerEntities = getSceneScriptManager().getScene().getEntities().values().stream().filter(e -> e.getEntityType() == EntityIdType.AVATAR.getId()).toList();
+        var playerEntities = getSceneScriptManager().getScene().getEntities().values().stream().filter(e -> e.getEntityType() == EntityType.Avatar).toList();
         for (GameEntity p : playerEntities){
             var player = (EntityAvatar)p;
             if(player.isAlive()){


### PR DESCRIPTION
## Description
Various fixes to make Librarian's story quest go from red to dark green.

4 in 1 pack!


## Issues fixed by this PR
GadgetGatherObject.java ->
When gathering an object, send a EventType.EVENT_GATHER to ScriptArgs so that those kinds of triggers will happen.
Quest 1010115 was not finishing because the lua in scene 1004 group 201004003 was not being told that the book was taken from the shelf.

ScriptLib.java -> config_id
There was a CreateGadget with config_id of 0 in scene 20010, group 220010006. I don't know what the crap it is supposed to do, but it keeps the group from loading.
I made it check for config_id of 0 and return a 0 in that case.

ScriptLib.java -> VisionType.VISION_TYPE_REMOVE
When we REMOVE an entity, we should send a VisionType.VISION_TYPE_REMOVE not a VisionType.VISION_TYPE_DIE
In the dungeon in this quest, there's an invisible floor that keeps you from taking the platform down. With VisionType.VISION_TYPE_DIE the invisible floor remained in place and with VisionType.VISION_TYPE_REMOVE it was removed.

GameEntity.java, EntityIdType.java, EntityType.java ->
This is the only fix that you might want to look into.
in the lua scripts, the values of EntityType are used for things like EntityType.GADGET . For Grasscutter, the values from EntityIdType are used to make unique IDs. I could not find a way to get an entity's EntityType from a GameEntity. So instead, I put a map in EntityIdType that converts EntityIdTypes to EntityType. I checked GameEntity's getEntityType() and it is only used when EntityType is needed, but it returns EntityIdTypes instead. I added Region to EntityType because it's used in the lua in the electric islands (might as well add it now).
In the game, when trying to remove that invisible floor I was talking about earlier, it would return a 1 instead of a 0 in ScriptLib.java's RemoveEntityByConfigId (scene 20010 group 220010010) and therefor fail. This was because entity.getEntityType() (which returns a EntityIdType) was being checked against  entityType (which was a EntityType). This made it so that the final worktop in the dungeon would appear to not do anything when you interacted with it.




<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
