### PR TITLE
Send QUEST_COND_NONE on every login

### DIFF
--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -1378,14 +1378,6 @@ public class Player implements PlayerHook, FieldFetch {
         this.getPlayerProgress().setPlayer(this); // Add reference to the player.
     }
 
-    /**
-     * Invoked when the player selects their avatar.
-     */
-    public void onPlayerBorn() {
-        Grasscutter.getThreadPool().submit(
-            this.getQuestManager()::onPlayerBorn);
-    }
-
     public void onLogin() {
         // Quest - Commented out because a problem is caused if you log out while this quest is active
         /*

--- a/src/main/java/emu/grasscutter/game/quest/QuestManager.java
+++ b/src/main/java/emu/grasscutter/game/quest/QuestManager.java
@@ -221,14 +221,11 @@ public final class QuestManager extends BasePlayerManager {
         this.player.sendPacket(new PacketGivingRecordNotify(this.getGivingRecords()));
     }
 
-    public void onPlayerBorn() {
+    public void onLogin() {
         if (this.isQuestingEnabled()) {
             this.enableQuests();
             this.sendGivingRecords();
         }
-    }
-
-    public void onLogin() {
 
         List<GameMainQuest> activeQuests = getActiveMainQuests();
         List<GameQuest> activeSubs = new ArrayList<>(activeQuests.size());

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerSetPlayerBornDataReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerSetPlayerBornDataReq.java
@@ -69,7 +69,6 @@ public class HandlerSetPlayerBornDataReq extends PacketHandler {
 
         // Login done
         session.getPlayer().onLogin();
-        session.getPlayer().onPlayerBorn();
 
         // Born resp packet
         session.send(new BasePacket(PacketOpcodes.SetPlayerBornDataRsp));


### PR DESCRIPTION
## Description
For players that enabled questing late, this pushes a QUEST_COND_NONE to them so that questing starts.
For players that already have questing enabled, this does the same thing, but is harmless.

## Issues fixed by this PR
Players that enabled questing late do not need to create a new account.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [x] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
