### PR TITLE
fix first entering teapot failure

### DIFF
--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -99,7 +99,13 @@ public class SceneScriptManager {
     }
 
     public SceneConfig getConfig() {
-        return this.isInit ? this.meta.config : null;
+        for (int i = 0; i < 10; ++i) {
+            if (this.isInit) {
+                return this.meta.config;
+            }
+            Utils.sleep(100);
+        }
+        return null;
     }
 
     public Map<Integer, SceneBlock> getBlocks() {


### PR DESCRIPTION
## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.

teapot is using a function call:

```java
Position pos = scene.getScriptManager().getConfig().born_pos;
```

but config may not be ready when the scene is first loaded using another thread, thus causing a fail

```java
    public SceneScriptManager(Scene scene) {
        ...
        // Create
        new Thread(this::init).start();
    }

    private void init() {
        var meta = ScriptLoader.getSceneMeta(getScene().getId());
        if (meta == null) {
            return;
        }
        this.meta = meta;

        // TEMP
        this.isInit = true;
    }
```

## Issues fixed by this PR

this is a dirty fix that waits 100ms 10 times when failure happens

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
