### PR TITLE
Fix freeze on startup

### DIFF
--- a/src/main/java/emu/grasscutter/Grasscutter.java
+++ b/src/main/java/emu/grasscutter/Grasscutter.java
@@ -158,7 +158,7 @@ public final class Grasscutter {
 
             // Generate handbooks.
             Tools.createGmHandbooks(false);
-
+            // Generate gacha mappings.
             Tools.generateGachaMappings();
         }
 

--- a/src/main/java/emu/grasscutter/Grasscutter.java
+++ b/src/main/java/emu/grasscutter/Grasscutter.java
@@ -158,6 +158,8 @@ public final class Grasscutter {
 
             // Generate handbooks.
             Tools.createGmHandbooks(false);
+
+            Tools.generateGachaMappings();
         }
 
         // Start servers.

--- a/src/main/java/emu/grasscutter/data/DataLoader.java
+++ b/src/main/java/emu/grasscutter/data/DataLoader.java
@@ -114,8 +114,6 @@ public class DataLoader {
         } catch (Exception e) {
             Grasscutter.getLogger().error("An error occurred while trying to check the data folder.", e);
         }
-
-        generateGachaMappings();
     }
 
     private static void checkAndCopyData(String name) {
@@ -129,18 +127,6 @@ public class DataLoader {
 
             Grasscutter.getLogger().debug("Creating default '" + name + "' data");
             FileUtils.copyResource("/defaults/data/" + name, filePath.toString());
-        }
-    }
-
-    private static void generateGachaMappings() {
-        var path = GachaHandler.getGachaMappingsPath();
-        if (!Files.exists(path)) {
-            try {
-                Grasscutter.getLogger().debug("Creating default '" + path + "' data");
-                Tools.createGachaMappings(path);
-            } catch (Exception exception) {
-                Grasscutter.getLogger().warn("Failed to create gacha mappings. \n" + exception);
-            }
         }
     }
 }

--- a/src/main/java/emu/grasscutter/tools/Tools.java
+++ b/src/main/java/emu/grasscutter/tools/Tools.java
@@ -10,6 +10,7 @@ import emu.grasscutter.data.common.ItemUseData;
 import emu.grasscutter.data.excels.*;
 import emu.grasscutter.data.excels.achievement.AchievementData;
 import emu.grasscutter.data.excels.avatar.AvatarData;
+import emu.grasscutter.server.http.handlers.GachaHandler;
 import emu.grasscutter.utils.*;
 import emu.grasscutter.utils.lang.Language;
 import emu.grasscutter.utils.lang.Language.TextStrings;
@@ -311,8 +312,20 @@ public final class Tools {
         return sbs.stream().map(StringBuilder::toString).toList();
     }
 
+    public static void generateGachaMappings() {
+        var path = GachaHandler.getGachaMappingsPath();
+        if (!Files.exists(path)) {
+            try {
+                Grasscutter.getLogger().debug("Creating default '" + path + "' data");
+                Tools.createGachaMappings(path);
+            } catch (Exception exception) {
+                Grasscutter.getLogger().warn("Failed to create gacha mappings. \n" + exception);
+            }
+        }
+    }
+
     public static void createGachaMappings(Path location) throws IOException {
-        ResourceLoader.loadResources();
+        // ResourceLoader.loadResources();
         List<String> jsons = createGachaMappingJsons();
         var usedLocales = new HashSet<String>();
         StringBuilder sb = new StringBuilder("mappings = {\n");

--- a/src/main/java/emu/grasscutter/tools/Tools.java
+++ b/src/main/java/emu/grasscutter/tools/Tools.java
@@ -325,7 +325,6 @@ public final class Tools {
     }
 
     public static void createGachaMappings(Path location) throws IOException {
-        // ResourceLoader.loadResources();
         List<String> jsons = createGachaMappingJsons();
         var usedLocales = new HashSet<String>();
         StringBuilder sb = new StringBuilder("mappings = {\n");


### PR DESCRIPTION
## Description

On some devices, after starting the server and displaying ‘Loading Grasscutter’, there is no further action. The CPU usage is shown as 0% in the task manager.

By adding logs, I found that `ResourceLoader.loadResources()` will be executed during static loading, and all resources will be loaded simultaneously using `parallel()`.

The specific calling path is: `Grasscutter static init` -> `Utils.startupCheck()` -> `DataLoader.checkAllFiles()` -> `generateGachaMappings()` -> `Tools.createGachaMappings(path)` -> `ResourceLoader.loadResources()` -> `parallel()` -> Freeze.

![Freeze screenshot](https://github.com/Grasscutters/Grasscutter/assets/29452349/ebed3943-af8a-464c-91bc-36ac5cd978bf)

If parallelism is removed,  it can be loaded normally, so I wonder if the thread pool has not been started during static initialization? Causes the parallel method to not continue?

![Sync load](https://github.com/Grasscutters/Grasscutter/assets/29452349/5e9c6e71-8a4b-4a7c-9e67-41fc27e45510)

Therefore, I adjusted the loading order, placed the generation logic after resource loading, and deleted the resource loading step during generation.

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
