### PR TITLE
fix: login too slow due to recursive update of HomeWorld Map

### DIFF
--- a/src/main/java/emu/grasscutter/game/home/HomeWorld.java
+++ b/src/main/java/emu/grasscutter/game/home/HomeWorld.java
@@ -25,7 +25,6 @@ public class HomeWorld extends World {
 
         this.home = owner.isOnline() ? owner.getHome() : GameHome.getByUid(owner.getUid());
         this.refreshModuleManager();
-        server.registerHomeWorld(this);
     }
 
     @Override

--- a/src/main/java/emu/grasscutter/game/world/World.java
+++ b/src/main/java/emu/grasscutter/game/world/World.java
@@ -72,6 +72,8 @@ public class World implements Iterable<Player> {
         this.scenes = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
         this.entity = new EntityWorld(this);
         this.lastUpdateTime = System.currentTimeMillis();
+
+        server.registerWorld(this);
     }
 
     public int getLevelEntityId() {

--- a/src/main/java/emu/grasscutter/server/game/GameServer.java
+++ b/src/main/java/emu/grasscutter/server/game/GameServer.java
@@ -311,11 +311,6 @@ public final class GameServer extends KcpServer implements Iterable<Player> {
         world.save(); // Save the player's world
     }
 
-    public void registerHomeWorld(HomeWorld homeWorld) {
-        this.getHomeWorlds().put(homeWorld.getOwnerUid(), homeWorld);
-        this.registerWorld(homeWorld);
-    }
-
     public HomeWorld getHomeWorldOrCreate(Player owner) {
         return this.getHomeWorlds()
                 .computeIfAbsent(owner.getUid(), (uid) -> new HomeWorld(this, owner));


### PR DESCRIPTION
## Description

fixes a bug:
- Logging in is too slow due to recursive update of HomeWorlds.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
