### PR TITLE
Fix entering home interior

### DIFF
--- a/src/main/java/emu/grasscutter/data/excels/ItemData.java
+++ b/src/main/java/emu/grasscutter/data/excels/ItemData.java
@@ -89,7 +89,7 @@ public class ItemData extends GameResource {
 
     @SerializedName(
             value = "roomSceneId",
-            alternate = {"BMEPAMCNABE", "DANFGGLKLNO", "JFDLJGDFIGL", "OHIANNAEEAK", "MFGACDIOHGF"})
+            alternate = {"BMEPAMCNABE", "DANFGGLKLNO", "JFDLJGDFIGL", "OHIANNAEEAK", "MFGACDIOHGF", "roomSceneID"})
     private int roomSceneId;
 
     // Custom


### PR DESCRIPTION
## Description

Fixes entering the interior of homes by adding alternate name for roomSceneId

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
