### PR TITLE
Add events to support scene group substitution

### DIFF
--- a/src/main/java/emu/grasscutter/game/world/GroupReplacementData.java
+++ b/src/main/java/emu/grasscutter/game/world/GroupReplacementData.java
@@ -5,6 +5,13 @@ import lombok.Data;
 
 @Data
 public class GroupReplacementData {
-    int id;
-    List<Integer> replace_groups;
+    public int id;
+    public List<Integer> replace_groups;
+
+    public GroupReplacementData() {}
+
+    public GroupReplacementData(int id, List<Integer> replace_groups) {
+        this.id = id;
+        this.replace_groups = replace_groups;
+    }
 }

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -1110,6 +1110,9 @@ public class Scene {
         if (group.regions != null) {
             group.regions.values().forEach(getScriptManager()::deregisterRegion);
         }
+        if (challenge != null && group.id == challenge.getGroup().id) {
+            challenge.fail();
+        }
 
         scriptManager.getLoadedGroupSetPerBlock().get(block.id).remove(group);
         this.loadedGroups.remove(group);

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -443,9 +443,9 @@ public class SceneScriptManager {
         var event = new SceneMetaLoadEvent(getScene());
         event.call();
 
-        if (event.hasOverride) {
-            // Group grids should not be cached when a scene group
-            // override is in effect. Otherwise, when the server
+        if (event.isOverride()) {
+            // Group grids should not be cached to disk when a scene
+            // group override is in effect. Otherwise, when the server
             // next runs without that override, the cached content
             // will not make sense.
             noCacheGroupGridsToDisk = true;

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -17,6 +17,7 @@ import emu.grasscutter.net.proto.VisionTypeOuterClass;
 import emu.grasscutter.scripts.constants.EventType;
 import emu.grasscutter.scripts.data.*;
 import emu.grasscutter.scripts.service.*;
+import emu.grasscutter.server.event.game.SceneMetaLoadEvent;
 import emu.grasscutter.server.packet.send.PacketGroupSuiteNotify;
 import emu.grasscutter.utils.*;
 import io.netty.util.concurrent.FastThreadLocalThread;
@@ -38,6 +39,7 @@ public class SceneScriptManager {
     private final Map<String, Integer> variables;
     private SceneMeta meta;
     private boolean isInit;
+    private boolean noCacheGroupGridsToDisk;
 
     private final Map<String, SceneTimeAxis> timeAxis = new ConcurrentHashMap<>();
 
@@ -134,7 +136,7 @@ public class SceneScriptManager {
     public void registerTrigger(SceneTrigger trigger) {
         this.triggerInvocations.put(trigger.getName(), new AtomicInteger(0));
         this.getTriggersByEvent(trigger.getEvent()).add(trigger);
-        Grasscutter.getLogger().trace("Registered trigger {}", trigger.getName());
+        Grasscutter.getLogger().trace("Registered trigger {} from group {}", trigger.getName(), trigger.getCurrentGroup().id);
     }
 
     public void deregisterTrigger(List<SceneTrigger> triggers) {
@@ -143,7 +145,7 @@ public class SceneScriptManager {
 
     public void deregisterTrigger(SceneTrigger trigger) {
         this.getTriggersByEvent(trigger.getEvent()).remove(trigger);
-        Grasscutter.getLogger().trace("deregistered trigger {}", trigger.getName());
+        Grasscutter.getLogger().trace("deregistered trigger {} from group {}", trigger.getName(), trigger.getCurrentGroup().id);
     }
 
     public void resetTriggers(int eventId) {
@@ -438,6 +440,17 @@ public class SceneScriptManager {
     }
 
     private void init() {
+        var event = new SceneMetaLoadEvent(getScene());
+        event.call();
+
+        if (event.hasOverride) {
+            // Group grids should not be cached when a scene group
+            // override is in effect. Otherwise, when the server
+            // next runs without that override, the cached content
+            // will not make sense.
+            noCacheGroupGridsToDisk = true;
+        }
+
         var meta = ScriptLoader.getSceneMeta(getScene().getId());
         if (meta == null) {
             return;
@@ -455,7 +468,7 @@ public class SceneScriptManager {
             return groupGridsCache.get(sceneId);
         } else {
             var path = FileUtils.getCachePath("scene" + sceneId + "_grid.json");
-            if (path.toFile().isFile() && !Grasscutter.config.server.game.cacheSceneEntitiesEveryRun) {
+            if (path.toFile().isFile() && !Grasscutter.config.server.game.cacheSceneEntitiesEveryRun && !noCacheGroupGridsToDisk) {
                 try {
                     var groupGrids = JsonUtils.loadToList(path, Grid.class);
                     groupGridsCache.put(sceneId, groupGrids);
@@ -585,15 +598,17 @@ public class SceneScriptManager {
             }
             groupGridsCache.put(scene.getId(), groupGrids);
 
-            try {
-                Files.createDirectories(path.getParent());
-            } catch (IOException ignored) {
-            }
-            try (var file = new FileWriter(path.toFile())) {
-                file.write(JsonUtils.encode(groupGrids));
-                Grasscutter.getLogger().info("Scene {} saved grid file.", getScene().getId());
-            } catch (Exception e) {
-                Grasscutter.getLogger().error("Scene {} unable to save grid file.", getScene().getId(), e);
+            if (!noCacheGroupGridsToDisk) {
+                try {
+                    Files.createDirectories(path.getParent());
+                } catch (IOException ignored) {
+                }
+                try (var file = new FileWriter(path.toFile())) {
+                    file.write(JsonUtils.encode(groupGrids));
+                    Grasscutter.getLogger().info("Scene {} saved grid file.", getScene().getId());
+                } catch (Exception e) {
+                    Grasscutter.getLogger().error("Scene {} unable to save grid file.", getScene().getId(), e);
+                }
             }
             return groupGrids;
         }

--- a/src/main/java/emu/grasscutter/scripts/data/SceneBlock.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneBlock.java
@@ -5,6 +5,7 @@ import com.github.davidmoten.rtreemulti.geometry.*;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.game.world.Position;
 import emu.grasscutter.scripts.*;
+import emu.grasscutter.server.event.game.SceneBlockLoadedEvent;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.script.*;
@@ -64,6 +65,11 @@ public class SceneBlock {
                             .collect(Collectors.toMap(x -> x.id, y -> y, (a, b) -> a));
 
             this.groups.values().forEach(g -> g.block_id = this.id);
+
+            var event = new SceneBlockLoadedEvent(this);
+            event.call();
+
+            var gids = this.groups.values().stream().map(g -> g.id).collect(Collectors.toList());
             this.sceneGroupIndex =
                     SceneIndexManager.buildIndex(3, this.groups.values(), g -> g.pos.toPoint());
         } catch (ScriptException exception) {

--- a/src/main/java/emu/grasscutter/scripts/data/SceneBlock.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneBlock.java
@@ -69,7 +69,6 @@ public class SceneBlock {
             var event = new SceneBlockLoadedEvent(this);
             event.call();
 
-            var gids = this.groups.values().stream().map(g -> g.id).collect(Collectors.toList());
             this.sceneGroupIndex =
                     SceneIndexManager.buildIndex(3, this.groups.values(), g -> g.pos.toPoint());
         } catch (ScriptException exception) {

--- a/src/main/java/emu/grasscutter/scripts/data/SceneGroup.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneGroup.java
@@ -3,6 +3,7 @@ package emu.grasscutter.scripts.data;
 import emu.grasscutter.Grasscutter;
 import emu.grasscutter.game.world.Position;
 import emu.grasscutter.scripts.ScriptLoader;
+import java.io.*;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.script.*;
@@ -39,6 +40,7 @@ public final class SceneGroup {
     private transient boolean loaded;
     private transient CompiledScript script;
     private transient Bindings bindings;
+    public String overrideScriptPath;
 
     public static SceneGroup of(int groupId) {
         var group = new SceneGroup();
@@ -86,8 +88,12 @@ public final class SceneGroup {
         // Create the bindings.
         this.bindings = ScriptLoader.getEngine().createBindings();
 
-        var cs =
-                ScriptLoader.getScript("Scene/%s/scene%s_group%s.lua".formatted(sceneId, sceneId, this.id));
+        CompiledScript cs;
+        if (overrideScriptPath != null && !overrideScriptPath.equals("")) {
+            cs = ScriptLoader.getScript(overrideScriptPath, true);
+        } else {
+            cs = ScriptLoader.getScript("Scene/%s/scene%s_group%s.lua".formatted(sceneId, sceneId, this.id));
+        }
 
         if (cs == null) {
             return this;

--- a/src/main/java/emu/grasscutter/server/event/game/SceneBlockLoadedEvent.java
+++ b/src/main/java/emu/grasscutter/server/event/game/SceneBlockLoadedEvent.java
@@ -1,0 +1,14 @@
+package emu.grasscutter.server.event.game;
+
+import emu.grasscutter.server.event.types.ServerEvent;
+import emu.grasscutter.scripts.data.SceneBlock;
+
+public final class SceneBlockLoadedEvent extends ServerEvent {
+    public SceneBlock block;
+
+    public SceneBlockLoadedEvent(SceneBlock block) {
+        super(Type.GAME);
+
+        this.block = block;
+    }
+}

--- a/src/main/java/emu/grasscutter/server/event/game/SceneBlockLoadedEvent.java
+++ b/src/main/java/emu/grasscutter/server/event/game/SceneBlockLoadedEvent.java
@@ -2,9 +2,11 @@ package emu.grasscutter.server.event.game;
 
 import emu.grasscutter.server.event.types.ServerEvent;
 import emu.grasscutter.scripts.data.SceneBlock;
+import lombok.*;
 
+@Getter
 public final class SceneBlockLoadedEvent extends ServerEvent {
-    public SceneBlock block;
+    private SceneBlock block;
 
     public SceneBlockLoadedEvent(SceneBlock block) {
         super(Type.GAME);

--- a/src/main/java/emu/grasscutter/server/event/game/SceneMetaLoadEvent.java
+++ b/src/main/java/emu/grasscutter/server/event/game/SceneMetaLoadEvent.java
@@ -1,0 +1,15 @@
+package emu.grasscutter.server.event.game;
+
+import emu.grasscutter.game.world.Scene;
+import emu.grasscutter.server.event.types.ServerEvent;
+
+public final class SceneMetaLoadEvent extends ServerEvent {
+    public Scene scene;
+    public boolean hasOverride;
+
+    public SceneMetaLoadEvent(Scene scene) {
+        super(Type.GAME);
+
+        this.scene = scene;
+    }
+}

--- a/src/main/java/emu/grasscutter/server/event/game/SceneMetaLoadEvent.java
+++ b/src/main/java/emu/grasscutter/server/event/game/SceneMetaLoadEvent.java
@@ -2,10 +2,12 @@ package emu.grasscutter.server.event.game;
 
 import emu.grasscutter.game.world.Scene;
 import emu.grasscutter.server.event.types.ServerEvent;
+import lombok.*;
 
+@Getter
 public final class SceneMetaLoadEvent extends ServerEvent {
-    public Scene scene;
-    public boolean hasOverride;
+    private Scene scene;
+    @Setter private boolean override;
 
     public SceneMetaLoadEvent(Scene scene) {
         super(Type.GAME);


### PR DESCRIPTION
## Description

Add new events to support scene group substitution:

| Event | Called when |
|-|-|
| SceneBlockLoadedEvent | SceneBlock finishes reading from block script |
| SceneMetaLoadEvent | SceneScriptManager starts loading SceneMeta |

Example plugin using these events: [SceneHook](https://github.com/longfruit/SceneHook). Disclaimer: I wrote it.

![gif](https://github.com/longfruit/Grasscutter/blob/scene-hook-gifs/shook.gif?raw=true)

Basic flow:
1. Plugin provides replacement groups.
2. Replacement groups can be registered on demand or automatically at plugin load time.
    1. On SceneBlock load, plugin can change existing and add new groups.
    2. On SceneMeta load, plugin can hook in dynamic group loads when scene finishes loading.
4. Groups become replaced on demand or automatically at scene load time.

---

Also, fix a script issue caused by EVENT_ANY_MONSTER_DIE firing at the same time.

| Before | After |
|-|-|
|![gif](https://github.com/longfruit/Grasscutter/blob/scene-hook-gifs/mob_ev_before.gif?raw=true)|![gif](https://github.com/longfruit/Grasscutter/blob/scene-hook-gifs/mob_ev_after.gif?raw=true)|

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [x] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
