### PR TITLE
fix: team avatar changes are not reflected

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/TeamManager.java
+++ b/src/main/java/emu/grasscutter/game/player/TeamManager.java
@@ -1,27 +1,42 @@
 package emu.grasscutter.game.player;
 
-import dev.morphia.annotations.*;
-import emu.grasscutter.*;
+import dev.morphia.annotations.Entity;
+import dev.morphia.annotations.Transient;
+import emu.grasscutter.GameConstants;
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.data.excels.avatar.AvatarSkillDepotData;
 import emu.grasscutter.game.avatar.Avatar;
-import emu.grasscutter.game.entity.*;
-import emu.grasscutter.game.props.*;
-import emu.grasscutter.game.world.*;
-import emu.grasscutter.net.packet.*;
-import emu.grasscutter.net.proto.*;
+import emu.grasscutter.game.entity.EntityAvatar;
+import emu.grasscutter.game.entity.EntityBaseGadget;
+import emu.grasscutter.game.entity.EntityTeam;
+import emu.grasscutter.game.props.ElementType;
+import emu.grasscutter.game.props.EnterReason;
+import emu.grasscutter.game.props.FightProperty;
+import emu.grasscutter.game.world.Position;
+import emu.grasscutter.game.world.Scene;
+import emu.grasscutter.game.world.World;
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.AbilityControlBlockOuterClass;
+import emu.grasscutter.net.proto.AbilityEmbryoOuterClass;
 import emu.grasscutter.net.proto.EnterTypeOuterClass.EnterType;
 import emu.grasscutter.net.proto.MotionStateOuterClass.MotionState;
 import emu.grasscutter.net.proto.PlayerDieTypeOuterClass.PlayerDieType;
 import emu.grasscutter.net.proto.RetcodeOuterClass.Retcode;
 import emu.grasscutter.net.proto.TrialAvatarGrantRecordOuterClass.TrialAvatarGrantRecord.GrantReason;
+import emu.grasscutter.net.proto.VisionTypeOuterClass;
 import emu.grasscutter.server.event.entity.EntityCreationEvent;
 import emu.grasscutter.server.event.player.PlayerTeamDeathEvent;
 import emu.grasscutter.server.packet.send.*;
 import emu.grasscutter.utils.Utils;
-import it.unimi.dsi.fastutil.ints.*;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
-import lombok.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.val;
 
 import java.util.*;
 import java.util.stream.Stream;
@@ -352,8 +367,8 @@ public final class TeamManager extends BasePlayerDataManager {
     /** Updates all properties of the active team. */
     public void updateTeamProperties() {
         this.updateTeamResonances(); // Update team resonances.
-        this.getPlayer()
-                .sendPacket(new PacketSceneTeamUpdateNotify(this.getPlayer())); // Notify the player.
+        this.getWorld()
+                .broadcastPacket(new PacketSceneTeamUpdateNotify(this.getPlayer())); // Notify the all players in the world.
 
         // Skill charges packet - Yes, this is official server behavior as of 2.6.0
         this.getActiveTeam().stream()


### PR DESCRIPTION
## Description

Fixes a bug:
- when the player changed team avatars, it is not reflected.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.

https://github.com/Grasscutters/Grasscutter/assets/60880668/67088520-2e6c-4e04-b474-2bd232d3cde9

