### PR TITLE
Fix revives; improve dungeon exit flow

### DIFF
--- a/src/main/java/emu/grasscutter/game/ability/AbilityManager.java
+++ b/src/main/java/emu/grasscutter/game/ability/AbilityManager.java
@@ -7,6 +7,7 @@ import emu.grasscutter.data.binout.*;
 import emu.grasscutter.data.binout.AbilityModifier.AbilityModifierAction;
 import emu.grasscutter.game.ability.actions.*;
 import emu.grasscutter.game.ability.mixins.*;
+import emu.grasscutter.game.entity.EntityAvatar;
 import emu.grasscutter.game.entity.GameEntity;
 import emu.grasscutter.game.player.*;
 import emu.grasscutter.game.props.FightProperty;
@@ -562,6 +563,14 @@ public final class AbilityManager extends BasePlayerManager {
         if (killState.getKilled()) {
             scene.killEntity(entity);
         } else if (!entity.isAlive()) {
+            if (entity instanceof EntityAvatar) {
+                // TODO Should EntityAvatar act on this invocation?
+                // It bugs revival due to resetting HP to max when
+                // the avatar should just stay dead.
+                Grasscutter.getLogger()
+                        .trace("Entity of ID {} is EntityAvatar. Ignoring", invoke.getEntityId());
+                return;
+            }
             entity.setFightProperty(
                     FightProperty.FIGHT_PROP_CUR_HP,
                     entity.getFightProperty(FightProperty.FIGHT_PROP_MAX_HP));

--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonSystem.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonSystem.java
@@ -168,13 +168,21 @@ public final class DungeonSystem extends BaseGameSystem {
             dungeonManager.unsetTrialTeam(player);
         }
         // clean temp team if it has
-        player.getTeamManager().cleanTemporaryTeam();
+        if (!player.getTeamManager().cleanTemporaryTeam())
+        {
+            // no temp team. Will use real current team, but check
+            // for any dead avatar to prevent switching into them.
+            player.getTeamManager().checkCurrentAvatarIsAlive(null);
+        }
         player.getTowerManager().clearEntry();
         dungeonManager.setTowerDungeon(false);
 
-        // Transfer player back to world
-        player.getWorld().transferPlayerToScene(player, prevScene, prevPos);
-        player.sendPacket(new BasePacket(PacketOpcodes.PlayerQuitDungeonRsp));
+        // Transfer player back to world after a small delay.
+        // This wait is important for avoiding double teleports,
+        // which specifically happen when player quits a dungeon
+        // by teleporting to map waypoints.
+        // From testing, 200ms seem reasonable.
+        player.getWorld().queueTransferPlayerToScene(player, prevScene, prevPos, 200);
     }
 
     public void restartDungeon(Player player) {

--- a/src/main/java/emu/grasscutter/game/entity/EntityAvatar.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityAvatar.java
@@ -67,6 +67,11 @@ public class EntityAvatar extends GameEntity {
         }
 
         this.initAbilities();
+
+        // New EntityAvatar instances are created on every scene transition.
+        // Ensure that isDead is properly carried over between scenes.
+        // Otherwise avatars could have 0 HP but not considered dead.
+        this.checkIfDead();
     }
 
     @Override

--- a/src/main/java/emu/grasscutter/game/entity/GameEntity.java
+++ b/src/main/java/emu/grasscutter/game/entity/GameEntity.java
@@ -174,13 +174,7 @@ public abstract class GameEntity {
         }
 
         this.lastAttackType = attackType;
-
-        // Check if dead
-        if (this.getFightProperty(FightProperty.FIGHT_PROP_CUR_HP) <= 0f) {
-            this.setFightProperty(FightProperty.FIGHT_PROP_CUR_HP, 0f);
-            this.isDead = true;
-        }
-
+        this.checkIfDead();
         this.runLuaCallbacks(event);
 
         // Packets
@@ -191,6 +185,17 @@ public abstract class GameEntity {
         // Check if dead.
         if (this.isDead) {
             this.getScene().killEntity(this, killerId);
+        }
+    }
+
+    public void checkIfDead() {
+        if (this.getFightProperties() == null || !hasFightProperty(FightProperty.FIGHT_PROP_CUR_HP)) {
+            return;
+        }
+
+        if (this.getFightProperty(FightProperty.FIGHT_PROP_CUR_HP) <= 0f) {
+            this.setFightProperty(FightProperty.FIGHT_PROP_CUR_HP, 0f);
+            this.isDead = true;
         }
     }
 
@@ -333,6 +338,8 @@ public abstract class GameEntity {
         if (entityController != null) {
             entityController.onDie(this, getLastAttackType());
         }
+
+        this.isDead = true;
     }
 
     /** Invoked when a global ability value is updated. */

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -176,6 +176,7 @@ public class Player implements PlayerHook, FieldFetch {
     @Getter @Setter private Set<Date> moonCardGetTimes;
 
     @Transient @Getter private boolean paused;
+    @Transient @Getter @Setter private Future<?> queuedTeleport;
     @Transient @Getter @Setter private int enterSceneToken;
     @Transient @Getter @Setter private SceneLoadState sceneLoadState = SceneLoadState.NONE;
     @Transient private boolean hasSentLoginPackets;

--- a/src/main/java/emu/grasscutter/game/player/TeamManager.java
+++ b/src/main/java/emu/grasscutter/game/player/TeamManager.java
@@ -425,6 +425,30 @@ public final class TeamManager extends BasePlayerDataManager {
             this.getPlayer().sendPacket(responsePacket);
         }
 
+        // Ensure new selected character index is alive.
+        // If not, change to another alive one or revive.
+        checkCurrentAvatarIsAlive(currentEntity);
+    }
+
+    public void checkCurrentAvatarIsAlive(EntityAvatar currentEntity) {
+        if (currentEntity == null) {
+            currentEntity = this.getCurrentAvatarEntity();
+        }
+
+        // Ensure currently selected character is still alive
+        if (!this.getActiveTeam().get(this.currentCharacterIndex).isAlive()) {
+            // Character died in a dungeon challenge...
+            int replaceIndex = getDeadAvatarReplacement();
+            if (0 <= replaceIndex && replaceIndex < this.getActiveTeam().size()) {
+                this.currentCharacterIndex = replaceIndex;
+            } else {
+                // Team wiped in dungeon...
+                // Revive and change to first avatar.
+                this.currentCharacterIndex = 0;
+                this.reviveAvatar(this.getCurrentAvatarEntity().getAvatar());
+            }
+        }
+
         // Check if character changed
         var newAvatarEntity = this.getCurrentAvatarEntity();
         if (currentEntity != null && newAvatarEntity != null && currentEntity != newAvatarEntity) {
@@ -700,15 +724,16 @@ public final class TeamManager extends BasePlayerDataManager {
         this.updateTeamEntities(null);
     }
 
-    public void cleanTemporaryTeam() {
+    public boolean cleanTemporaryTeam() {
         // check if using temporary team
         if (useTemporarilyTeamIndex < 0) {
-            return;
+            return false;
         }
 
         this.useTemporarilyTeamIndex = -1;
         this.temporaryTeam = null;
         this.updateTeamEntities(null);
+        return true;
     }
 
     public synchronized void setCurrentTeam(int teamId) {
@@ -810,20 +835,13 @@ public final class TeamManager extends BasePlayerDataManager {
             // TODO: Perhaps find a way to get vanilla experience?
             this.getPlayer().sendPacket(new PacketWorldPlayerDieNotify(dieType, killedBy));
         } else {
-            // Replacement avatar
-            EntityAvatar replacement = null;
-            int replaceIndex = -1;
-
-            for (int i = 0; i < this.getActiveTeam().size(); i++) {
-                EntityAvatar entity = this.getActiveTeam().get(i);
-                if (entity.isAlive()) {
-                    replaceIndex = i;
-                    replacement = entity;
-                    break;
-                }
-            }
-
-            if (replacement == null) {
+            // Find replacement avatar
+            int replaceIndex = getDeadAvatarReplacement();
+            if (0 <= replaceIndex && replaceIndex < this.getActiveTeam().size()) {
+                // Set index and spawn replacement member
+                this.setCurrentCharacterIndex(replaceIndex);
+                this.getPlayer().getScene().addEntity(this.getActiveTeam().get(replaceIndex));
+            } else {
                 // No more living team members...
                 this.getPlayer().sendPacket(new PacketWorldPlayerDieNotify(dieType, killedBy));
                 // Invoke player team death event.
@@ -831,15 +849,25 @@ public final class TeamManager extends BasePlayerDataManager {
                         new PlayerTeamDeathEvent(
                                 this.getPlayer(), this.getActiveTeam().get(this.getCurrentCharacterIndex()));
                 event.call();
-            } else {
-                // Set index and spawn replacement member
-                this.setCurrentCharacterIndex(replaceIndex);
-                this.getPlayer().getScene().addEntity(replacement);
             }
         }
 
         // Response packet
         this.getPlayer().sendPacket(new PacketAvatarDieAnimationEndRsp(deadAvatar.getId(), 0));
+    }
+
+    public int getDeadAvatarReplacement() {
+        int replaceIndex = -1;
+
+        for (int i = 0; i < this.getActiveTeam().size(); i++) {
+            EntityAvatar entity = this.getActiveTeam().get(i);
+            if (entity.isAlive()) {
+                replaceIndex = i;
+                break;
+            }
+        }
+
+        return replaceIndex;
     }
 
     public boolean reviveAvatar(Avatar avatar) {

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerDungeonDieOptionReq.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerDungeonDieOptionReq.java
@@ -1,0 +1,22 @@
+package emu.grasscutter.server.packet.recv;
+
+import emu.grasscutter.net.packet.*;
+import emu.grasscutter.net.proto.DungeonDieOptionReqOuterClass.DungeonDieOptionReq;
+import emu.grasscutter.net.proto.PlayerDieOptionOuterClass.PlayerDieOption;
+import emu.grasscutter.server.game.GameSession;
+
+@Opcodes(PacketOpcodes.DungeonDieOptionReq)
+public class HandlerDungeonDieOptionReq extends PacketHandler {
+
+    @Override
+    public void handle(GameSession session, byte[] header, byte[] payload) throws Exception {
+        DungeonDieOptionReq req = DungeonDieOptionReq.parseFrom(payload);
+        var dieOption = req.getDieOption();
+        // TODO Handle other die options
+        if (req.getIsQuitImmediately()) {
+            session.getPlayer().getServer().getDungeonSystem().exitDungeon(session.getPlayer());
+        }
+        session.getPlayer().sendPacket(new BasePacket(PacketOpcodes.DungeonDieOptionRsp));
+    }
+}
+


### PR DESCRIPTION
## Description

Fix "Internal Server Error" when reviving dead avatars.
* On scene transition, new EntityAvatar instances are created. Ensure dead avatars stay dead here by looking in fight prop cur HP.
* Avoid switching to dead avatars when leaving dungeons. On team wipe, revive and switch to the first avatar.
* Ignore AbilityMetaSetKilledState for EntityAvatar. Pretty sure this is not supposed to immediately reset dead avatars to full HP, because it will bug revivals.

Allow quitting from tower on team wipe.

Fix player becoming stranded in dungeons by teleporting away.
* DungeonSystem.exitDungeon normally teleports player out on exit. But when player quits a dungeon by teleporting on map, this causes double teleports:
    1. Teleport by DungeonSystem.exitDungeon
    2. Teleport by map waypoint
* This causes the player to get stranded. Fix it by having DungeonSystem.exitDungeon delay its teleport by 200ms. If map teleport happens, the delayed teleport is canceled.

Some befores/afters:

| | Before | After |
|-|-|-|
|Team wipe| ![gif](https://github.com/longfruit/Grasscutter/blob/fix-revives-gifs/wipe_before.gif?raw=true) | ![gif](https://github.com/longfruit/Grasscutter/blob/fix-revives-gifs/wipe_after.gif?raw=true) |
|Teleporting from dungeon| ![gif](https://github.com/longfruit/Grasscutter/blob/fix-revives-gifs/exit_before.gif?raw=true) | ![gif](https://github.com/longfruit/Grasscutter/blob/fix-revives-gifs/exit_after.gif?raw=true) |
|Revive| ![gif](https://github.com/longfruit/Grasscutter/blob/fix-revives-gifs/fell_before.gif?raw=true) | ![gif](https://github.com/longfruit/Grasscutter/blob/fix-revives-gifs/fell_after.gif?raw=true) |

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
