### PR TITLE
fix: home worlds are ticked twice

### DIFF
--- a/src/main/java/emu/grasscutter/game/home/HomeWorld.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeWorld.java
@@ -23,8 +23,8 @@ public class HomeWorld extends World {
         super(server, owner);
 
         this.home = owner.isOnline() ? owner.getHome() : GameHome.getByUid(owner.getUid());
-        server.registerHomeWorld(this);
         this.refreshModuleManager();
+        server.registerHomeWorld(this);
     }
 
     @Override

--- a/src/main/java/emu/grasscutter/server/game/GameServer.java
+++ b/src/main/java/emu/grasscutter/server/game/GameServer.java
@@ -288,11 +288,8 @@ public final class GameServer extends KcpServer implements Iterable<Player> {
     public synchronized void onTick() {
         var tickStart = Instant.now();
 
-        // Tick worlds.
+        // Tick worlds and home worlds.
         this.worlds.removeIf(World::onTick);
-
-        // Tick Home Worlds (Not remove, HomeWorld is constant).
-        this.homeWorlds.values().forEach(HomeWorld::onTick);
 
         // Tick players.
         this.players.values().forEach(Player::onTick);


### PR DESCRIPTION
## Description

fixes:
- the server ticks home worlds twice.


## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
