### PR TITLE
Fix ore not falling from rocks

### DIFF
--- a/src/main/java/emu/grasscutter/game/ability/AbilityManager.java
+++ b/src/main/java/emu/grasscutter/game/ability/AbilityManager.java
@@ -9,9 +9,9 @@ import emu.grasscutter.game.ability.actions.*;
 import emu.grasscutter.game.ability.mixins.*;
 import emu.grasscutter.game.entity.EntityGadget;
 import emu.grasscutter.game.entity.GameEntity;
+import emu.grasscutter.game.entity.gadget.GadgetGatherObject;
 import emu.grasscutter.game.player.*;
 import emu.grasscutter.game.props.FightProperty;
-import emu.grasscutter.game.entity.gadget.GadgetGatherObject;
 import emu.grasscutter.net.proto.AbilityInvokeEntryOuterClass.AbilityInvokeEntry;
 import emu.grasscutter.net.proto.AbilityMetaAddAbilityOuterClass.AbilityMetaAddAbility;
 import emu.grasscutter.net.proto.AbilityMetaModifierChangeOuterClass.AbilityMetaModifierChange;
@@ -369,7 +369,9 @@ public final class AbilityManager extends BasePlayerManager {
         var entity = this.player.getScene().getEntityById(invoke.getEntityId());
         if (entity == null) {
             Grasscutter.getLogger().debug("Entity not found: {}", invoke.getEntityId());
-            return;
+            entity = this.player.getScene().getRemovedEntityById(invoke.getEntityId());
+            if (entity == null) return;
+            Grasscutter.getLogger().debug("Using removed Entity: {}", invoke.getEntityId());
         }
 
         // Destroying rocks

--- a/src/main/java/emu/grasscutter/game/entity/gadget/GadgetGatherObject.java
+++ b/src/main/java/emu/grasscutter/game/entity/gadget/GadgetGatherObject.java
@@ -101,7 +101,6 @@ public final class GadgetGatherObject extends GadgetContent {
             scene.addEntity(item);
         }
 
-        scene.killEntity(this.getGadget(), player.getTeamManager().getCurrentAvatarEntity().getId());
         // Todo: add record
     }
 }

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -44,6 +44,7 @@ public final class Scene {
     @Getter private final SceneData sceneData;
     @Getter private final List<Player> players;
     @Getter private final Map<Integer, GameEntity> entities;
+    @Getter private final LinkedHashMap<Integer, GameEntity> removedEntities;
     @Getter private final Map<Integer, GameEntity> weaponEntities;
     @Getter private final Set<SpawnDataEntry> spawnedEntities;
     @Getter private final Set<SpawnDataEntry> deadSpawnedEntities;
@@ -75,6 +76,12 @@ public final class Scene {
         this.sceneData = sceneData;
         this.players = new CopyOnWriteArrayList<>();
         this.entities = new ConcurrentHashMap<>();
+        this.removedEntities = new LinkedHashMap<>(){
+            protected boolean removeEldestEntry(Map.Entry<Integer, GameEntity> eldest) {
+                // Fit to taste. 500 entities is about two loading zones.
+                return size() > 500;
+            }
+        };
         this.weaponEntities = new ConcurrentHashMap<>();
 
         this.prevScene = 3;
@@ -136,6 +143,10 @@ public final class Scene {
         }
 
         return entity;
+    }
+
+    public GameEntity getRemovedEntityById(int id) {
+        return this.removedEntities.get(id);
     }
 
     public GameEntity getEntityByConfigId(int configId) {
@@ -396,6 +407,7 @@ public final class Scene {
         var removed = getEntities().remove(entity.getId());
         if (removed != null) {
             removed.onRemoved(); // Call entity remove event
+            getRemovedEntities().put(entity.getId(), removed);
         }
         return removed;
     }


### PR DESCRIPTION
## Description
Fix ore not falling from rocks.

Note however that the client tells the server to remove the rock, and then tells the server to do the drops.
It is not safe to call player.getScene().getEntityById().

So I implemented a cache system for recently deleted entities.
I've set the size limit to an arbitrary 500 entities. That's about 2 loading zones full of entities. 
removeEldestEntry comes in clutch. If it returns true, it deletes the oldest entry when .put() is used.

## Issues fixed by this PR
Ores did not drop.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
