### PR TITLE
add support for 3.8 teapot binout files (scene 2005, 2204)

### DIFF
--- a/src/main/java/emu/grasscutter/data/binout/HomeworldDefaultSaveData.java
+++ b/src/main/java/emu/grasscutter/data/binout/HomeworldDefaultSaveData.java
@@ -11,38 +11,38 @@ import lombok.experimental.FieldDefaults;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class HomeworldDefaultSaveData {
 
-    @SerializedName(value = "KFHBFNPDJBE", alternate = "PKACPHDGGEI")
+    @SerializedName(value = "KFHBFNPDJBE", alternate = {"PKACPHDGGEI", "AKOLOBLHDFK"})
     List<HomeBlock> homeBlockLists;
 
-    @SerializedName(value = "IJNPADKGNKE", alternate = "MINCKHBNING")
+    @SerializedName(value = "IJNPADKGNKE", alternate = {"MINCKHBNING", "MBICDPDEKDM"})
     Position bornPos;
 
-    @SerializedName("IPIIGEMFLHK")
+    @SerializedName(value = "IPIIGEMFLHK", alternate = {"EJJIOJKFKCO"})
     Position bornRot;
 
-    @SerializedName("HHOLBNPIHEM")
+    @SerializedName(value = "HHOLBNPIHEM", alternate = {"CJAKHCIFHNP"})
     Position djinPos;
 
-    @SerializedName("KNHCJKHCOAN")
+    @SerializedName(value = "KNHCJKHCOAN", alternate = {"AMDNOHPGKMI"})
     HomeFurniture mainhouse;
 
-    @SerializedName("NIHOJFEKFPG")
+    @SerializedName(value = "NIHOJFEKFPG", alternate = {"BHCPEAOPIDC"})
     List<HomeFurniture> doorLists;
 
-    @SerializedName("EPGELGEFJFK")
+    @SerializedName(value = "EPGELGEFJFK", alternate = {"AABEPENIFLN"})
     List<HomeFurniture> stairLists;
 
     @Data
     @FieldDefaults(level = AccessLevel.PRIVATE)
     public static class HomeBlock {
 
-        @SerializedName(value = "FGIJCELCGFI", alternate = "PGDPDIDJEEL")
+        @SerializedName(value = "FGIJCELCGFI", alternate = {"PGDPDIDJEEL", "ANICBLBOBKD"})
         int blockId;
 
-        @SerializedName("BEAPOFELABD")
+        @SerializedName(value = "BEAPOFELABD", alternate = {"NCIMIKKFLOH"})
         List<HomeFurniture> furnitures;
 
-        @SerializedName("MLIODLGDFHJ")
+        @SerializedName(value = "MLIODLGDFHJ", alternate = {"GJGNLIINBGB"})
         List<HomeFurniture> persistentFurnitures;
     }
 
@@ -50,10 +50,10 @@ public class HomeworldDefaultSaveData {
     @FieldDefaults(level = AccessLevel.PRIVATE)
     public static class HomeFurniture {
 
-        @SerializedName(value = "ENHNGKJBJAB", alternate = "KMAAJJHPNBA")
+        @SerializedName(value = "ENHNGKJBJAB", alternate = {"KMAAJJHPNBA", "FFLCGFGGGND"})
         int id;
 
-        @SerializedName(value = "NGIEEIOLPPO", alternate = "JFKAHNCPDME")
+        @SerializedName(value = "NGIEEIOLPPO", alternate = {"JFKAHNCPDME", "BPCGGBKIAMG"})
         Position pos;
         // @SerializedName(value = "HEOCEHKEBFM", alternate = "LKCKOOGFDBM")
         Position rot;


### PR DESCRIPTION
## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.

dendro main house and world default save loading (from dimbreath version 3.8 bin output)

2005: `51e271a4.json`
2204: `2ca9b7af.json`

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
