### PR TITLE
Fix triggered Monster Tide spawn; fix Tower dungeon handoff

### DIFF
--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonSystem.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonSystem.java
@@ -131,7 +131,9 @@ public final class DungeonSystem extends BaseGameSystem {
                         dungeonId);
 
         if (player.getWorld().transferPlayerToScene(player, data.getSceneId(), data)) {
-            dungeonSettleListeners.forEach(player.getScene()::addDungeonSettleObserver);
+            var scene = player.getScene();
+            scene.setDungeonManager(new DungeonManager(scene, data));
+            dungeonSettleListeners.forEach(scene::addDungeonSettleObserver);
         }
         return true;
     }

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -774,9 +774,9 @@ public class SceneScriptManager {
     }
 
     public void startMonsterTideInGroup(
-            SceneGroup group, Integer[] ordersConfigId, int tideCount, int sceneLimit) {
+            String source, SceneGroup group, Integer[] ordersConfigId, int tideCount, int sceneLimit) {
         this.scriptMonsterTideService =
-                new ScriptMonsterTideService(this, group, tideCount, sceneLimit, ordersConfigId);
+                new ScriptMonsterTideService(this, source, group, tideCount, sceneLimit, ordersConfigId);
     }
 
     public void unloadCurrentMonsterTide() {

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -31,7 +31,7 @@ import static emu.grasscutter.scripts.constants.GroupKillPolicy.*;
 
 @SuppressWarnings("unused")
 public class ScriptLib {
-    public static final Logger logger = LoggerFactory.getLogger(ScriptLib.class);
+    public static final Logger logger = Grasscutter.getLogger();
     private final FastThreadLocal<SceneScriptManager> sceneScriptManager;
     private final FastThreadLocal<SceneGroup> currentGroup;
     private final FastThreadLocal<ScriptArgs> callParams;
@@ -215,9 +215,9 @@ public class ScriptLib {
     }
 
     // Some fields are guessed
-    public int AutoMonsterTide(int challengeIndex, int groupId, Integer[] ordersConfigId, int tideCount, int sceneLimit, int param6) {
+    public int AutoMonsterTide(int sourceId, int groupId, Integer[] ordersConfigId, int tideCount, int sceneLimit, int param6) {
         logger.debug("[LUA] Call AutoMonsterTide with {},{},{},{},{},{}",
-            challengeIndex,groupId,ordersConfigId,tideCount,sceneLimit,param6);
+            sourceId,groupId,ordersConfigId,tideCount,sceneLimit,param6);
 
         SceneGroup group = getSceneScriptManager().getGroupById(groupId);
 
@@ -225,7 +225,7 @@ public class ScriptLib {
             return 1;
         }
 
-        this.getSceneScriptManager().startMonsterTideInGroup(group, ordersConfigId, tideCount, sceneLimit);
+        this.getSceneScriptManager().startMonsterTideInGroup(Integer.toString(sourceId), group, ordersConfigId, tideCount, sceneLimit);
 
         return 0;
     }

--- a/src/main/java/emu/grasscutter/scripts/ScriptLib.java
+++ b/src/main/java/emu/grasscutter/scripts/ScriptLib.java
@@ -31,7 +31,7 @@ import static emu.grasscutter.scripts.constants.GroupKillPolicy.*;
 
 @SuppressWarnings("unused")
 public class ScriptLib {
-    public static final Logger logger = Grasscutter.getLogger();
+    public static final Logger logger = LoggerFactory.getLogger(ScriptLib.class);
     private final FastThreadLocal<SceneScriptManager> sceneScriptManager;
     private final FastThreadLocal<SceneGroup> currentGroup;
     private final FastThreadLocal<ScriptArgs> callParams;

--- a/src/main/java/emu/grasscutter/scripts/service/ScriptMonsterTideService.java
+++ b/src/main/java/emu/grasscutter/scripts/service/ScriptMonsterTideService.java
@@ -1,5 +1,6 @@
 package emu.grasscutter.scripts.service;
 
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.game.entity.EntityMonster;
 import emu.grasscutter.scripts.SceneScriptManager;
 import emu.grasscutter.scripts.constants.EventType;
@@ -20,9 +21,11 @@ public final class ScriptMonsterTideService {
     private final List<Integer> monsterConfigIds;
     private final OnMonsterCreated onMonsterCreated = new OnMonsterCreated();
     private final OnMonsterDead onMonsterDead = new OnMonsterDead();
+    private final String source;
 
     public ScriptMonsterTideService(
             SceneScriptManager sceneScriptManager,
+            String source,
             SceneGroup group,
             int tideCount,
             int monsterSceneLimit,
@@ -35,6 +38,7 @@ public final class ScriptMonsterTideService {
         this.monsterAlive = new AtomicInteger(0);
         this.monsterConfigOrders = new ConcurrentLinkedQueue<>(List.of(ordersConfigId));
         this.monsterConfigIds = List.of(ordersConfigId);
+        this.source = source;
 
         this.sceneScriptManager
                 .getScriptMonsterSpawnService()
@@ -83,11 +87,10 @@ public final class ScriptMonsterTideService {
                         sceneScriptManager.createMonster(
                                 currentGroup.id, currentGroup.block_id, getNextMonster()));
             }
-            // spawn the last turn of monsters
-            // fix the 5-2
-            sceneScriptManager.callEvent(
-                    new ScriptArgs(
-                            currentGroup.id, EventType.EVENT_MONSTER_TIDE_DIE, monsterKillCount.get()));
+            // call registered events that may spawn in more monsters
+            var scriptArgs = new ScriptArgs(currentGroup.id, EventType.EVENT_MONSTER_TIDE_DIE, monsterKillCount.get());
+            scriptArgs.setEventSource(source);
+            sceneScriptManager.callEvent(scriptArgs);
         }
     }
 

--- a/src/main/java/emu/grasscutter/scripts/service/ScriptMonsterTideService.java
+++ b/src/main/java/emu/grasscutter/scripts/service/ScriptMonsterTideService.java
@@ -1,6 +1,5 @@
 package emu.grasscutter.scripts.service;
 
-import emu.grasscutter.Grasscutter;
 import emu.grasscutter.game.entity.EntityMonster;
 import emu.grasscutter.scripts.SceneScriptManager;
 import emu.grasscutter.scripts.constants.EventType;

--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -100,7 +100,7 @@ public class GameSession implements GameSessionManager.KcpChannel {
     public void logPacket(String sendOrRecv, int opcode, byte[] payload) {
         Grasscutter.getLogger()
                 .info(sendOrRecv + ": " + PacketOpcodesUtils.getOpcodeName(opcode) + " (" + opcode + ")");
-        if (GAME_INFO.isShowPacketPayload) System.out.println(Utils.bytesToHex(payload));
+        if (GAME_INFO.isShowPacketPayload) Grasscutter.getLogger().trace(Utils.bytesToHex(payload));
     }
 
     public void send(BasePacket packet) {

--- a/src/main/java/emu/grasscutter/server/game/GameSession.java
+++ b/src/main/java/emu/grasscutter/server/game/GameSession.java
@@ -100,7 +100,7 @@ public class GameSession implements GameSessionManager.KcpChannel {
     public void logPacket(String sendOrRecv, int opcode, byte[] payload) {
         Grasscutter.getLogger()
                 .info(sendOrRecv + ": " + PacketOpcodesUtils.getOpcodeName(opcode) + " (" + opcode + ")");
-        if (GAME_INFO.isShowPacketPayload) Grasscutter.getLogger().trace(Utils.bytesToHex(payload));
+        if (GAME_INFO.isShowPacketPayload) System.out.println(Utils.bytesToHex(payload));
     }
 
     public void send(BasePacket packet) {


### PR DESCRIPTION
## Description

* Monster Tide spawn that depends on a trigger (like killing the first 20 mobs in Floor 1 Chamber 1 to trigger spawning the last 3) used to not trigger because its source ID was not kept, causing SceneScriptManager to fail to find its relevant triggers.
* After succeeding a Tower challenge, handoff (to Floor 1 Chamber 2 for example) was not happening because no DungeonManager was registered to the Tower scene, causing challenge completion event to be missed.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
