### PR TITLE
make xxGroupVariableValueByGroup the same as xxGroupVariableValue

### DIFF
--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -398,10 +398,39 @@ public class ScriptLib {
 
         val old = variables.getOrDefault(var, 0);
         variables.put(var, old + value);
-        logger.debug("[LUA] Call ChangeGroupVariableValue with {},{}",
-            old, old+value);
         getSceneScriptManager().callEvent(new ScriptArgs(groupId, EventType.EVENT_VARIABLE_CHANGE, old+value, old).setEventSource(var));
         return LuaValue.ZERO;
+    }
+
+    public int GetGroupVariableValueByGroup(String var, int groupId){
+        logger.debug("[LUA] Call GetGroupVariableValueByGroup with {},{}",
+            var,groupId);
+
+        return getSceneScriptManager().getVariables(groupId).getOrDefault(var, 0);
+    }
+
+    public int SetGroupVariableValueByGroup(String var, int value, int groupId){
+        logger.debug("[LUA] Call SetGroupVariableValueByGroup with {},{},{}",
+            var,value,groupId);
+
+        val variables = getSceneScriptManager().getVariables(groupId);
+
+        val old = variables.getOrDefault(var, value);
+        variables.put(var, value);
+        getSceneScriptManager().callEvent(new ScriptArgs(groupId, EventType.EVENT_VARIABLE_CHANGE, value, old).setEventSource(var));
+        return 0;
+    }
+
+    public int ChangeGroupVariableValueByGroup(String var, int value, int groupId){
+        logger.debug("[LUA] Call ChangeGroupVariableValueByGroup with {},{}",
+            var,groupId);
+
+        val variables = getSceneScriptManager().getVariables(groupId);
+
+        val old = variables.getOrDefault(var, 0);
+        variables.put(var, old + value);
+        getSceneScriptManager().callEvent(new ScriptArgs(groupId, EventType.EVENT_VARIABLE_CHANGE, old+value, old).setEventSource(var));
+        return 0;
     }
 
     /**
@@ -533,20 +562,6 @@ public class ScriptLib {
         return 0;
     }
 
-    public int GetGroupVariableValueByGroup(String name, int groupId){
-        logger.debug("[LUA] Call GetGroupVariableValueByGroup with {},{}",
-            name,groupId);
-
-        return getSceneScriptManager().getVariables(groupId).getOrDefault(name, 0);
-    }
-    public int ChangeGroupVariableValueByGroup(String name, int value, int groupId){
-        logger.debug("[LUA] Call ChangeGroupVariableValueByGroup with {},{}",
-            name,groupId);
-        //TODO test
-        getSceneScriptManager().getVariables(groupId).put(name, value);
-        return 0;
-    }
-
     public int SetIsAllowUseSkill(int canUse){
         logger.debug("[LUA] Call SetIsAllowUseSkill with {}",
             canUse);
@@ -568,14 +583,6 @@ public class ScriptLib {
             return 0;
         }
         getSceneScriptManager().getScene().killEntity(entity, 0);
-        return 0;
-    }
-
-    public int SetGroupVariableValueByGroup(String key, int value, int groupId){
-        logger.debug("[LUA] Call SetGroupVariableValueByGroup with {},{},{}",
-            key,value,groupId);
-
-        getSceneScriptManager().getVariables(groupId).put(key, value);
         return 0;
     }
 


### PR DESCRIPTION
## Description
For some reason collecting ores in the first interlude chapter uses SetGroupVariableValueByGroup instead of SetGroupVariableValue. I needed to copy the SetGroupVariableValue code over to make it work the same. Mainly it was missing a call event, otherwise the code was functionally the same.

I went ahead and moved the section of code up so that they are all next to each other.

## Issues fixed by this PR
Collect the iron, and the quest continues.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
