### PR TITLE
fix: redundant packet 'PacketTakeAchievementRewardReq' in login req

### DIFF
--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerPlayerLoginReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerPlayerLoginReq.java
@@ -9,7 +9,6 @@ import emu.grasscutter.net.proto.PlayerLoginReqOuterClass.PlayerLoginReq;
 import emu.grasscutter.server.game.GameSession;
 import emu.grasscutter.server.game.GameSession.SessionState;
 import emu.grasscutter.server.packet.send.PacketPlayerLoginRsp;
-import emu.grasscutter.server.packet.send.PacketTakeAchievementRewardReq;
 
 @Opcodes(PacketOpcodes.PlayerLoginReq) // Sends initial data packets
 public class HandlerPlayerLoginReq extends PacketHandler {
@@ -46,6 +45,5 @@ public class HandlerPlayerLoginReq extends PacketHandler {
 
         // Final packet to tell client logging in is done
         session.send(new PacketPlayerLoginRsp(session));
-        session.send(new PacketTakeAchievementRewardReq(session));
     }
 }


### PR DESCRIPTION
## Description

it makes no sense that server sends this packet.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
