### PR TITLE
Implement QUEST_EXEC_RANDOM_QUEST_VAR

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
+++ b/src/main/java/emu/grasscutter/game/quest/GameMainQuest.java
@@ -16,6 +16,7 @@ import emu.grasscutter.net.proto.ChildQuestOuterClass.ChildQuest;
 import emu.grasscutter.net.proto.ParentQuestOuterClass.ParentQuest;
 import emu.grasscutter.server.packet.send.*;
 import emu.grasscutter.utils.ConversionUtils;
+import emu.grasscutter.utils.Utils;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.*;
@@ -116,6 +117,16 @@ public class GameMainQuest {
         Grasscutter.getLogger()
                 .debug(
                         "questVar {} value decremented from {} to {}", i, previousValue, previousValue - dec);
+
+        this.triggerQuestVarAction(i, this.questVars[i]);
+    }
+
+    public void randomQuestVar(int i, int low, int high) {
+        int previousValue = this.questVars[i];
+        this.questVars[i] = Utils.random.nextInt(low, high);
+        Grasscutter.getLogger()
+                .debug(
+                        "questVar {} value randomized from {} to {}", i, previousValue, this.questVars[i]);
 
         this.triggerQuestVarAction(i, this.questVars[i]);
     }

--- a/src/main/java/emu/grasscutter/game/quest/enums/QuestExec.java
+++ b/src/main/java/emu/grasscutter/game/quest/enums/QuestExec.java
@@ -59,7 +59,7 @@ public enum QuestExec implements QuestTrigger {
     QUEST_EXEC_SET_QUEST_VAR(48),
     QUEST_EXEC_INC_QUEST_VAR(49),
     QUEST_EXEC_DEC_QUEST_VAR(50),
-    QUEST_EXEC_RANDOM_QUEST_VAR(51), // missing
+    QUEST_EXEC_RANDOM_QUEST_VAR(51),
     QUEST_EXEC_ACTIVATE_SCANNING_PIC(52), // missing, currently unused
     QUEST_EXEC_RELOAD_SCENE_TAG(53), // missing
     QUEST_EXEC_REGISTER_DYNAMIC_GROUP_ONLY(54), // missing

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecRandomQuestVar.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecRandomQuestVar.java
@@ -1,0 +1,16 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.excels.quest.QuestData;
+import emu.grasscutter.game.quest.GameQuest;
+import emu.grasscutter.game.quest.QuestValueExec;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+
+@QuestValueExec(QuestExec.QUEST_EXEC_RANDOM_QUEST_VAR)
+public class ExecRandomQuestVar extends QuestExecHandler {
+    @Override
+    public boolean execute(GameQuest quest, QuestData.QuestExecParam condition, String... paramStr) {
+        quest.getMainQuest().randomQuestVar(Integer.parseInt(paramStr[0]), Integer.parseInt(paramStr[1]), Integer.parseInt(paramStr[2]));
+        return true;
+    }
+}


### PR DESCRIPTION
## Description
QUEST_EXEC_RANDOM_QUEST_VAR makes random variables for quests! Not variables for random quests!

The first number is the quest var index, the second in the lower bound (inclusive) and the third is the upper bound (exclusive).

So a [0,1,4] will set variable 0 to either 1, 2, or 3.

## Issues fixed by this PR
I can pull a fortune stick at the festival!

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
