### PR TITLE
fix: bullet state doesn't synchronize in mp mode

### DIFF
--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtBulletDeactiveNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtBulletDeactiveNotify.java
@@ -1,0 +1,16 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.EvtBulletDeactiveNotifyOuterClass;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketEvtBulletDeactiveNotify;
+
+@Opcodes(PacketOpcodes.EvtBulletDeactiveNotify)
+public class HandlerEvtBulletDeactiveNotify extends PacketHandler {
+    @Override
+    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+        session.getPlayer().getScene().broadcastPacketToOthers(session.getPlayer(), new PacketEvtBulletDeactiveNotify(EvtBulletDeactiveNotifyOuterClass.EvtBulletDeactiveNotify.parseFrom(payload)));
+    }
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtBulletHitNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtBulletHitNotify.java
@@ -1,0 +1,16 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.EvtBulletHitNotifyOuterClass;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketEvtBulletHitNotify;
+
+@Opcodes(PacketOpcodes.EvtBulletHitNotify)
+public class HandlerEvtBulletHitNotify extends PacketHandler {
+    @Override
+    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+        session.getPlayer().getScene().broadcastPacketToOthers(session.getPlayer(), new PacketEvtBulletHitNotify(EvtBulletHitNotifyOuterClass.EvtBulletHitNotify.parseFrom(payload)));
+    }
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtBulletMoveNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtBulletMoveNotify.java
@@ -1,0 +1,16 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.EvtBulletMoveNotifyOuterClass;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketEvtBulletMoveNotify;
+
+@Opcodes(PacketOpcodes.EvtBulletMoveNotify)
+public class HandlerEvtBulletMoveNotify extends PacketHandler {
+    @Override
+    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+        session.getPlayer().getScene().broadcastPacketToOthers(session.getPlayer(), new PacketEvtBulletMoveNotify(EvtBulletMoveNotifyOuterClass.EvtBulletMoveNotify.parseFrom(payload)));
+    }
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerMassiveEntityElementOpBatchNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerMassiveEntityElementOpBatchNotify.java
@@ -1,0 +1,16 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.MassiveEntityElementOpBatchNotifyOuterClass;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketMassiveEntityElementOpBatchNotify;
+
+@Opcodes(PacketOpcodes.MassiveEntityElementOpBatchNotify)
+public class HandlerMassiveEntityElementOpBatchNotify extends PacketHandler {
+    @Override
+    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+        session.getPlayer().getScene().broadcastPacketToOthers(session.getPlayer(), new PacketMassiveEntityElementOpBatchNotify(MassiveEntityElementOpBatchNotifyOuterClass.MassiveEntityElementOpBatchNotify.parseFrom(payload)));
+    }
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketEvtBulletDeactiveNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketEvtBulletDeactiveNotify.java
@@ -1,0 +1,13 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.EvtBulletDeactiveNotifyOuterClass;
+
+public class PacketEvtBulletDeactiveNotify extends BasePacket {
+    public PacketEvtBulletDeactiveNotify(EvtBulletDeactiveNotifyOuterClass.EvtBulletDeactiveNotify notify) {
+        super(PacketOpcodes.EvtBulletDeactiveNotify);
+
+        this.setData(EvtBulletDeactiveNotifyOuterClass.EvtBulletDeactiveNotify.newBuilder(notify));
+    }
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketEvtBulletHitNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketEvtBulletHitNotify.java
@@ -1,0 +1,13 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.EvtBulletHitNotifyOuterClass;
+
+public class PacketEvtBulletHitNotify extends BasePacket {
+    public PacketEvtBulletHitNotify(EvtBulletHitNotifyOuterClass.EvtBulletHitNotify notify) {
+        super(PacketOpcodes.EvtBulletHitNotify);
+
+        this.setData(EvtBulletHitNotifyOuterClass.EvtBulletHitNotify.newBuilder(notify));
+    }
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketEvtBulletMoveNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketEvtBulletMoveNotify.java
@@ -1,0 +1,13 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.EvtBulletMoveNotifyOuterClass;
+
+public class PacketEvtBulletMoveNotify extends BasePacket {
+    public PacketEvtBulletMoveNotify(EvtBulletMoveNotifyOuterClass.EvtBulletMoveNotify notify) {
+        super(PacketOpcodes.EvtBulletMoveNotify);
+
+        this.setData(EvtBulletMoveNotifyOuterClass.EvtBulletMoveNotify.newBuilder(notify));
+    }
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketMassiveEntityElementOpBatchNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketMassiveEntityElementOpBatchNotify.java
@@ -1,0 +1,13 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.MassiveEntityElementOpBatchNotifyOuterClass;
+
+public class PacketMassiveEntityElementOpBatchNotify extends BasePacket {
+    public PacketMassiveEntityElementOpBatchNotify(MassiveEntityElementOpBatchNotifyOuterClass.MassiveEntityElementOpBatchNotify notify) {
+        super(PacketOpcodes.MassiveEntityElementOpBatchNotify);
+
+        this.setData(MassiveEntityElementOpBatchNotifyOuterClass.MassiveEntityElementOpBatchNotify.newBuilder(notify));
+    }
+}


### PR DESCRIPTION
## Description

Fixes a bug:
- Bullet (e.g. tornado of traveller's skill) state does not synchronize in multiplayer mode.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.

https://github.com/Grasscutters/Grasscutter/assets/60880668/e3148aec-04c9-4b73-8add-36441ca1444d