### PR TITLE
fix the error that the parameter regionCache of class PacketPlayerLoginRsp is null in game only mode

### DIFF
--- a/src/main/java/emu/grasscutter/server/packet/send/PacketPlayerLoginRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketPlayerLoginRsp.java
@@ -37,7 +37,7 @@ public class PacketPlayerLoginRsp extends BasePacket {
                                     .setGateserverPort(lr(GAME_INFO.accessPort, GAME_INFO.bindPort))
                                     .build();
 
-                    var regionCache =
+                    regionCache =
                             QueryCurrRegionHttpRspOuterClass.QueryCurrRegionHttpRsp.newBuilder()
                                     .setRegionInfo(serverRegion)
                                     .setClientSecretKey(ByteString.copyFrom(Crypto.DISPATCH_SEED))


### PR DESCRIPTION
## Description

running in game only mode will get the following error

 java.lang.NullPointerException: Cannot invoke "emu.grasscutter.net.proto.QueryCurrRegionHttpRspOuterClass$QueryCurrRegionHttpRsp.getRegionInfo()" because "emu.grasscutter.server.packet.send.PacketPlayerLoginRsp.regionCache" is null
	at emu.grasscutter.server.packet.send.PacketPlayerLoginRsp.<init>(PacketPlayerLoginRsp.java:50)
	at emu.grasscutter.server.packet.recv.HandlerPlayerLoginReq.handle(HandlerPlayerLoginReq.java:48)
	at emu.grasscutter.server.game.GameServerPacketHandler.handle(GameServerPacketHandler.java:91)
	at emu.grasscutter.server.game.GameSession.handleReceive(GameSession.java:221)
	at emu.grasscutter.server.game.GameSessionManager$1.lambda$handleReceive$0(GameSessionManager.java:72)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
	at io.netty.channel.DefaultEventLoop.run(DefaultEventLoop.java:54)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
