### PR TITLE
Add reset scene tag subcommand

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/SetSceneTagCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetSceneTagCommand.java
@@ -39,8 +39,9 @@ public final class SetSceneTagCommand implements CommandHandler {
             if (actionStr.equals("unlockall")) {
                 unlockAllSceneTags(targetPlayer);
                 return;
-            } else if (actionStr.equals("reset")) {
+            } else if (actionStr.equals("reset") || actionStr.equals("restore")) {
                 resetAllSceneTags(targetPlayer);
+                return;
             } else {
                 CommandHandler.sendTranslatedMessage(sender, "commands.execution.argument_error");
                 return;


### PR DESCRIPTION
## Description

The regret medicine for `/tag unlockall`.

Use '/tag reset' to restore to the default scene tag.

## Type of changes

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
