### PR TITLE
Gadgets can be picked up too

### DIFF
--- a/src/main/java/emu/grasscutter/game/entity/gadget/GadgetGatherObject.java
+++ b/src/main/java/emu/grasscutter/game/entity/gadget/GadgetGatherObject.java
@@ -59,12 +59,11 @@ public final class GadgetGatherObject extends GadgetContent {
         GameItem item = new GameItem(itemData, 1);
         player.getInventory().addItem(item, ActionReason.Gather);
 
-        getGadget()
-                .getScene()
-                .getScriptManager()
-                .callEvent(
-                        new ScriptArgs(
-                                getGadget().getGroupId(), EventType.EVENT_GATHER, getGadget().getConfigId()));
+        var ScriptArgs = new ScriptArgs(getGadget().getGroupId(), EventType.EVENT_GATHER, getGadget().getConfigId());
+        if(getGadget().getMetaGadget() != null){
+            ScriptArgs.setEventSource(getGadget().getMetaGadget().config_id);
+        }
+        getGadget().getScene().getScriptManager().callEvent(ScriptArgs);
 
         getGadget()
                 .getScene()

--- a/src/main/java/emu/grasscutter/game/entity/gadget/GadgetObject.java
+++ b/src/main/java/emu/grasscutter/game/entity/gadget/GadgetObject.java
@@ -27,7 +27,7 @@ public class GadgetObject extends GadgetContent {
 
     @Override
     public boolean onInteract(Player player, GadgetInteractReqOuterClass.GadgetInteractReq req) {
-        // Sanity check
+        // This is a workaround until a proper gadget interaction system can be put in place.
         ItemData itemData = GameData.getItemDataMap().get(this.itemId);
         if (itemData == null) {
             return false;

--- a/src/main/java/emu/grasscutter/game/entity/gadget/GadgetObject.java
+++ b/src/main/java/emu/grasscutter/game/entity/gadget/GadgetObject.java
@@ -1,18 +1,52 @@
 package emu.grasscutter.game.entity.gadget;
 
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.excels.GatherData;
+import emu.grasscutter.data.excels.ItemData;
 import emu.grasscutter.game.entity.EntityGadget;
+import emu.grasscutter.game.inventory.GameItem;
 import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.props.ActionReason;
 import emu.grasscutter.net.proto.GadgetInteractReqOuterClass;
+import emu.grasscutter.net.proto.InteractTypeOuterClass;
 import emu.grasscutter.net.proto.SceneGadgetInfoOuterClass;
+import emu.grasscutter.scripts.constants.EventType;
+import emu.grasscutter.scripts.data.ScriptArgs;
+import emu.grasscutter.server.packet.send.PacketGadgetInteractRsp;
 
 public class GadgetObject extends GadgetContent {
+    private int itemId;
+
     public GadgetObject(EntityGadget gadget) {
         super(gadget);
+        GatherData gatherData = GameData.getGatherDataMap().get(gadget.getPointType());
+        if (gatherData != null) {
+            this.itemId = gatherData.getItemId();
+        }
     }
 
     @Override
     public boolean onInteract(Player player, GadgetInteractReqOuterClass.GadgetInteractReq req) {
-        return false;
+        // Sanity check
+        ItemData itemData = GameData.getItemDataMap().get(this.itemId);
+        if (itemData == null) {
+            return false;
+        }
+
+        GameItem item = new GameItem(itemData, 1);
+        player.getInventory().addItem(item, ActionReason.Gather);
+
+        var ScriptArgs = new ScriptArgs(getGadget().getGroupId(), EventType.EVENT_GATHER, getGadget().getConfigId());
+        if(getGadget().getMetaGadget() != null){
+            ScriptArgs.setEventSource(getGadget().getMetaGadget().config_id);
+        }
+        getGadget().getScene().getScriptManager().callEvent(ScriptArgs);
+
+        getGadget()
+            .getScene()
+            .broadcastPacket(
+                new PacketGadgetInteractRsp(getGadget(), InteractTypeOuterClass.InteractType.INTERACT_TYPE_GATHER));
+        return true;
     }
 
     @Override


### PR DESCRIPTION
## Description
On the island off the east cost, there's a book under a rock. ( group 133006005 config 5008) This book is a GadgetObject and not a GatherGadgetObject, so it didn't have any pickup code. I've added the pickup code from GatherGadgetObject, which is really good about checking for things like if there is an item and what item it needs to give you. If there isn't an associated gather item for the gadget (like most gadgets), it should still have the same functionality it used to.

I then figured out that the group for that item (3 group 133006005) was also expecting the metagadget's configid as the EVENT_GATHER source. See PR #2218 when I added GatherGadgetObject's EVENT_GATHER. In that PR, source was "" so it didn't matter. I've already tested that librarian's story quest still works.

## Issues fixed by this PR
The world quest on the small secret island off the east coast can continue.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
