### PR TITLE
Fix bug in quest cond state not equal

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateEqual.java
@@ -20,6 +20,9 @@ public class ConditionStateEqual extends BaseCondition {
         var questStateValue = condition.getParam()[1];
         var checkQuest = owner.getQuestManager().getQuestById(questId);
 
-        return checkQuest != null && checkQuest.getState().getValue() == questStateValue;
+        if (checkQuest == null) {
+            return questStateValue == 0;
+        }
+        return checkQuest.getState().getValue() == questStateValue;
     }
 }

--- a/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateNotEqual.java
+++ b/src/main/java/emu/grasscutter/game/quest/conditions/ConditionStateNotEqual.java
@@ -20,6 +20,9 @@ public class ConditionStateNotEqual extends BaseCondition {
         var questStateValue = condition.getParam()[1];
         var checkQuest = owner.getQuestManager().getQuestById(questId);
 
-        return checkQuest != null && checkQuest.getState().getValue() != questStateValue;
+        if (checkQuest == null) {
+            return questStateValue != 0;
+        }
+        return checkQuest.getState().getValue() != questStateValue;
     }
 }


### PR DESCRIPTION
## Description
Not tested! Typed on phone! If it compiles, it's probably good, though.

When quests are state 0, they will be null. So if a quest is null, we need to test if the condition was (or was not) 0.

## Issues fixed by this PR
Hopefully the emergency food will be more talkative at the end of act 1.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
