### PR TITLE
Improve Platforms

### DIFF
--- a/src/main/java/emu/grasscutter/data/ResourceLoader.java
+++ b/src/main/java/emu/grasscutter/data/ResourceLoader.java
@@ -9,6 +9,7 @@ import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.binout.*;
 import emu.grasscutter.data.binout.AbilityModifier.AbilityModifierAction;
 import emu.grasscutter.data.binout.config.*;
+import emu.grasscutter.data.binout.routes.*;
 import emu.grasscutter.data.common.PointData;
 import emu.grasscutter.data.custom.*;
 import emu.grasscutter.data.excels.trial.TrialAvatarActivityDataData;
@@ -107,6 +108,7 @@ public final class ResourceLoader {
         // Load default home layout
         loadHomeworldDefaultSaveData();
         loadNpcBornData();
+        loadRoutes();
         loadBlossomResources();
         cacheTalentLevelSets();
         // Load activities.
@@ -261,6 +263,30 @@ public final class ResourceLoader {
         } catch (IOException ignored) {
             Grasscutter.getLogger()
                     .error("Scene point files cannot be found, you cannot use teleport waypoints!");
+        }
+    }
+
+    private static void loadRoutes() {
+        try {
+            Files.newDirectoryStream(getResourcePath("BinOutput/LevelDesign/Routes/"),"*.json")
+                    .forEach(
+                            path -> {
+                                try {
+                                    val data = JsonUtils.loadToClass(path, SceneRoutes.class);
+                                    val routesArray = data.getRoutes();
+                                    if (routesArray == null) return;
+                                    val routesMap = GameData.getSceneRouteData().getOrDefault(data.getSceneId(), new Int2ObjectOpenHashMap<>());
+                                    for (Route route : routesArray) {
+                                        routesMap.put(route.getLocalId(), route);
+                                    }
+                                    GameData.getSceneRouteData().put(data.getSceneId(), routesMap);
+                                } catch (IOException ignored) {
+                                }
+                            });
+            Grasscutter.getLogger()
+                .debug("Loaded " + GameData.getSceneNpcBornData().size() + " SceneRouteDatas.");
+        } catch (IOException e) {
+            Grasscutter.getLogger().error("Failed to load SceneRouteData folder.");
         }
     }
 

--- a/src/main/java/emu/grasscutter/game/entity/gadget/platform/ConfigRoute.java
+++ b/src/main/java/emu/grasscutter/game/entity/gadget/platform/ConfigRoute.java
@@ -18,22 +18,22 @@ public class ConfigRoute extends BaseRoute {
     public ConfigRoute(SceneGadget gadget) {
         super(gadget);
         this.routeId = gadget.route_id;
-        startIndex = 0;
-        scheduledIndexes = new ArrayList<>();
+        this.startIndex = 0;
+        this.scheduledIndexes = new ArrayList<>();
     }
 
     public ConfigRoute(Position startRot, boolean startRoute, boolean isActive, int routeId) {
         super(startRot, startRoute, isActive);
         this.routeId = routeId;
-        startIndex = 0;
-        scheduledIndexes = new ArrayList<>();
+        this.startIndex = 0;
+        this.scheduledIndexes = new ArrayList<>();
     }
 
     @Override
     public PlatformInfoOuterClass.PlatformInfo.Builder toProto() {
         return super.toProto()
-                .setRouteId(routeId)
-                .setStartIndex(startIndex)
+                .setRouteId(this.routeId)
+                .setStartIndex(this.startIndex)
                 .setMovingPlatformType(
                         MovingPlatformTypeOuterClass.MovingPlatformType.MOVING_PLATFORM_TYPE_USE_CONFIG);
     }

--- a/src/main/java/emu/grasscutter/game/entity/gadget/platform/ConfigRoute.java
+++ b/src/main/java/emu/grasscutter/game/entity/gadget/platform/ConfigRoute.java
@@ -6,25 +6,34 @@ import emu.grasscutter.net.proto.PlatformInfoOuterClass;
 import emu.grasscutter.scripts.data.SceneGadget;
 import lombok.Getter;
 import lombok.Setter;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ConfigRoute extends BaseRoute {
 
     @Getter @Setter private int routeId;
+    @Getter @Setter private int startIndex;
+    @Getter @Setter private List<Integer> scheduledIndexes;
 
     public ConfigRoute(SceneGadget gadget) {
         super(gadget);
         this.routeId = gadget.route_id;
+        startIndex = 0;
+        scheduledIndexes = new ArrayList<>();
     }
 
     public ConfigRoute(Position startRot, boolean startRoute, boolean isActive, int routeId) {
         super(startRot, startRoute, isActive);
         this.routeId = routeId;
+        startIndex = 0;
+        scheduledIndexes = new ArrayList<>();
     }
 
     @Override
     public PlatformInfoOuterClass.PlatformInfo.Builder toProto() {
         return super.toProto()
                 .setRouteId(routeId)
+                .setStartIndex(startIndex)
                 .setMovingPlatformType(
                         MovingPlatformTypeOuterClass.MovingPlatformType.MOVING_PLATFORM_TYPE_USE_CONFIG);
     }

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -31,6 +31,7 @@ import emu.grasscutter.scripts.data.*;
 import emu.grasscutter.server.event.entity.EntityCreationEvent;
 import emu.grasscutter.server.event.player.PlayerTeleportEvent;
 import emu.grasscutter.server.packet.send.*;
+import emu.grasscutter.server.scheduler.ServerTaskScheduler;
 import emu.grasscutter.utils.objects.KahnsSort;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import java.util.*;
@@ -71,6 +72,7 @@ public final class Scene {
     private final List<Runnable> afterHostInitCallbacks = new ArrayList<>();
 
     @Getter private GameEntity sceneEntity;
+    @Getter private final ServerTaskScheduler scheduler;
 
     public Scene(World world, SceneData sceneData) {
         this.world = world;
@@ -94,6 +96,7 @@ public final class Scene {
         this.blossomManager = new BlossomManager(this);
         this.unlockedForces = new HashSet<>();
         this.sceneEntity = new EntityScene(this);
+        this.scheduler = new ServerTaskScheduler();
     }
 
     public int getId() {
@@ -531,6 +534,10 @@ public final class Scene {
                 || this.getSceneType() == SceneType.SCENE_HOME_ROOM) {
             this.finishLoading();
             return;
+        }
+
+        if(!isPaused) {
+            this.getScheduler().runTasks();
         }
 
         if (this.getScriptManager().isInit()) {

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -1319,6 +1319,13 @@ public class ScriptLib {
         }
 
         configRoute.setRouteId(routeId);
+        configRoute.setStartIndex(0);
+        configRoute.setStarted(false);
+        for(var task : configRoute.getScheduledIndexes()) {
+            sceneScriptManager.get().getScene().getScheduler().cancelTask(task);
+        }
+        configRoute.getScheduledIndexes().clear();
+
         sceneScriptManager.get().getScene().broadcastPacket(new PacketPlatformChangeRouteNotify(entityGadget));
         return 0;
     }

--- a/src/main/java/emu/grasscutter/server/scheduler/ServerTask.java
+++ b/src/main/java/emu/grasscutter/server/scheduler/ServerTask.java
@@ -36,7 +36,7 @@ public final class ServerTask implements Runnable {
      */
     public boolean shouldRun() {
         // Increase tick count.
-        var ticks = this.ticks++;
+        ++this.ticks;
         if (this.delay != -1 && this.considerDelay) {
             // Check if the task should run.
             var shouldRun = ticks >= this.delay;


### PR DESCRIPTION
## Description
Implemented EVENT_PLATFORM_REACH_POINT

## Issues fixed by this PR
What this fixes: 
Two balloon escort missions one in a story quest (freedom city leader), and one in act 1 of chapter 2.

What this does not:
Platforms are jumpy. Maybe incomplete protos usage?
There's some missing dialog commentary while the platform is moving.
Seelies are still broken.
https://discord.com/channels/965284035985305680/1096180670625222758/1133029488150708285

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
