### PR TITLE
fix: sync home avatar costume

### DIFF
--- a/src/main/java/emu/grasscutter/game/avatar/AvatarStorage.java
+++ b/src/main/java/emu/grasscutter/game/avatar/AvatarStorage.java
@@ -1,17 +1,23 @@
 package emu.grasscutter.game.avatar;
 
 import emu.grasscutter.data.GameData;
-import emu.grasscutter.data.excels.avatar.*;
+import emu.grasscutter.data.excels.avatar.AvatarData;
+import emu.grasscutter.data.excels.avatar.AvatarSkillDepotData;
 import emu.grasscutter.database.DatabaseHelper;
 import emu.grasscutter.game.entity.EntityAvatar;
 import emu.grasscutter.game.inventory.GameItem;
-import emu.grasscutter.game.player.*;
+import emu.grasscutter.game.player.BasePlayerManager;
+import emu.grasscutter.game.player.Player;
 import emu.grasscutter.server.event.entity.EntityCreationEvent;
-import emu.grasscutter.server.packet.send.*;
-import it.unimi.dsi.fastutil.ints.*;
-import it.unimi.dsi.fastutil.longs.*;
+import emu.grasscutter.server.packet.send.PacketAvatarChangeCostumeNotify;
+import emu.grasscutter.server.packet.send.PacketAvatarFlycloakChangeNotify;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.List;
 
 public class AvatarStorage extends BasePlayerManager implements Iterable<Avatar> {
     private final Int2ObjectMap<Avatar> avatars;
@@ -114,10 +120,13 @@ public class AvatarStorage extends BasePlayerManager implements Iterable<Avatar>
             entity =
                     EntityCreationEvent.call(
                             EntityAvatar.class, new Class<?>[] {Avatar.class}, new Object[] {avatar});
-            getPlayer().sendPacket(new PacketAvatarChangeCostumeNotify(entity));
+            getPlayer().getWorld().broadcastPacket(new PacketAvatarChangeCostumeNotify(entity));
         } else {
-            getPlayer().getScene().broadcastPacket(new PacketAvatarChangeCostumeNotify(entity));
+            getPlayer().getWorld().broadcastPacket(new PacketAvatarChangeCostumeNotify(entity));
         }
+
+        // Notify costume change to HomeWorld
+        this.getPlayer().getHome().onPlayerChangedAvatarCostume(avatar);
 
         // Done
         return true;

--- a/src/main/java/emu/grasscutter/game/home/HomeNPCItem.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeNPCItem.java
@@ -3,8 +3,12 @@ package emu.grasscutter.game.home;
 import dev.morphia.annotations.Entity;
 import emu.grasscutter.data.GameData;
 import emu.grasscutter.game.world.Position;
-import emu.grasscutter.net.proto.*;
-import lombok.*;
+import emu.grasscutter.net.proto.HomeMarkPointFurnitureDataOuterClass;
+import emu.grasscutter.net.proto.HomeMarkPointNPCDataOuterClass;
+import emu.grasscutter.net.proto.HomeNpcDataOuterClass;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
 import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.Nullable;
 
@@ -24,7 +28,6 @@ public class HomeNPCItem implements HomeMarkPointProtoFactory {
             .avatarId(homeNpcData.getAvatarId())
             .spawnPos(new Position(homeNpcData.getSpawnPos()))
             .spawnRot(new Position(homeNpcData.getSpawnRot()))
-            .costumeId(homeNpcData.getCostumeId())
             .build();
     }
 

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketHomeAvatarCostumeChangeNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketHomeAvatarCostumeChangeNotify.java
@@ -1,0 +1,15 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.BasePacket;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.HomeAvatarCostumeChangeNotifyOuterClass;
+
+public class PacketHomeAvatarCostumeChangeNotify extends BasePacket {
+    public PacketHomeAvatarCostumeChangeNotify(int avatarId, int costumeId) {
+        super(PacketOpcodes.HomeAvatarCostumeChangeNotify);
+
+        this.setData(HomeAvatarCostumeChangeNotifyOuterClass.HomeAvatarCostumeChangeNotify.newBuilder()
+            .setAvatarId(avatarId)
+            .setCostumeId(costumeId));
+    }
+}


### PR DESCRIPTION
## Description

fixes bug that changes of avatar costume are not reflected in home world.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.

https://github.com/Grasscutters/Grasscutter/assets/60880668/e5d19b30-89fa-4b59-afea-1af87d30f9ce

