### PR TITLE
Handle Dungeons with null config

### DIFF
--- a/src/main/java/emu/grasscutter/data/excels/dungeon/DungeonPassConfigData.java
+++ b/src/main/java/emu/grasscutter/data/excels/dungeon/DungeonPassConfigData.java
@@ -6,12 +6,13 @@ import emu.grasscutter.game.dungeons.enums.DungeonPassConditionType;
 import emu.grasscutter.game.quest.enums.LogicType;
 import java.util.List;
 import lombok.Getter;
+import lombok.Setter;
 
 @ResourceType(name = "DungeonPassExcelConfigData.json")
 public class DungeonPassConfigData extends GameResource {
     @Getter private int id;
     @Getter private LogicType logicType;
-    @Getter private List<DungeonPassCondition> conds;
+    @Getter @Setter private List<DungeonPassCondition> conds;
 
     public static class DungeonPassCondition {
         @Getter private DungeonPassConditionType condType;

--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
@@ -53,8 +53,13 @@ public final class DungeonManager {
     public DungeonManager(@NonNull Scene scene, @NonNull DungeonData dungeonData) {
         this.scene = scene;
         this.dungeonData = dungeonData;
-        this.passConfigData = GameData.getDungeonPassConfigDataMap().get(dungeonData.getPassCond());
-        this.finishedConditions = new int[passConfigData.getConds().size()];
+        if(dungeonData.getPassCond() == 0){
+            this.passConfigData = new DungeonPassConfigData();
+            this.passConfigData.setConds(new ArrayList<>());
+        }else {
+            this.passConfigData = GameData.getDungeonPassConfigDataMap().get(dungeonData.getPassCond());
+        }
+        this.finishedConditions = new int[this.passConfigData.getConds().size()];
     }
 
     public void triggerEvent(DungeonPassConditionType conditionType, int... params) {
@@ -76,6 +81,7 @@ public final class DungeonManager {
     }
 
     public boolean isFinishedSuccessfully() {
+        if(passConfigData.getLogicType()==null) return false;
         return LogicType.calculate(passConfigData.getLogicType(), finishedConditions);
     }
 


### PR DESCRIPTION
## Description
In DungeonExcelConfigData.json, some dungeons have passCond and some do not. passCond are for referencing DungeonPassExcelConfigData.json where there are things such as finish conditions.

Grasscutter null pointer exception'd when a dungeon didn't have passCond.

## Issues fixed by this PR
Backstabber water dude's dungeon and battle works!


## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
