### PR TITLE
Fix starting wrong quest for story quests

### DIFF
--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerUnlockPersonalLineReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerUnlockPersonalLineReq.java
@@ -21,7 +21,6 @@ public class HandlerUnlockPersonalLineReq extends PacketHandler {
             return;
         }
 
-        session.getPlayer().getQuestManager().addQuest(data.getStartQuestId());
         session.getPlayer().addPersonalLine(data.getId());
         session.getPlayer().useLegendaryKey(1);
 


### PR DESCRIPTION
## Description
PersonalLineExcelConfigData.json's StartQuestId is not the first quest in the quest line. It's the quest with the starting screen. Manually starting that quest (which isn't always the first quest) can cause two quests in the quest line to be started at the same time.

## Issues fixed by this PR
Electric god's second story quest has the first two quests running at the same time after unlocking it.


<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
