### PR TITLE
`tp` to move directly in the same scene

### DIFF
--- a/src/main/java/emu/grasscutter/game/world/World.java
+++ b/src/main/java/emu/grasscutter/game/world/World.java
@@ -385,7 +385,7 @@ public class World implements Iterable<Player> {
 
         // Call player teleport event.
         PlayerTeleportEvent event =
-                new PlayerTeleportEvent(player, teleportProperties, player.getPosition());
+            new PlayerTeleportEvent(player, teleportProperties, player.getPosition());
         // Call event and check if it was canceled.
         event.call();
         if (event.isCanceled()) {
@@ -396,39 +396,53 @@ public class World implements Iterable<Player> {
             return false;
         }
 
-        Scene oldScene = null;
-        if (player.getScene() != null) {
-            oldScene = player.getScene();
+        Scene oldScene = player.getScene();
+        var newScene = this.getSceneById(teleportProperties.getSceneId());
 
+        // Move directly in the same scene.
+        if (newScene == oldScene && teleportProperties.getTeleportType() == TeleportType.COMMAND) {
+            // Set player position and rotation
+            if (teleportProperties.getTeleportTo() != null) {
+                player.getPosition().set(teleportProperties.getTeleportTo());
+            }
+            if (teleportProperties.getTeleportRot() != null) {
+                player.getRotation().set(teleportProperties.getTeleportRot());
+            }
+            player.sendPacket(new PacketSceneEntityAppearNotify(player));
+            return true;
+        }
+
+        if (oldScene != null) {
             // Don't deregister scenes if the player is going to tp back into them
-            if (oldScene.getId() == teleportProperties.getSceneId()) {
+            if (oldScene == newScene) {
                 oldScene.setDontDestroyWhenEmpty(true);
             }
-
             oldScene.removePlayer(player);
         }
 
-        var newScene = this.getSceneById(teleportProperties.getSceneId());
-        newScene.addPlayer(player);
+        if (newScene != null) {
+            newScene.addPlayer(player);
 
-        player.getTeamManager().applyAbilities(newScene);
+            player.getTeamManager().applyAbilities(newScene);
 
-        // Dungeon
-        // Dungeon system is handling this already
-        // if(dungeonData!=null){
-        //     var dungeonManager = new DungeonManager(newScene, dungeonData);
-        //     dungeonManager.startDungeon();
-        // }
+            // Dungeon
+            // Dungeon system is handling this already
+            // if(dungeonData!=null){
+            //     var dungeonManager = new DungeonManager(newScene, dungeonData);
+            //     dungeonManager.startDungeon();
+            // }
 
-        SceneConfig config = newScene.getScriptManager().getConfig();
-        if (teleportProperties.getTeleportTo() == null && config != null) {
-            if (config.born_pos != null) {
-                teleportProperties.setTeleportTo(config.born_pos);
-            }
-            if (config.born_rot != null) {
-                teleportProperties.setTeleportRot(config.born_rot);
+            SceneConfig config = newScene.getScriptManager().getConfig();
+            if (teleportProperties.getTeleportTo() == null && config != null) {
+                if (config.born_pos != null) {
+                    teleportProperties.setTeleportTo(config.born_pos);
+                }
+                if (config.born_rot != null) {
+                    teleportProperties.setTeleportRot(config.born_rot);
+                }
             }
         }
+
 
         // Set player position and rotation
         if (teleportProperties.getTeleportTo() != null) {
@@ -438,7 +452,7 @@ public class World implements Iterable<Player> {
             player.getRotation().set(teleportProperties.getTeleportRot());
         }
 
-        if (oldScene != null && newScene != oldScene) {
+        if (oldScene != null && newScene != null && newScene != oldScene) {
             newScene.setPrevScenePoint(oldScene.getPrevScenePoint());
             oldScene.setDontDestroyWhenEmpty(false);
         }
@@ -447,7 +461,7 @@ public class World implements Iterable<Player> {
         player.sendPacket(new PacketPlayerEnterSceneNotify(player, teleportProperties));
 
         if (teleportProperties.getTeleportType() != TeleportType.INTERNAL
-                && teleportProperties.getTeleportType() != SCRIPT) {
+            && teleportProperties.getTeleportType() != SCRIPT) {
             player.getQuestManager().queueEvent(QuestContent.QUEST_CONTENT_ANY_MANUAL_TRANSPORT);
         }
 


### PR DESCRIPTION
## Description

Using command transfer in the same scene will directly change the position to avoid reloading.

## Type of changes

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.