### PR TITLE
Fix swimming stamina cost

### DIFF
--- a/src/main/java/emu/grasscutter/game/managers/stamina/StaminaManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/stamina/StaminaManager.java
@@ -389,6 +389,9 @@ public class StaminaManager extends BasePlayerManager {
             return;
         }
 
+        // Update previous motion state
+        this.previousState = currentState;
+
         // Update the current state.
         this.currentState = motionState;
         // logger.trace(currentState + "\t" + (notifyEntityId == currentAvatarEntityId ? "character" : "vehicle"));
@@ -417,6 +420,11 @@ public class StaminaManager extends BasePlayerManager {
     // Internal handler
 
     private void handleImmediateStamina(GameSession session, @NotNull MotionState motionState) {
+        // Don't double dip on sustained stamina start costs
+        if (previousState == currentState) {
+            return;
+        }
+
         switch (motionState) {
             case MOTION_STATE_CLIMB ->
                 updateStaminaRelative(session, new Consumption(ConsumptionType.CLIMB_START), true);


### PR DESCRIPTION
## Description

Fixes swimming stamina consumption, where the start cost was erroneously being repeatedly taken.
It appears initial dash cost is still pulling about double what official does, but this at least makes swimming any reasonable distance possible.

https://github.com/Grasscutters/Grasscutter/assets/107363768/29f5581b-381f-4b76-8c94-6a189d1ff503

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
