### PR TITLE
Fix setPrevScene bug

### DIFF
--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerPersonalSceneJumpReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerPersonalSceneJumpReq.java
@@ -15,10 +15,11 @@ public class HandlerPersonalSceneJumpReq extends PacketHandler {
     public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
         PersonalSceneJumpReq req = PersonalSceneJumpReq.parseFrom(payload);
         var player = session.getPlayer();
+        var prevSceneId = player.getSceneId();
 
         // get the scene point
         ScenePointEntry scenePointEntry =
-                GameData.getScenePointEntryById(player.getSceneId(), req.getPointId());
+                GameData.getScenePointEntryById(prevSceneId, req.getPointId());
 
         if (scenePointEntry != null) {
             Position pos =
@@ -26,6 +27,7 @@ public class HandlerPersonalSceneJumpReq extends PacketHandler {
             int sceneId = scenePointEntry.getPointData().getTranSceneId();
 
             player.getWorld().transferPlayerToScene(player, sceneId, pos);
+            player.getScene().setPrevScene(prevSceneId);
             session.send(new PacketPersonalSceneJumpRsp(sceneId, pos));
         }
     }


### PR DESCRIPTION
## Description
PR https://github.com/Grasscutters/Grasscutter/pull/2366 broke PR https://github.com/Grasscutters/Grasscutter/pull/2262
PR https://github.com/Grasscutters/Grasscutter/pull/2366 made it the responsibility of the function calling transferPlayerToScene to set the PrevScene since it doesn't always need to be set (chained dungeons)

## Issues fixed by this PR
Tested against the quests talked about in https://github.com/Grasscutters/Grasscutter/pull/2366  and https://github.com/Grasscutters/Grasscutter/pull/2262 . Everything works great.

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
