### PR TITLE
Fixes for alchemy dude's quest part 2

### DIFF
--- a/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityGadget.java
@@ -256,6 +256,9 @@ public class EntityGadget extends EntityBaseGadget {
             var route = this.getScene().getSceneRouteById(configRoute.getRouteId());
             if (route != null) {
                 var points = route.getPoints();
+                if (configRoute.getStartIndex() == points.length - 1) {
+                    configRoute.setStartIndex(0);
+                }
                 val currIndex = configRoute.getStartIndex();
 
                 Position prevpos;
@@ -301,6 +304,9 @@ public class EntityGadget extends EntityBaseGadget {
                                                         }
                                                         configRoute.setStartIndex(I);
                                                         this.position.set(points[I].getPos());
+                                                        if(I == points.length - 1) {
+                                                            configRoute.setStarted(false);
+                                                        }
                                                     },
                                                     (int) time));
                 }

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -1180,7 +1180,7 @@ public class SceneScriptManager {
 
         Grasscutter.getLogger()
                 .warn("trying to cancel a timer that's not active {} {}", groupID, source);
-        return 1;
+        return 0;
     }
 
     // todo use killed monsters instead of spawned entites for check?

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -1330,9 +1330,8 @@ public class ScriptLib {
         return -1;
     }
 
-    //TODO check
     public int SetPlatformRouteId(int entityConfigId, int routeId){
-        logger.info("[LUA] Call SetPlatformRouteId {} {}", entityConfigId, routeId);
+        logger.debug("[LUA] Call SetPlatformRouteId {} {}", entityConfigId, routeId);
 
         val entity = getSceneScriptManager().getScene().getEntityByConfigId(entityConfigId);
         if(entity == null){
@@ -1365,12 +1364,9 @@ public class ScriptLib {
         return 0;
     }
 
-    //TODO check
     public int StartPlatform(int configId){
         logger.debug("[LUA] Call StartPlatform {} ", configId);
-
         val entity = sceneScriptManager.get().getScene().getEntityByConfigId(configId);
-
         if(!(entity instanceof EntityGadget entityGadget)) {
             return 1;
         }
@@ -1378,9 +1374,8 @@ public class ScriptLib {
         return entityGadget.startPlatform() ? 0 : 2;
     }
 
-    //TODO check
     public int StopPlatform(int configId){
-        logger.info("[LUA] Call StopPlatform {} ", configId);
+        logger.debug("[LUA] Call StopPlatform {} ", configId);
         val entity = sceneScriptManager.get().getScene().getEntityByConfigId(configId);
         if(!(entity instanceof EntityGadget entityGadget)) {
             return 1;

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerClientScriptEventNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerClientScriptEventNotify.java
@@ -1,0 +1,47 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.Grasscutter;
+import emu.grasscutter.net.packet.Opcodes;
+import emu.grasscutter.net.packet.PacketHandler;
+import emu.grasscutter.net.packet.PacketOpcodes;
+import emu.grasscutter.net.proto.ClientScriptEventNotifyOuterClass.ClientScriptEventNotify;
+import emu.grasscutter.scripts.constants.EventType;
+import emu.grasscutter.scripts.data.ScriptArgs;
+import emu.grasscutter.server.game.GameSession;
+import lombok.val;
+
+@Opcodes(PacketOpcodes.ClientScriptEventNotify)
+public class HandlerClientScriptEventNotify extends PacketHandler {
+
+    @Override
+    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+        val data = ClientScriptEventNotify.parseFrom(payload);
+        val scriptManager = session.getPlayer().getScene().getScriptManager();
+        val args = new ScriptArgs(0, data.getEventType())
+                .setSourceEntityId(data.getSourceEntityId())
+                .setTargetEntityId(data.getTargetEntityId());
+
+        for (int i = 0; i < data.getParamListCount(); i++) {
+            switch (i) {
+                case 0 -> args.setParam1(data.getParamList(i));
+                case 1 -> args.setParam2(data.getParamList(i));
+                case 2 -> args.setParam3(data.getParamList(i));
+            }
+        }
+
+        if(data.getEventType() == EventType.EVENT_AVATAR_NEAR_PLATFORM){
+            if(data.getParamList(0) == 0) {
+                Grasscutter.getLogger().debug("Found a zero Param1 for an EVENT_AVATAR_NEAR_PLATFORM. Doing the configID workaround.");
+                val entity = session.getPlayer().getScene().getEntityById(data.getSourceEntityId());
+                if(entity == null) {
+                    Grasscutter.getLogger().debug("But it failed.");
+                } else {
+                    args.setParam1(entity.getConfigId());
+                }
+            }
+        }
+
+        scriptManager.callEvent(args);
+    }
+
+}


### PR DESCRIPTION
## Description
[Make platforms able to reset](https://github.com/Grasscutters/Grasscutter/commit/21ac77685ce3c58923f959458cd53deed1d69bd8): First part of the puzzle. 
A seelie goes around some torches when you get near to the seelie. You can trigger the seelie again after it has made a circuit. It also seems to cancel a timer on the torches before lighting them again. Logically you ought to be able to do that without bailing the function early.

[Fix Seelies](https://github.com/Grasscutters/Grasscutter/commit/1ed7c94585df4327ff0aa73d16508369a29fdfad): Second part of the puzzle.
Implemented HandlerClientScriptEventNotify which is the source for EVENT_AVATAR_NEAR_PLATFORM. Shoutout to @Hartie95 for the code. I took the opportunity to also quiet down the platform functions. They should mostly be good to go now.


## Issues fixed by this PR
Minor technical things that didn't work in the puzzle in alchemy dude's quest.

SEELIES WORK! WOO HOO!

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
