### PR TITLE
Fix dungeons with no finish logic in DungeonManager.java

### DIFF
--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
@@ -81,7 +81,7 @@ public final class DungeonManager {
     }
 
     public boolean isFinishedSuccessfully() {
-        if (passConfigData.getLogicType() == null) return false;
+        if (passConfigData.getConds() == null) return false;
         return LogicType.calculate(passConfigData.getLogicType(), finishedConditions);
     }
 


### PR DESCRIPTION
## Description
Bug from #2279
Having no conditions is a better indicator that there is no pass config than there being no condition logic.

## Issues fixed by this PR
Every dungeon missing logicType in its DungeonPassExcelConfigData.
DungeonPassExcelConfigData doesn't have any dungeons missing conditions, so this is a better indicator.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
