### PR TITLE
Fix reset tag without notification

### DIFF
--- a/src/main/java/emu/grasscutter/command/commands/SetSceneTagCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetSceneTagCommand.java
@@ -114,6 +114,8 @@ public final class SetSceneTagCommand implements CommandHandler {
                                     .computeIfAbsent(sceneTag.getSceneId(), k -> new HashSet<>());
                             targetPlayer.getSceneTags().get(sceneTag.getSceneId()).add(sceneTag.getId());
                         });
+
+        this.setSceneTags(targetPlayer);
     }
 
     private void setSceneTags(Player targetPlayer) {


### PR DESCRIPTION
## Description

I forgot to send a notification afte the scene tag reset

## Type of changes

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
