### PR TITLE
Fix unlogging quests

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/QuestCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/QuestCommand.java
@@ -112,7 +112,7 @@ public final class QuestCommand implements CommandHandler {
                 var shouldAdd = !loggedQuests.contains(questId);
 
                 if (shouldAdd) loggedQuests.add(questId);
-                else loggedQuests.remove(questId);
+                else loggedQuests.remove(loggedQuests.indexOf(questId));
 
                 CommandHandler.sendMessage(
                         sender,


### PR DESCRIPTION
## Description
I couldn't use /q dubug to turn off debugging on a quest.
loggedQuests.remove() here is getting confused between 

public E remove(int index)
and
public boolean remove(Object o)

because questId is an int.

## Issues fixed by this PR
![image](https://github.com/Grasscutters/Grasscutter/assets/1877986/d992c4f7-b21f-4f55-897f-d5cf6e3f0f8d)

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
