### PR TITLE
fix `serverStatus` error when gameserver not running

### DIFF
--- a/src/main/java/emu/grasscutter/server/http/handlers/GenericHandler.java
+++ b/src/main/java/emu/grasscutter/server/http/handlers/GenericHandler.java
@@ -29,7 +29,7 @@ public final class GenericHandler implements Router {
                         + maxPlayer
                         + ",\"version\":\""
                         + version
-                        + ",\"runmode\":\""
+                        + "\",\"runmode\":\""
                         + SERVER.runMode
                         + "\"}}");
     }

--- a/src/main/java/emu/grasscutter/server/http/handlers/GenericHandler.java
+++ b/src/main/java/emu/grasscutter/server/http/handlers/GenericHandler.java
@@ -1,6 +1,7 @@
 package emu.grasscutter.server.http.handlers;
 
 import static emu.grasscutter.config.Configuration.ACCOUNT;
+import static emu.grasscutter.config.Configuration.SERVER;
 
 import emu.grasscutter.GameConstants;
 import emu.grasscutter.Grasscutter;
@@ -13,7 +14,11 @@ import io.javalin.http.Context;
 /** Handles all generic, hard-coded responses. */
 public final class GenericHandler implements Router {
     private static void serverStatus(Context ctx) {
-        int playerCount = Grasscutter.getGameServer().getPlayers().size();
+        int playerCount;
+        if (SERVER.runMode != Grasscutter.ServerRunMode.HYBRID )
+            playerCount = 0;
+        else
+            playerCount = Grasscutter.getGameServer().getPlayers().size();
         int maxPlayer = ACCOUNT.maxPlayer;
         String version = GameConstants.VERSION;
 
@@ -24,6 +29,8 @@ public final class GenericHandler implements Router {
                         + maxPlayer
                         + ",\"version\":\""
                         + version
+                        + ",\"runmode\":\""
+                        + SERVER.runMode
                         + "\"}}");
     }
 


### PR DESCRIPTION
## Description

Fix `serverStatus` error when gameserver is not running.
Add field `runmode` to the HTTP response of `serverStatus`.

## Issues fixed by this PR

#2223 

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
