### PR TITLE
FIX auto skipping handbook generation when file is not found.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -283,7 +283,7 @@ idea {
         // proto files and generated Java files are automatically added as
         // source dirs.
         // If you have additional sources, add them here:
-        sourceDirs += file('/proto/');
+        sourceDirs += file('/proto/')
     }
 }
 
@@ -354,31 +354,31 @@ tasks.register('generateHandbook') {
         println('NPM is not installed. Skipping handbook generation.')
     } else {
         // Check if the handbook resources are present.
-        if (!file('src/handbook/data/commands.json')) {
+        if (!file('src/handbook/data/commands.json').exists()) {
             println('Command data was not found. Skipping handbook generation.')
             return
         }
-        if (!file('src/handbook/data/avatars.csv')) {
+        if (!file('src/handbook/data/avatars.csv').exists()) {
             println('Avatar data was not found. Skipping handbook generation.')
             return
         }
-        if (!file('src/handbook/data/entities.csv')) {
+        if (!file('src/handbook/data/entities.csv').exists()) {
             println('Entity data was not found. Skipping handbook generation.')
             return
         }
-        if (!file('src/handbook/data/items.csv')) {
+        if (!file('src/handbook/data/items.csv').exists()) {
             println('Item data was not found. Skipping handbook generation.')
             return
         }
-        if (!file('src/handbook/data/mainquests.csv')) {
+        if (!file('src/handbook/data/mainquests.csv').exists()) {
             println('Main quest data was not found. Skipping handbook generation.')
             return
         }
-        if (!file('src/handbook/data/quests.csv')) {
+        if (!file('src/handbook/data/quests.csv').exists()) {
             println('Quest data was not found. Skipping handbook generation.')
             return
         }
-        if (!file('src/handbook/data/scenes.csv')) {
+        if (!file('src/handbook/data/scenes.csv').exists()) {
             println('Scene data was not found. Skipping handbook generation.')
             return
         }


### PR DESCRIPTION
## Description

Fix can't skip generate handbook when 'src/handbook/data/commands.json', 'src/handbook/data/avatars.csv' ... are not found.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
#2186
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
