### PR TITLE
Fix errors in chasm

### DIFF
--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -910,8 +910,8 @@ public final class Scene {
 
     public int loadDynamicGroup(int group_id) {
         SceneGroup group = getScriptManager().getGroupById(group_id);
-        if (group == null || getScriptManager().getGroupInstanceById(group_id) != null)
-            return -1; // Group not found or already instanced
+        if (group == null)
+            return -1; // Group not found
 
         this.onLoadGroup(new ArrayList<>(List.of(group)));
 

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -437,7 +437,7 @@ public class ScriptLib {
      * Set the actions and triggers to designated group
      */
     public int RefreshGroup(LuaTable table) {
-        logger.debug("[LUA] Call RefreshGroup with {}",
+        logger.info("[LUA] Call RefreshGroup with {}",
             printTable(table));
         // Kill and Respawn?
         int groupId = table.get("group_id").toint();
@@ -1241,6 +1241,11 @@ public class ScriptLib {
         return dungeonManager.activateRespawnPoint(var1) ? 0:2;
     }
 
+    public int[] GetOpeningDungeonListByRosterId(int var1){
+        logger.warn("[LUA] Call unimplemented GetOpeningDungeonListByRosterId with {}", var1);
+        return new int[] {0,0};
+    }
+
     //TODO check
     public int SetWeatherAreaState(int var1, int var2){
         logger.warn("[LUA] Call unimplemented SetWeatherAreaState with {} {}", var1, var2);
@@ -1251,6 +1256,17 @@ public class ScriptLib {
     public int EnterWeatherArea(int var1){
         logger.warn("[LUA] Call unimplemented EnterWeatherArea with {}", var1);
         //TODO implement
+        return 0;
+    }
+
+    public int ModifyClimatePolygonParamTable(int var1, LuaTable var2){
+        logger.warn("[LUA] Call unimplemented ModifyClimatePolygonParamTable with {} {}", var1, printTable(var2));
+        //TODO implement
+        return 0;
+    }
+
+    public int SetEnvironmentEffectState(int var1, String var2, int[] var3, int[] var4){
+        logger.warn("[LUA] Call unimplemented SetEnvironmentEffectState with {} {} {} {}", var1, var2, var3, var4);
         return 0;
     }
 
@@ -1521,6 +1537,16 @@ public class ScriptLib {
         }
 
         return result;
+    }
+
+    public int GetRegionConfigId(LuaTable var1){
+        logger.warn("[LUA] Call untested GetRegionConfigId with {}", printTable(var1));
+        var EntityId = var1.get("region_eid").toint();
+        var entity = getSceneScriptManager().getScene().getScriptManager().getRegionById(EntityId);
+        if (entity == null){
+            return -1;
+        }
+        return entity.getConfigId();
     }
 
     public int GetGameHour(){


### PR DESCRIPTION
## Description
Various fixes for making the chasm questing go smoother.

Scene.java:
I have never seen a dynamic group get loaded. It seems that getScriptManager().getGroupInstanceById always returns true.
So instead, I removed the check for it so it always reloads the dynamic group if a quest calls for it.

SceneScriptManager.java cachedSceneGroupsInstances.put:
I was getting all kinds of nasty errors about missing lua files. I tracked it back to these cachedSceneGroupsInstances.put's that were not setting the lua scripts when caching groups. This probably fixes the missing suites problem we had earlier.

SceneScriptManager.java enterEntities and leaveEntities not being 19:
19 are gadgets. Some time ago we changed the region code so that it gets triggered by everything: monsters, avatars, gadgets, you name it. There were some problems where regions were being triggered early due to the region containing a gadget and there being no other checks in the lua to prevent the region from triggering. Form what we've seen, there's nowhere in the code specifically looking for gadgets triggering regions.

SceneScriptManager.java t.getName().length() <= 12:
This is prep for later when we add "require" scripts (require is the lua equivalent of C's #include). In those files, region triggers don't have numbers, so this new code keeps it from erroring out.

ScriptLib.java RefreshGroup:
RefreshGroup is slightly different than official. in official, it seems that RefreshGroup does not cause createEntity to fire, but in grasscutter, it simply kills and creates all the entities. This causes bugs, and I want to track them by changing debug to info.

ScriptLib.java GetOpeningDungeonListByRosterId ModifyClimatePolygonParamTable SetEnvironmentEffectState GetRegionConfigId:
New functions, 'nuff said.

## Issues fixed by this PR
Scene.java: 
When you first go down into the chasm, there's three diary pages you need to look for. They were not being loaded because they were a dynamic group.

SceneScriptManager.java cachedSceneGroupsInstances.put:
big floods of errors.

SceneScriptManager.java enterEntities and leaveEntities not being 19:
emergency food was getting pretty chatty and things were being triggered at distance due to the region containing gadgets. Specifically a big one was this parkour route that takes you up a rope bridge that was being triggered because the marker you were supposed to get close to was a gadget.

SceneScriptManager.java t.getName().length() <= 12:
Errors when adding the require code in later.

ScriptLib.java RefreshGroup:
There's an infinite loop involving RefreshGroup, and this will make it more clear.

ScriptLib.java GetOpeningDungeonListByRosterId ModifyClimatePolygonParamTable SetEnvironmentEffectState GetRegionConfigId:
New functions, 'nuff said.


<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
