### PR TITLE
fix: HomeModuleManager isnt ticked unless player changes module

### DIFF
--- a/src/main/java/emu/grasscutter/game/home/HomeModuleManager.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeModuleManager.java
@@ -59,11 +59,11 @@ public class HomeModuleManager {
     }
 
     public void onUpdateArrangement() {
-        this.fireAllAvatarRewardEvent();
-        this.cancelSummonEventIfAvatarLeave();
+        this.fireAllAvatarRewardEvents();
+        this.cancelSummonEventsIfAvatarLeave();
     }
 
-    private void fireAllAvatarRewardEvent() {
+    private void fireAllAvatarRewardEvents() {
         this.rewardEvents.clear();
         var allBlockItems =
                 Stream.of(this.getOutdoorSceneItem(), this.getIndoorSceneItem())
@@ -111,7 +111,7 @@ public class HomeModuleManager {
         }
     }
 
-    private void cancelSummonEventIfAvatarLeave() {
+    private void cancelSummonEventsIfAvatarLeave() {
         var avatars =
                 Stream.of(this.getOutdoorSceneItem(), this.getIndoorSceneItem())
                         .map(HomeSceneItem::getBlockItems)
@@ -225,10 +225,14 @@ public class HomeModuleManager {
 
         this.outdoor.addEntities(this.getOutdoorSceneItem().getAnimals(this.outdoor));
         this.indoor.addEntities(this.getIndoorSceneItem().getAnimals(this.indoor));
-        this.fireAllAvatarRewardEvent();
+        this.fireAllAvatarRewardEvents();
     }
 
     public void onRemovedModule() {
+        if (this.moduleId == 0) {
+            return;
+        }
+
         this.outdoor.getEntities().clear();
         this.indoor.getEntities().clear();
     }

--- a/src/main/java/emu/grasscutter/game/home/HomeWorld.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeWorld.java
@@ -11,13 +11,15 @@ import emu.grasscutter.server.game.GameServer;
 import emu.grasscutter.server.packet.send.PacketDelTeamEntityNotify;
 import emu.grasscutter.server.packet.send.PacketPlayerChatNotify;
 import emu.grasscutter.server.packet.send.PacketPlayerGameTimeNotify;
-import java.util.List;
-import java.util.function.Consumer;
 import lombok.Getter;
 
+import java.util.List;
+import java.util.function.Consumer;
+
+@Getter
 public class HomeWorld extends World {
-    @Getter private final GameHome home;
-    @Getter private HomeModuleManager moduleManager;
+    private final GameHome home;
+    private HomeModuleManager moduleManager;
 
     public HomeWorld(GameServer server, Player owner) {
         super(server, owner);
@@ -60,7 +62,11 @@ public class HomeWorld extends World {
     }
 
     public int getActiveIndoorSceneId() {
-        return this.getSceneById(this.getActiveOutdoorSceneId()).getSceneItem().getRoomSceneId();
+        return this.isRealmIdValid() ? this.getSceneById(this.getActiveOutdoorSceneId()).getSceneItem().getRoomSceneId() : -1;
+    }
+
+    public boolean isRealmIdValid() {
+        return this.getHost().getCurrentRealmId() > 0;
     }
 
     @Override

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeChooseModuleReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerHomeChooseModuleReq.java
@@ -14,6 +14,7 @@ public class HandlerHomeChooseModuleReq extends PacketHandler {
                 HomeChooseModuleReqOuterClass.HomeChooseModuleReq.parseFrom(payload);
         session.getPlayer().addRealmList(req.getModuleId());
         session.getPlayer().setCurrentRealmId(req.getModuleId());
+        session.getPlayer().getCurHomeWorld().refreshModuleManager();
         session.send(new PacketHomeChooseModuleRsp(req.getModuleId()));
         session.send(new PacketPlayerHomeCompInfoNotify(session.getPlayer()));
         session.send(new PacketHomeComfortInfoNotify(session.getPlayer()));


### PR DESCRIPTION
## Description

fixes a bug:
- HomeModuleManager is not ticked cuz moduleId keeps being 0 when a player first enters teapot.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
