### PR TITLE
Implement passJumpDungeon.

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/EnterDungeonCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/EnterDungeonCommand.java
@@ -33,7 +33,7 @@ public final class EnterDungeonCommand implements CommandHandler {
                     targetPlayer
                             .getServer()
                             .getDungeonSystem()
-                            .enterDungeon(targetPlayer.getSession().getPlayer(), 0, dungeonId);
+                            .enterDungeon(targetPlayer.getSession().getPlayer(), 0, dungeonId, true);
 
             if (!result) {
                 CommandHandler.sendMessage(

--- a/src/main/java/emu/grasscutter/data/excels/dungeon/DungeonData.java
+++ b/src/main/java/emu/grasscutter/data/excels/dungeon/DungeonData.java
@@ -22,6 +22,7 @@ public class DungeonData extends GameResource {
     private DungeonInvolveType involveType;
     @Getter private int limitLevel;
     @Getter private int passCond;
+    @Getter private int passJumpDungeon;
     @Getter private int reviveMaxCount;
     @Getter private int settleCountdownTime;
     @Getter private int failSettleCountdownTime;

--- a/src/main/java/emu/grasscutter/game/activity/trialavatar/TrialAvatarActivityHandler.java
+++ b/src/main/java/emu/grasscutter/game/activity/trialavatar/TrialAvatarActivityHandler.java
@@ -80,7 +80,7 @@ public class TrialAvatarActivityHandler extends ActivityHandler {
         if (!player
                 .getServer()
                 .getDungeonSystem()
-                .enterDungeon(player, enterPointId, getTrialActivityDungeonId(trialAvatarIndexId)))
+                .enterDungeon(player, enterPointId, getTrialActivityDungeonId(trialAvatarIndexId), true))
             return false;
 
         setSelectedTrialAvatarIndex(trialAvatarIndexId);

--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
@@ -282,6 +282,13 @@ public final class DungeonManager {
 
         // Call PlayerFinishDungeonEvent.
         new PlayerFinishDungeonEvent(this.getScene().getPlayers(), this.getScene(), this).call();
+
+        // jump players to next dungeon if available
+        if (this.dungeonData.getPassJumpDungeon() != 0) {
+            for (var player : this.getScene().getPlayers()) {
+                player.getServer().getDungeonSystem().enterDungeon(player, 0, this.dungeonData.getPassJumpDungeon(), false);
+            }
+        }
     }
 
     public void quitDungeon() {

--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonSystem.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonSystem.java
@@ -88,7 +88,7 @@ public final class DungeonSystem extends BaseGameSystem {
         return handler.execute(condition, params);
     }
 
-    public boolean enterDungeon(Player player, int pointId, int dungeonId) {
+    public boolean enterDungeon(Player player, int pointId, int dungeonId, boolean savePrevious) {
         DungeonData data = GameData.getDungeonDataMap().get(dungeonId);
 
         if (data == null) {
@@ -103,7 +103,7 @@ public final class DungeonSystem extends BaseGameSystem {
 
         var sceneId = data.getSceneId();
         var scene = player.getScene();
-        scene.setPrevScene(sceneId);
+        if (savePrevious) scene.setPrevScene(scene.getId());
 
         if (player.getWorld().transferPlayerToScene(player, sceneId, data)) {
             scene = player.getScene();
@@ -111,7 +111,7 @@ public final class DungeonSystem extends BaseGameSystem {
             scene.addDungeonSettleObserver(basicDungeonSettleObserver);
         }
 
-        scene.setPrevScenePoint(pointId);
+        if (savePrevious) scene.setPrevScenePoint(pointId);
         return true;
     }
 

--- a/src/main/java/emu/grasscutter/game/world/World.java
+++ b/src/main/java/emu/grasscutter/game/world/World.java
@@ -439,7 +439,7 @@ public class World implements Iterable<Player> {
         }
 
         if (oldScene != null && newScene != oldScene) {
-            newScene.setPrevScene(oldScene.getId());
+            newScene.setPrevScenePoint(oldScene.getPrevScenePoint());
             oldScene.setDontDestroyWhenEmpty(false);
         }
 

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerPlayerEnterDungeonReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerPlayerEnterDungeonReq.java
@@ -17,7 +17,7 @@ public class HandlerPlayerEnterDungeonReq extends PacketHandler {
                 session
                         .getServer()
                         .getDungeonSystem()
-                        .enterDungeon(session.getPlayer(), req.getPointId(), req.getDungeonId());
+                        .enterDungeon(session.getPlayer(), req.getPointId(), req.getDungeonId(), true);
         session
                 .getPlayer()
                 .sendPacket(new PacketPlayerEnterDungeonRsp(req.getPointId(), req.getDungeonId(), success));


### PR DESCRIPTION
## Description
Implement passJumpDungeon. 
Make dungeons kick you out to the correct scene.

## Issues fixed by this PR
Bunny girl's dungeon now sends you to the second part.
in chapter 3 the main quest involving a boat of thought ought to send you to the next dungeon, but I haven't gotten that far yet.
If the second dragon fight was less broken, it'd send you to the second part of that dungeon too.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
