### PR TITLE
Fix QUEST_CONTENT_LEAVE_SCENE

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/content/ContentLeaveScene.java
+++ b/src/main/java/emu/grasscutter/game/quest/content/ContentLeaveScene.java
@@ -12,6 +12,6 @@ public class ContentLeaveScene extends BaseContent {
     @Override
     public boolean execute(
             GameQuest quest, QuestData.QuestContentCondition condition, String paramStr, int... params) {
-        return quest.getOwner().getScene().getPrevScene() == params[0];
+        return condition.getParam()[0] == params[0];
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerPostEnterSceneReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerPostEnterSceneReq.java
@@ -28,6 +28,7 @@ public class HandlerPostEnterSceneReq extends PacketHandler {
                 if (dungeonManager != null) dungeonManager.startDungeon();
             }
         }
+        questManager.queueEvent(QuestContent.QUEST_CONTENT_LEAVE_SCENE, scene.getPrevScene());
 
         session.send(new PacketPostEnterSceneRsp(session.getPlayer()));
     }


### PR DESCRIPTION
## Description
There was no trigger for QUEST_CONTENT_LEAVE_SCENE, and the logic behind checking it needed to be brought in line with most of the other quest content logic.

## Issues fixed by this PR
On the very last part of clan head dude's story quest, he tells you to GTFO of his mansion, but the quest wasn't finishing.


## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
