### PR TITLE
Only deduct energy when elemental burst actually fires

### DIFF
--- a/src/main/java/emu/grasscutter/data/binout/AbilityModifier.java
+++ b/src/main/java/emu/grasscutter/data/binout/AbilityModifier.java
@@ -327,6 +327,7 @@ public class AbilityModifier implements Serializable {
         public String srcKey, dstKey;
 
         public int skillID;
+        public int resistanceListID;
 
         public AbilityModifierAction[] actions;
         public AbilityModifierAction[] successActions;

--- a/src/main/java/emu/grasscutter/game/managers/energy/EnergyManager.java
+++ b/src/main/java/emu/grasscutter/game/managers/energy/EnergyManager.java
@@ -259,8 +259,14 @@ public class EnergyManager extends BasePlayerManager {
             return;
         }
 
+        // Also reference AvatarSkillData in case the burst gets a different skill ID
+        // when the avatar is in a different state. For example, Wanderer's burst is
+        // 10755 usually but when he floats, it becomes 10753.
+        var skillData = GameData.getAvatarSkillDataMap().get(skillId);
+
         // If the cast skill was a burst, consume energy.
-        if (avatar.getSkillDepot() != null && skillId == avatar.getSkillDepot().getEnergySkill()) {
+        if ((avatar.getSkillDepot() != null && skillId == avatar.getSkillDepot().getEnergySkill()) ||
+                    (skillData != null && skillData.getCostElemVal() > 0)) {
             avatar.getAsEntity().clearEnergy(ChangeEnergyReason.CHANGE_ENERGY_REASON_SKILL_START);
         }
     }

--- a/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtDoSkillSuccNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/recv/HandlerEvtDoSkillSuccNotify.java
@@ -21,7 +21,6 @@ public class HandlerEvtDoSkillSuccNotify extends PacketHandler {
 
         // Handle skill notify in other managers.
         player.getStaminaManager().handleEvtDoSkillSuccNotify(session, skillId, casterId);
-        player.getEnergyManager().handleEvtDoSkillSuccNotify(session, skillId, casterId);
         player.getQuestManager().queueEvent(QuestContent.QUEST_CONTENT_SKILL, skillId);
     }
 }


### PR DESCRIPTION
## Description

Elemental burst (Q) can misfire occasionally if done when dashing, doing elemental skill (E), or switching avatars. The client would still send EvtDoSkillSuccNotify, but the burst may not actually happen, and GC currently clears energy whether the burst happened or not.

Fix this by checking AbilityInvocationsNotify packets from the client. On successful bursts, there will be packets with information specific to the burst, like setting resistance/invincible state, AvatarSkillStart action. These can be used to decide when to clear energy and set invulnerability.

Also fix Wanderer's energy not clearing if bursting while floating.

---

This fix could use more testing. I can't exhaustively test through all characters and scenarios. But at least my quick swap teams in abyss no longer have any burst issue.

Preview:
* Faruzan: Works fine
* Bennett: E into Q causes misfire
* Yelan: E into Q causes misfire
* Wanderer: E into Q doesn't clear energy

| Before | After |
|-|-|
| ![gif](https://github.com/longfruit/Grasscutter/blob/gifs/bursts_before.gif?raw=true) | ![gif](https://github.com/longfruit/Grasscutter/blob/gifs/bursts.gif?raw=true) |

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
https://github.com/Grasscutters/Grasscutter/issues/1248


## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
