### PR TITLE
Fix daily dungeon flow

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/DebugCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/DebugCommand.java
@@ -32,9 +32,12 @@ public final class DebugCommand implements CommandHandler {
 
                 var scene = sender.getScene();
                 var entityId = Integer.parseInt(args.get(0));
+                // TODO Might want to allow groupId specification,
+                // because there can be more than one entity with
+                // the given config ID.
                 var entity =
                         args.size() > 1 && args.get(1).equals("config")
-                                ? scene.getEntityByConfigId(entityId)
+                                ? scene.getFirstEntityByConfigId(entityId)
                                 : scene.getEntityById(entityId);
                 if (entity == null) {
                     sender.dropMessage("Entity not found.");

--- a/src/main/java/emu/grasscutter/command/commands/EntityCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/EntityCommand.java
@@ -51,7 +51,10 @@ public final class EntityCommand implements CommandHandler {
         }
 
         param.scene = targetPlayer.getScene();
-        var entity = param.scene.getEntityByConfigId(param.configId);
+        // TODO Might want to allow groupId specification,
+        // because there can be more than one entity with
+        // the given config ID.
+        var entity = param.scene.getFirstEntityByConfigId(param.configId);
 
         if (entity == null) {
             CommandHandler.sendMessage(sender, translate(sender, "commands.entity.not_found_error"));

--- a/src/main/java/emu/grasscutter/data/common/PointData.java
+++ b/src/main/java/emu/grasscutter/data/common/PointData.java
@@ -19,6 +19,7 @@ public final class PointData {
     @Getter private Position size;
     @Getter private boolean forbidSimpleUnlock;
     @Getter private boolean unlocked;
+    @Getter private boolean groupLimit;
 
     @SerializedName(
             value = "dungeonIds",
@@ -28,7 +29,7 @@ public final class PointData {
 
     @SerializedName(
             value = "dungeonRandomList",
-            alternate = {"OIBKFJNBLHO"})
+            alternate = {"GLEKJMEEOMH"})
     @Getter
     private int[] dungeonRandomList;
 

--- a/src/main/java/emu/grasscutter/data/excels/dungeon/DungeonEntryData.java
+++ b/src/main/java/emu/grasscutter/data/excels/dungeon/DungeonEntryData.java
@@ -1,6 +1,8 @@
 package emu.grasscutter.data.excels.dungeon;
 
+import emu.grasscutter.game.dungeons.enums.*;
 import emu.grasscutter.data.*;
+import java.util.List;
 import lombok.*;
 
 @ResourceType(name = "DungeonEntryExcelConfigData.json")
@@ -12,4 +14,44 @@ public class DungeonEntryData extends GameResource {
 
     private int dungeonEntryId;
     private int sceneId;
+    private DungunEntryType type;
+    private DungeonEntryCondCombType condComb;
+    private List<DungeonEntryCondition> satisfiedCond;
+
+    public static class DungeonEntryCondition {
+        private DungeonEntrySatisfiedConditionType type;
+        private int param1;
+    }
+
+    public DungunEntryType getType() {
+        if (type == null) {
+            return DungunEntryType.DUNGEN_ENTRY_TYPE_NONE;
+        }
+        return type;
+    }
+
+    public DungeonEntryCondCombType getCondComb() {
+        if (condComb == null) {
+            return DungeonEntryCondCombType.DUNGEON_ENTRY_COND_COMB_NONE;
+        }
+        return condComb;
+    }
+
+    public int getLevelCondition() {
+        for (var cond : satisfiedCond) {
+            if (cond.type != null && cond.type.equals(DungeonEntrySatisfiedConditionType.DUNGEON_ENTRY_CONDITION_LEVEL)) {
+                return cond.param1;
+            }
+        }
+        return 0;
+    }
+
+    public int getQuestCondition() {
+        for (var cond : satisfiedCond) {
+            if (cond.type != null && cond.type.equals(DungeonEntrySatisfiedConditionType.DUNGEON_ENTRY_CONDITION_QUEST)) {
+                return cond.param1;
+            }
+        }
+        return 0;
+    }
 }

--- a/src/main/java/emu/grasscutter/game/dungeons/enums/DungeonEntryCondCombType.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/enums/DungeonEntryCondCombType.java
@@ -1,0 +1,7 @@
+package emu.grasscutter.game.dungeons.enums;
+
+public enum DungeonEntryCondCombType {
+    DUNGEON_ENTRY_COND_COMB_NONE,
+    DUNGEON_ENTRY_COND_COMB_LOGIC_OR,
+    DUNGEON_ENTRY_COND_COMB_LOGIC_AND
+}

--- a/src/main/java/emu/grasscutter/game/entity/gadget/GadgetRewardStatue.java
+++ b/src/main/java/emu/grasscutter/game/entity/gadget/GadgetRewardStatue.java
@@ -1,6 +1,6 @@
 package emu.grasscutter.game.entity.gadget;
 
-import emu.grasscutter.game.dungeons.challenge.DungeonChallenge;
+import emu.grasscutter.game.dungeons.challenge.WorldChallenge;
 import emu.grasscutter.game.entity.EntityGadget;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.net.proto.GadgetInteractReqOuterClass.GadgetInteractReq;
@@ -18,7 +18,7 @@ public final class GadgetRewardStatue extends GadgetContent {
     public boolean onInteract(Player player, GadgetInteractReq req) {
         var dungeonManager = player.getScene().getDungeonManager();
 
-        if (player.getScene().getChallenge() instanceof DungeonChallenge) {
+        if (player.getScene().getChallenge() instanceof WorldChallenge) {
             var useCondensed =
                     req.getResinCostType() == ResinCostTypeOuterClass.ResinCostType.RESIN_COST_TYPE_CONDENSE;
             dungeonManager.getStatueDrops(player, useCondensed, getGadget().getGroupId());

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -1530,6 +1530,31 @@ public class Player implements PlayerHook, FieldFetch {
         getServer().getPlayers().values().removeIf(player1 -> player1 == this);
     }
 
+    public void unfreezeUnlockedScenePoints(int sceneId) {
+        // Unfreeze previously unlocked scene points. For example,
+        // the first weapon mats domain needs some script interaction
+        // to unlock. It needs to be unfrozen when GetScenePointReq
+        // comes in to be interactable again.
+        GameData.getScenePointEntryMap().values().stream()
+                .filter(scenePointEntry ->
+                        // Note: Only DungeonEntry scene points need to be unfrozen
+                        scenePointEntry.getPointData().getType().equals("DungeonEntry")
+                        // groupLimit says this scene point needs to be unfrozen
+                        && scenePointEntry.getPointData().isGroupLimit())
+                .forEach(scenePointEntry -> {
+                        // If this is a previously unlocked scene point,
+                        // send unfreeze packet.
+                        val pointId = scenePointEntry.getPointData().getId();
+                        if (unlockedScenePoints.get(sceneId).contains(pointId)) {
+                            this.sendPacket(new PacketUnfreezeGroupLimitNotify(pointId, sceneId));
+                        }
+                });
+    }
+
+    public void unfreezeUnlockedScenePoints() {
+        unlockedScenePoints.keySet().forEach(sceneId -> unfreezeUnlockedScenePoints(sceneId));
+    }
+
     public int getLegendaryKey() {
         return this.getProperty(PlayerProperty.PROP_PLAYER_LEGENDARY_KEY);
     }

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -158,7 +158,7 @@ public class Scene {
         return entity;
     }
 
-    public GameEntity getEntityByConfigId(int configId) {
+    public GameEntity getFirstEntityByConfigId(int configId) {
         return this.entities.values().stream()
                 .filter(x -> x.getConfigId() == configId)
                 .findFirst()

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -265,6 +265,10 @@ public class SceneScriptManager {
 
         groupInstance.setActiveSuiteId(suiteIndex);
         groupInstance.setLastTimeRefreshed(getScene().getWorld().getGameTime());
+
+        // Call EVENT_GROUP_REFRESH for any action trigger waiting for it
+        callEvent(new ScriptArgs(groupInstance.getGroupId(), EventType.EVENT_GROUP_REFRESH));
+
         return suiteIndex;
     }
 
@@ -323,7 +327,7 @@ public class SceneScriptManager {
                 group.monsters.values().stream()
                         .filter(
                                 m -> {
-                                    var entity = scene.getEntityByConfigId(m.config_id);
+                                    var entity = scene.getEntityByConfigId(m.config_id, groupId);
                                     return (entity == null
                                             || entity.getGroupId()
                                                     != group
@@ -694,7 +698,7 @@ public class SceneScriptManager {
         return suite.sceneGadgets.stream()
                 .filter(
                         m -> {
-                            var entity = scene.getEntityByConfigId(m.config_id);
+                            var entity = scene.getEntityByConfigId(m.config_id, group.id);
                             return (entity == null || entity.getGroupId() != group.id)
                                     && (!m.isOneoff
                                             || !m.persistent
@@ -712,7 +716,7 @@ public class SceneScriptManager {
         return suite.sceneMonsters.stream()
                 .filter(
                         m -> {
-                            var entity = scene.getEntityByConfigId(m.config_id);
+                            var entity = scene.getEntityByConfigId(m.config_id, group.id);
                             return (entity == null
                                     || entity.getGroupId()
                                             != group
@@ -788,7 +792,7 @@ public class SceneScriptManager {
 
     public void spawnMonstersByConfigId(SceneGroup group, int configId, int delayTime) {
         // TODO delay
-        var entity = scene.getEntityByConfigId(configId);
+        var entity = scene.getEntityByConfigId(configId, group.id);
         if (entity != null && entity.getGroupId() == group.id) {
             Grasscutter.getLogger()
                     .debug("entity already exists failed in group {} with config {}", group.id, configId);
@@ -884,9 +888,11 @@ public class SceneScriptManager {
     private boolean evaluateTriggerCondition(SceneTrigger trigger, ScriptArgs params) {
         Grasscutter.getLogger()
                 .trace(
-                        "Call Condition Trigger {}, [{},{},{}]",
+                        "Call Condition Trigger {}, [{},{},{}], source_eid {}, target_eid {}",
                         trigger.getCondition(),
                         params.param1,
+                        params.param2,
+                        params.param3,
                         params.source_eid,
                         params.target_eid);
         LuaValue ret = this.callScriptFunc(trigger.getCondition(), trigger.currentGroup, params);
@@ -1194,7 +1200,7 @@ public class SceneScriptManager {
         return monsters.values().stream()
                 .noneMatch(
                         m -> {
-                            val entity = scene.getEntityByConfigId(m.config_id);
+                            val entity = scene.getEntityByConfigId(m.config_id, groupId);
                             return entity != null && entity.getGroupId() == groupId;
                         });
     }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerDungeonRestartReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerDungeonRestartReq.java
@@ -1,0 +1,15 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.*;
+import emu.grasscutter.net.proto.DungeonRestartReqOuterClass.DungeonRestartReq;
+import emu.grasscutter.net.proto.DungeonRestartRspOuterClass.DungeonRestartRsp;
+import emu.grasscutter.server.game.GameSession;
+
+@Opcodes(PacketOpcodes.DungeonRestartReq)
+public class HandlerDungeonRestartReq extends PacketHandler {
+    @Override
+    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+        session.getPlayer().getServer().getDungeonSystem().restartDungeon(session.getPlayer());
+        session.getPlayer().sendPacket(new BasePacket(PacketOpcodes.DungeonRestartRsp));
+    }
+}

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetDungeonEntryExploreConditionReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerGetDungeonEntryExploreConditionReq.java
@@ -1,0 +1,27 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.Grasscutter;
+import emu.grasscutter.net.packet.*;
+import emu.grasscutter.server.game.GameSession;
+import emu.grasscutter.server.packet.send.PacketGetDungeonEntryExploreConditionRsp;
+import emu.grasscutter.server.packet.send.PacketDungeonEntryToBeExploreNotify;
+import emu.grasscutter.net.proto.GetDungeonEntryExploreConditionReqOuterClass.GetDungeonEntryExploreConditionReq;
+
+@Opcodes(PacketOpcodes.GetDungeonEntryExploreConditionReq)
+public class HandlerGetDungeonEntryExploreConditionReq extends PacketHandler {
+    @Override
+    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+        var req = GetDungeonEntryExploreConditionReq.parseFrom(payload);
+
+        // TODO Send GetDungeonEntryExploreConditionRsp if condition
+        // (adventurer rank or quest completion) is not met. Parse
+        // dungeon entry conditions from DungeonEntryExcelConfigData.json.
+        //session.send(new PacketGetDungeonEntryExploreConditionRsp(req.getDungeonEntryConfigId()));
+
+        // For now, just unlock any domain the player touches.
+        session.send(new PacketDungeonEntryToBeExploreNotify(
+                req.getDungeonEntryScenePointId(),
+                req.getSceneId(),
+                req.getDungeonEntryConfigId()));
+    }
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketDungeonEntryToBeExploreNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketDungeonEntryToBeExploreNotify.java
@@ -4,6 +4,11 @@ import emu.grasscutter.net.packet.*;
 import emu.grasscutter.net.proto.DungeonEntryToBeExploreNotifyOuterClass.DungeonEntryToBeExploreNotify;
 
 public class PacketDungeonEntryToBeExploreNotify extends BasePacket {
+
+    /**
+     * Marks the dungeon as pending exploration.
+     * This creates the "Unknown" text bubble above the dungeon entry in the world map.
+     */
     public PacketDungeonEntryToBeExploreNotify(int dungeonEntryScenePointId, int sceneId, int dungeonEntryConfigId) {
         super(PacketOpcodes.DungeonEntryToBeExploreNotify);
         this.setData(DungeonEntryToBeExploreNotify.newBuilder()

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketDungeonEntryToBeExploreNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketDungeonEntryToBeExploreNotify.java
@@ -1,0 +1,15 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.*;
+import emu.grasscutter.net.proto.DungeonEntryToBeExploreNotifyOuterClass.DungeonEntryToBeExploreNotify;
+
+public class PacketDungeonEntryToBeExploreNotify extends BasePacket {
+    public PacketDungeonEntryToBeExploreNotify(int dungeonEntryScenePointId, int sceneId, int dungeonEntryConfigId) {
+        super(PacketOpcodes.DungeonEntryToBeExploreNotify);
+        this.setData(DungeonEntryToBeExploreNotify.newBuilder()
+                .setDungeonEntryScenePointId(dungeonEntryScenePointId)
+                .setSceneId(sceneId)
+                .setDungeonEntryConfigId(dungeonEntryConfigId)
+        );
+    }
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketGetDungeonEntryExploreConditionRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketGetDungeonEntryExploreConditionRsp.java
@@ -1,0 +1,31 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.net.packet.*;
+import emu.grasscutter.net.proto.GetDungeonEntryExploreConditionRspOuterClass.GetDungeonEntryExploreConditionRsp;
+import emu.grasscutter.net.proto.DungeonEntryCondOuterClass.DungeonEntryCond;
+import emu.grasscutter.net.proto.DungeonEntryBlockReasonOuterClass.DungeonEntryBlockReason;
+
+public class PacketGetDungeonEntryExploreConditionRsp extends BasePacket {
+    public PacketGetDungeonEntryExploreConditionRsp(int dungeonId) {
+        super(PacketOpcodes.GetDungeonEntryExploreConditionRsp);
+
+        var data = GameData.getDungeonEntryDataMap().values().stream()
+                .filter(d -> d.getId() == dungeonId)
+                .toList().get(0);
+
+        var level = data.getLevelCondition();
+        var quest = data.getQuestCondition();
+        var proto = GetDungeonEntryExploreConditionRsp.newBuilder()
+                .setRetcode(0)
+                .setDungeonEntryCond(DungeonEntryCond.newBuilder()
+                        // There is also a DUNGEON_ENTRY_REASON_MULIPLE but only one param1
+                        // field to put values in. Only report the required level for now, then.
+                        .setCondReason(DungeonEntryBlockReason.DUNGEON_ENTRY_REASON_LEVEL)
+                        .setParam1(level)
+                )
+                .build();
+
+        this.setData(proto);
+    }
+}

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketPostEnterSceneRsp.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketPostEnterSceneRsp.java
@@ -12,6 +12,11 @@ public class PacketPostEnterSceneRsp extends BasePacket {
         PostEnterSceneRsp p =
                 PostEnterSceneRsp.newBuilder().setEnterSceneToken(player.getEnterSceneToken()).build();
 
+        //
+        // On moving to new scene:
+        // Unfreeze dungeon entry points that have already been unlocked in this scene.
+        player.unfreezeUnlockedScenePoints();
+
         this.setData(p);
     }
 }

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketUnfreezeGroupLimitNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketUnfreezeGroupLimitNotify.java
@@ -1,0 +1,14 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.net.packet.*;
+import emu.grasscutter.net.proto.UnfreezeGroupLimitNotifyOuterClass.UnfreezeGroupLimitNotify;
+
+public class PacketUnfreezeGroupLimitNotify extends BasePacket {
+    public PacketUnfreezeGroupLimitNotify(int pointId, int sceneId) {
+        super(PacketOpcodes.UnfreezeGroupLimitNotify);
+        this.setData(UnfreezeGroupLimitNotify.newBuilder()
+                .setPointId(pointId)
+                .setSceneId(sceneId)
+        );
+    }
+}


### PR DESCRIPTION
Fix daily dungeon flow

## Description

* Fixed "Locked" dungeon entry issue. How this works:
    * Dungeons start out Locked on client side. Interacting with dungeons in this state causes the client to send GetDungeonEntryExploreConditionReq to get level and/or quest completion requirement for dungeon entry.
    * The server would respond with GetDungeonEntryExploreConditionRsp to show the conditions.
        * On player level (AR) up, the server _should_ send DungeonEntryToBeExploreNotify to tell the client some dungeon is ready to be explored. This gives that dungeon the "Unknown" text bubble in the client world map.
        * In this state, the client will no longer send GetDungeonEntryExploreConditionReq and instead send DungeonEntryInfoReq to enumerate dungeon entries as usual, as well as the packet to unlock the teleport waypoint.
    * Unfortunately this fix still needs improvement: I don't know how to make the unlock state persistent.
        * On relog, the dungeon goes back to its locked state. However, its teleport waypoint is still active.
            * In this state, player can still teleport to it, but on interaction, client resumes sending GetDungeonEntryExploreConditionReq.
            * The server has to resend the DungeonEntryToBeExploreNotify again to put it in the unlock state for client to enter.
* Fix daily dungeon enumeration issue.
    * The "dungeonRandomList" field now has alternative name "GLEKJMEEOMH"
    * Note: This field enumerates dungeon entries for different days of week.
* Implement dungeon replay flow by kicking every player out of its scene and adding them back in again.
    * This causes the scene to be cleaned up so that scripting states are restarted when the players are spawned back in. Otherwise the Key trigger to start the dungeon challenge will be missing, as will the barrier to the reward statue.
* Fix GadgetRewardStatue not actually dispensing rewards.
    * Seems the dungeons used to have DungeonChallenge, but they are now WorldChallenge. GadgetRewardStatue was only dispensing rewards for DungeonChallenge.
        * DungeonChallenge is currently used only in Tower.
* Implement UnfreezeGroupLimit.
    * This fixes unlocking the first weapon mats dungeon and hopefully other dungeons with similar unlock requirements.
    * These dungeons have attribute `groupLimit: true` in `BinOutput/Scene/Point/scene*_point.json`. Lua scripts would call UnfreezeGroupLimit, which should then send an UnfreezeGroupLimitNotify to trigger the unlock.


### Under the hood

* Update ScriptLib to pass in current group ID in addition to config ID. Getting the first entity found with only a config ID can lead to wrong outcomes. Config IDs are not unique in a scene.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
https://github.com/Grasscutters/Grasscutter/issues/2282


## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
