### PR TITLE
Fix home nulls

### DIFF
--- a/src/main/java/emu/grasscutter/game/home/HomeModuleManager.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeModuleManager.java
@@ -41,12 +41,20 @@ public class HomeModuleManager {
     }
 
     public void tick() {
+        if (this.moduleId == 0) {
+            return;
+        }
+
         this.outdoor.onTick();
         this.indoor.onTick();
         this.summonEvents.removeIf(HomeAvatarSummonEvent::isTimeOver);
     }
 
     public void refreshMainHouse() {
+        if (this.moduleId == 0) {
+            return;
+        }
+
         this.indoor = this.homeWorld.getSceneById(this.homeWorld.getActiveIndoorSceneId());
     }
 
@@ -67,6 +75,7 @@ public class HomeModuleManager {
         var suites =
                 allBlockItems.stream()
                         .map(HomeBlockItem::getSuiteList)
+                        .filter(Objects::nonNull)
                         .flatMap(Collection::stream)
                         .distinct()
                         .toList();
@@ -210,6 +219,10 @@ public class HomeModuleManager {
     }
 
     public void onSetModule() {
+        if (this.moduleId == 0) {
+            return;
+        }
+
         this.outdoor.addEntities(this.getOutdoorSceneItem().getAnimals(this.outdoor));
         this.indoor.addEntities(this.getIndoorSceneItem().getAnimals(this.indoor));
         this.fireAllAvatarRewardEvent();

--- a/src/main/java/emu/grasscutter/game/home/HomeWorld.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeWorld.java
@@ -29,6 +29,9 @@ public class HomeWorld extends World {
 
     @Override
     public boolean onTick() {
+        if (this.moduleManager == null) {
+            return false;
+        }
         this.moduleManager.tick();
 
         if (this.getTickCount() % 10 == 0) {


### PR DESCRIPTION
## Description

Fixes nulls causing account loading failure (particularly new ones) when trying to tick HomeModuleManager, as well as nulls when loading some older accounts.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
