### PR TITLE
Fix mirror tower stages; fix tower time challenge and star scoring

### DIFF
--- a/src/main/java/emu/grasscutter/data/excels/tower/TowerLevelData.java
+++ b/src/main/java/emu/grasscutter/data/excels/tower/TowerLevelData.java
@@ -1,33 +1,82 @@
 package emu.grasscutter.data.excels.tower;
 
 import emu.grasscutter.data.*;
+import java.util.List;
+import lombok.*;
 
 @ResourceType(name = "TowerLevelExcelConfigData.json")
+@Getter
 public class TowerLevelData extends GameResource {
 
     private int levelId;
     private int levelIndex;
     private int levelGroupId;
     private int dungeonId;
+    private List<TowerLevelCond> conds;
+
+    public static class TowerLevelCond {
+        private TowerCondType towerCondType;
+        private List<Integer> argumentList;
+    }
+
+    public enum TowerCondType {
+        TOWER_COND_NONE,
+        TOWER_COND_CHALLENGE_LEFT_TIME_MORE_THAN,
+        TOWER_COND_LEFT_HP_GREATER_THAN
+    }
+
+    // Not actual data in TowerLevelExcelConfigData.
+    // Just packaging condition parameters for convenience.
+    @Getter
+    public class TowerCondTimeParams {
+        private int param1;
+        private int minimumTimeInSeconds;
+
+        public TowerCondTimeParams(int param1, int minimumTimeInSeconds) {
+            this.param1 = param1;
+            this.minimumTimeInSeconds = minimumTimeInSeconds;
+        }
+    }
+
+    @Getter
+    public class TowerCondHpParams {
+        private int sceneId;
+        private int configId;
+        private int minimumHpPercentage;
+
+        public TowerCondHpParams(int sceneId, int configId, int minimumHpPercentage) {
+            this.sceneId = sceneId;
+            this.configId = configId;
+            this.minimumHpPercentage = minimumHpPercentage;
+        }
+    }
 
     @Override
     public int getId() {
         return this.getLevelId();
     }
 
-    public int getLevelId() {
-        return levelId;
+    public TowerCondType getCondType(int star) {
+        if (star < 0 || conds == null || star >= conds.size()) {
+            return TowerCondType.TOWER_COND_NONE;
+        }
+        var condType = conds.get(star).towerCondType;
+        return condType == null ? TowerCondType.TOWER_COND_NONE : condType;
     }
 
-    public int getLevelGroupId() {
-        return levelGroupId;
+    public TowerCondTimeParams getTimeCond(int star) {
+        if (star < 0 || conds == null || star >= conds.size()) {
+            return null;
+        }
+        var params = conds.get(star).argumentList;
+        return new TowerCondTimeParams(params.get(0), params.get(1));
     }
 
-    public int getLevelIndex() {
-        return levelIndex;
-    }
-
-    public int getDungeonId() {
-        return dungeonId;
+    public TowerCondHpParams getHpCond(int star) {
+        if (star < 0 || conds == null || star >= conds.size()) {
+            return null;
+        }
+        var params = conds.get(star).argumentList;
+        return new TowerCondHpParams(params.get(0), params.get(1), params.get(2));
     }
 }

--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
@@ -38,6 +38,7 @@ public final class DungeonManager {
     private boolean ended = false;
     private int newestWayPoint = 0;
     @Getter private int startSceneTime = 0;
+    @Setter @Getter private boolean towerDungeon = false;
 
     DungeonTrialTeam trialTeam = null;
 
@@ -323,14 +324,29 @@ public final class DungeonManager {
                                 p.getBattlePassManager().triggerMission(WatcherTriggerType.TRIGGER_FINISH_DUNGEON);
                             }
                         });
-        scene
-                .getScriptManager()
-                .callEvent(new ScriptArgs(0, EventType.EVENT_DUNGEON_SETTLE, successfully ? 1 : 0));
+        var future = scene
+                            .getScriptManager()
+                            .callEvent(new ScriptArgs(0, EventType.EVENT_DUNGEON_SETTLE, successfully ? 1 : 0));
+        // Note: There is a possible race condition with calling
+        //       EVENT_DUNGEON_SETTLE here asynchronously:
+        // 1. EVENT_DUNGEON_SETTLE triggers some Lua-side logic,
+        //    which may happen after 2 (below) finishes.
+        // 2. Some DungeonSettleListener could be comparing some
+        //    Lua variable before its setting in 1 (above) finishes.
+        // For safety, ensure all events have finished before returning.
+        try {
+            future.get();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     public void endDungeon(BaseDungeonResult.DungeonEndReason endReason) {
         if (scene.getDungeonSettleListeners() != null) {
             scene.getDungeonSettleListeners().forEach(o -> o.onDungeonSettle(this, endReason));
+        }
+        if (isTowerDungeon()) {
+            scene.getPlayers().get(0).getTowerManager().onEnd();
         }
         ended = true;
     }

--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonSystem.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonSystem.java
@@ -132,7 +132,9 @@ public final class DungeonSystem extends BaseGameSystem {
 
         if (player.getWorld().transferPlayerToScene(player, data.getSceneId(), data)) {
             var scene = player.getScene();
-            scene.setDungeonManager(new DungeonManager(scene, data));
+            var dungeonManager = new DungeonManager(scene, data);
+            dungeonManager.setTowerDungeon(true);
+            scene.setDungeonManager(dungeonManager);
             dungeonSettleListeners.forEach(scene::addDungeonSettleObserver);
         }
         return true;
@@ -168,6 +170,7 @@ public final class DungeonSystem extends BaseGameSystem {
         // clean temp team if it has
         player.getTeamManager().cleanTemporaryTeam();
         player.getTowerManager().clearEntry();
+        dungeonManager.setTowerDungeon(false);
 
         // Transfer player back to world
         player.getWorld().transferPlayerToScene(player, prevScene, prevPos);

--- a/src/main/java/emu/grasscutter/game/dungeons/TowerDungeonSettleListener.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/TowerDungeonSettleListener.java
@@ -9,6 +9,7 @@ public class TowerDungeonSettleListener implements DungeonSettleListener {
     @Override
     public void onDungeonSettle(DungeonManager dungeonManager, DungeonEndReason endReason) {
         var scene = dungeonManager.getScene();
+
         var dungeonData = dungeonManager.getDungeonData();
         if (scene.getLoadedGroups().stream()
                 .anyMatch(
@@ -22,17 +23,18 @@ public class TowerDungeonSettleListener implements DungeonSettleListener {
         }
 
         var towerManager = scene.getPlayers().get(0).getTowerManager();
+        var stars = towerManager.getCurLevelStars();
 
-        towerManager.notifyCurLevelRecordChangeWhenDone(3);
+        towerManager.notifyCurLevelRecordChangeWhenDone(stars);
         scene.broadcastPacket(
                 new PacketTowerFloorRecordChangeNotify(
-                        towerManager.getCurrentFloorId(), 3, towerManager.canEnterScheduleFloor()));
+                        towerManager.getCurrentFloorId(), stars, towerManager.canEnterScheduleFloor()));
 
         var challenge = scene.getChallenge();
         var dungeonStats =
                 new DungeonEndStats(
                         scene.getKilledMonsterCount(), challenge.getFinishedTime(), 0, endReason);
-        var result = new TowerResult(dungeonData, dungeonStats, towerManager, challenge);
+        var result = new TowerResult(dungeonData, dungeonStats, towerManager, challenge, stars);
 
         scene.broadcastPacket(new PacketDungeonSettleNotify(result));
     }

--- a/src/main/java/emu/grasscutter/game/dungeons/challenge/WorldChallenge.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/challenge/WorldChallenge.java
@@ -80,9 +80,16 @@ public class WorldChallenge {
             return;
         }
         this.progress = true;
-        this.startedAt = System.currentTimeMillis();
+        this.startedAt = getScene().getSceneTimeSeconds();
         getScene().broadcastPacket(new PacketDungeonChallengeBeginNotify(this));
         challengeTriggers.forEach(t -> t.onBegin(this));
+
+        var player = scene.getPlayers().get(0);
+        var dungeonManager = scene.getDungeonManager();
+        var towerManager = player.getTowerManager();
+        if (dungeonManager != null && dungeonManager.isTowerDungeon() && towerManager != null) {
+            towerManager.onBegin();
+        }
     }
 
     public void done() {

--- a/src/main/java/emu/grasscutter/game/dungeons/challenge/trigger/InTimeTrigger.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/challenge/trigger/InTimeTrigger.java
@@ -1,10 +1,29 @@
 package emu.grasscutter.game.dungeons.challenge.trigger;
 
 import emu.grasscutter.game.dungeons.challenge.WorldChallenge;
+import emu.grasscutter.server.packet.send.PacketChallengeDataNotify;
 
 public class InTimeTrigger extends ChallengeTrigger {
     @Override
+    public void onBegin(WorldChallenge challenge) {
+        // Show time remaining UI
+        var scene = challenge.getScene();
+        scene.broadcastPacket(
+                new PacketChallengeDataNotify(
+                        challenge,
+                        2,
+                        // Compensate for time passed so far in scene.
+                        challenge.getTimeLimit() + scene.getSceneTimeSeconds()));
+    }
+
+    @Override
     public void onCheckTimeout(WorldChallenge challenge) {
+        // In Tower challenges, time can run out without
+        // causing the challenge to fail. (Player just
+        // gets 0 stars when they ultimately finish.)
+        var dungeonManager = challenge.getScene().getDungeonManager();
+        if (dungeonManager != null && dungeonManager.isTowerDungeon()) return;
+
         var current = challenge.getScene().getSceneTimeSeconds();
         if (current - challenge.getStartedAt() > challenge.getTimeLimit()) {
             challenge.fail();

--- a/src/main/java/emu/grasscutter/game/dungeons/dungeon_results/TowerResult.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/dungeon_results/TowerResult.java
@@ -13,17 +13,20 @@ public class TowerResult extends BaseDungeonResult {
     boolean canJump;
     boolean hasNextLevel;
     int nextFloorId;
+    int currentStars;
 
     public TowerResult(
             DungeonData dungeonData,
             DungeonEndStats dungeonStats,
             TowerManager towerManager,
-            WorldChallenge challenge) {
+            WorldChallenge challenge,
+            int currentStars) {
         super(dungeonData, dungeonStats);
         this.challenge = challenge;
         this.canJump = towerManager.hasNextFloor();
         this.hasNextLevel = towerManager.hasNextLevel();
         this.nextFloorId = hasNextLevel ? 0 : towerManager.getNextFloorId();
+        this.currentStars = currentStars;
     }
 
     @Override
@@ -40,14 +43,16 @@ public class TowerResult extends BaseDungeonResult {
                 TowerLevelEndNotify.newBuilder()
                         .setIsSuccess(challenge.isSuccess())
                         .setContinueState(continueStatus)
-                        .addFinishedStarCondList(1)
-                        .addFinishedStarCondList(2)
-                        .addFinishedStarCondList(3)
                         .addRewardItemList(
-                                ItemParamOuterClass.ItemParam.newBuilder().setItemId(201).setCount(1000).build());
+                                ItemParamOuterClass.ItemParam.newBuilder().setItemId(201).setCount(1000));
+
+        for (int i = 1; i <= currentStars; i++) {
+            towerLevelEndNotify.addFinishedStarCondList(i);
+        }
+
         if (nextFloorId > 0 && canJump) {
             towerLevelEndNotify.setNextFloorId(nextFloorId);
         }
-        builder.setTowerLevelEndNotify(towerLevelEndNotify);
+        builder.setTowerLevelEndNotify(towerLevelEndNotify.build());
     }
 }

--- a/src/main/java/emu/grasscutter/game/tower/TowerLevelRecord.java
+++ b/src/main/java/emu/grasscutter/game/tower/TowerLevelRecord.java
@@ -25,6 +25,10 @@ public class TowerLevelRecord {
         return this;
     }
 
+    public int getLevelStars(int levelId) {
+        return passedLevelMap.get(levelId);
+    }
+
     public int getStarCount() {
         return passedLevelMap.values().stream().mapToInt(Integer::intValue).sum();
     }

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -597,6 +597,13 @@ public class Scene {
 
         blossomManager.onTick();
 
+        // Should be OK to check only player 0,
+        // as no other players could enter Tower
+        var towerManager = getPlayers().get(0).getTowerManager();
+        if (towerManager != null) {
+            towerManager.onTick();
+        }
+
         this.checkNpcGroup();
 
         this.finishLoading();

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -807,11 +807,11 @@ public class SceneScriptManager {
         }
     }
     // Events
-    public void callEvent(int groupId, int eventType) {
-        callEvent(new ScriptArgs(groupId, eventType));
+    public Future<?> callEvent(int groupId, int eventType) {
+        return callEvent(new ScriptArgs(groupId, eventType));
     }
 
-    public void callEvent(@Nonnull ScriptArgs params) {
+    public Future<?> callEvent(@Nonnull ScriptArgs params) {
         /**
          * We use ThreadLocal to trans SceneScriptManager context to ScriptLib, to avoid eval script for
          * every groups' trigger in every scene instances. But when callEvent is called in a ScriptLib
@@ -819,7 +819,7 @@ public class SceneScriptManager {
          * not get it. e.g. CallEvent -> set -> ScriptLib.xxx -> CallEvent -> set -> remove -> NPE ->
          * (remove) So we use thread pool to clean the stack to avoid this new issue.
          */
-        eventExecutor.submit(() -> this.realCallEvent(params));
+        return eventExecutor.submit(() -> this.realCallEvent(params));
     }
 
     private void realCallEvent(@Nonnull ScriptArgs params) {

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketTowerLevelStarCondNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketTowerLevelStarCondNotify.java
@@ -6,27 +6,37 @@ import emu.grasscutter.net.proto.TowerLevelStarCondNotifyOuterClass.TowerLevelSt
 
 public class PacketTowerLevelStarCondNotify extends BasePacket {
 
-    public PacketTowerLevelStarCondNotify(int floorId, int levelIndex) {
+    public PacketTowerLevelStarCondNotify(int floorId, int levelIndex, int lostStar) {
         super(PacketOpcodes.TowerLevelStarCondNotify);
 
-        TowerLevelStarCondNotify proto =
-                TowerLevelStarCondNotify.newBuilder()
-                        .setFloorId(floorId)
-                        .setLevelIndex(levelIndex)
-                        .addCondDataList(
-                                TowerLevelStarCondData.newBuilder()
-                                        // .setCondValue(1)
-                                        .build())
-                        .addCondDataList(
-                                TowerLevelStarCondData.newBuilder()
-                                        // .setCondValue(2)
-                                        .build())
-                        .addCondDataList(
-                                TowerLevelStarCondData.newBuilder()
-                                        // .setCondValue(3)
-                                        .build())
-                        .build();
+        var proto = TowerLevelStarCondNotify.newBuilder()
+                            .setFloorId(floorId)
+                            .setLevelIndex(levelIndex);
 
-        this.setData(proto);
+        if (1 <= lostStar && lostStar <= 3) {
+            proto.addCondDataList(
+                    TowerLevelStarCondData.newBuilder()
+                            // If these are still obfuscated in the next client version,
+                            // just set all int fields to the star (1 <= star <= 3)
+                            // that failed and set all boolean fields to true.
+                            .setNGHNFHCLFBH(lostStar)
+                            .setIBGHBFANCBK(true)
+                            .setOILLLBMMABH(true)
+                            .setOMOECEGOALC(lostStar)
+                            .build());
+        } else {
+            proto
+                    .addCondDataList(
+                            TowerLevelStarCondData.newBuilder()
+                                    .build())
+                    .addCondDataList(
+                            TowerLevelStarCondData.newBuilder()
+                                    .build())
+                    .addCondDataList(
+                            TowerLevelStarCondData.newBuilder()
+                                    .build());
+        }
+
+        this.setData(proto.build());
     }
 }


### PR DESCRIPTION
## Description

Improve Tower experience:
* Mirror stages should now work
![gif](https://github.com/longfruit/Grasscutter/blob/8cba3304af23d8f494360e0f6656da2a5b55797f/chambercomplete.gif?raw=true)
* Stars can now be lost in time challenges. Monolith HP% challenges still wip
![gif](https://github.com/longfruit/Grasscutter/blob/tower-improve-gifs/starcond.gif?raw=true)
* Correct number of stars are awarded and recorded at the end. 1000 primos are given anyway, why not.
![gif](https://github.com/longfruit/Grasscutter/blob/tower-improve-gifs/starresults.gif?raw=true)

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
