### PR TITLE
Fix tower mob level and hp scaling

### DIFF
--- a/src/main/java/emu/grasscutter/data/excels/tower/TowerLevelData.java
+++ b/src/main/java/emu/grasscutter/data/excels/tower/TowerLevelData.java
@@ -13,6 +13,7 @@ public class TowerLevelData extends GameResource {
     private int levelGroupId;
     private int dungeonId;
     private List<TowerLevelCond> conds;
+    private int monsterLevel;
 
     public static class TowerLevelCond {
         private TowerCondType towerCondType;

--- a/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/DungeonManager.java
@@ -82,8 +82,13 @@ public final class DungeonManager {
     }
 
     public int getLevelForMonster(int id) {
-        // TODO should use levelConfigMap? and how?
-        return dungeonData.getShowLevel();
+        if (isTowerDungeon()) {
+            // Tower dungeons have their own level setting in TowerLevelData
+            return scene.getPlayers().get(0).getTowerManager().getCurrentMonsterLevel();
+        } else {
+            // TODO should use levelConfigMap? and how?
+            return dungeonData.getShowLevel();
+        }
     }
 
     public boolean activateRespawnPoint(int pointId) {

--- a/src/main/java/emu/grasscutter/game/entity/EntityMonster.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityMonster.java
@@ -355,6 +355,28 @@ public class EntityMonster extends GameEntity {
                                         + (this.getFightProperty(c.getBase())
                                                 * (1f + this.getFightProperty(c.getPercent())))));
 
+        // If in tower, scale max hp by
+        //   +50%: Floors 3 – 7
+        //  +100%: Floors 8 – 11
+        //  +150%: Floor 12
+        var dungeonManager = getScene().getDungeonManager();
+        var towerManager = getScene().getPlayers().get(0).getTowerManager();
+        if (dungeonManager != null && dungeonManager.isTowerDungeon() && towerManager != null) {
+            var floor = towerManager.getCurrentFloorNumber();
+            float additionalScaleFactor = 0f;
+            if (floor >= 12) {
+                additionalScaleFactor = 1.5f;
+            } else if (floor >= 8) {
+                additionalScaleFactor = 1.f;
+            } else if (floor >= 3) {
+                additionalScaleFactor = .5f;
+            }
+
+            this.setFightProperty(
+                    FightProperty.FIGHT_PROP_MAX_HP,
+                    this.getFightProperty(FightProperty.FIGHT_PROP_MAX_HP) * (1 + additionalScaleFactor));
+        }
+
         // Set current hp
         this.setFightProperty(
                 FightProperty.FIGHT_PROP_CUR_HP,

--- a/src/main/java/emu/grasscutter/game/tower/TowerManager.java
+++ b/src/main/java/emu/grasscutter/game/tower/TowerManager.java
@@ -29,6 +29,11 @@ public class TowerManager extends BasePlayerManager {
         return this.getTowerData().currentFloorId;
     }
 
+    /** floor number: 1 - 12 **/
+    public int getCurrentFloorNumber() {
+        return GameData.getTowerFloorDataMap().get(getCurrentFloorId()).getFloorIndex();
+    }
+
     public int getCurrentLevelId() {
         return this.getTowerData().currentLevelId + this.getTowerData().currentLevel;
     }
@@ -93,8 +98,17 @@ public class TowerManager extends BasePlayerManager {
         player.getTeamManager().setupTemporaryTeam(towerTeams);
     }
 
+    public TowerLevelData getCurrentTowerLevelDataMap() {
+        return GameData.getTowerLevelDataMap().get(getCurrentLevelId());
+    }
+
+    public int getCurrentMonsterLevel() {
+        // monsterLevel given in TowerLevelExcelConfigData.json is off by one.
+        return getCurrentTowerLevelDataMap().getMonsterLevel() + 1;
+    }
+
     public void enterLevel(int enterPointId) {
-        var levelData = GameData.getTowerLevelDataMap().get(getCurrentLevelId());
+        var levelData = getCurrentTowerLevelDataMap();
 
         var dungeonId = levelData.getDungeonId();
 
@@ -140,7 +154,7 @@ public class TowerManager extends BasePlayerManager {
             return 0;
         }
 
-        var levelData = GameData.getTowerLevelDataMap().get(getCurrentLevelId());
+        var levelData = getCurrentTowerLevelDataMap();
         // 0-based indexing. "star" = 0 means checking for 1-star conditions.
         int star;
         for (star = 2; star >= 0; star--) {

--- a/src/main/java/emu/grasscutter/game/world/Scene.java
+++ b/src/main/java/emu/grasscutter/game/world/Scene.java
@@ -767,6 +767,20 @@ public class Scene {
         return level;
     }
 
+    public int getLevelForMonster(int configId, int defaultLevel) {
+        if (getDungeonManager() != null) {
+            return getDungeonManager().getLevelForMonster(configId);
+        } else if (getWorld().getWorldLevel() > 0) {
+            var worldLevelData =
+                    GameData.getWorldLevelDataMap().get(getWorld().getWorldLevel());
+
+            if (worldLevelData != null) {
+                return worldLevelData.getMonsterLevel();
+            }
+        }
+        return defaultLevel;
+    }
+
     public void checkNpcGroup() {
         Set<SceneNpcBornEntry> npcBornEntries = ConcurrentHashMap.newKeySet();
         for (Player player : this.getPlayers()) {

--- a/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
+++ b/src/main/java/emu/grasscutter/scripts/SceneScriptManager.java
@@ -1069,18 +1069,7 @@ public class SceneScriptManager {
         }
 
         // Calculate level
-        int level = monster.level;
-
-        if (getScene().getDungeonManager() != null) {
-            level = getScene().getDungeonManager().getLevelForMonster(monster.config_id);
-        } else if (getScene().getWorld().getWorldLevel() > 0) {
-            var worldLevelData =
-                    GameData.getWorldLevelDataMap().get(getScene().getWorld().getWorldLevel());
-
-            if (worldLevelData != null) {
-                level = worldLevelData.getMonsterLevel();
-            }
-        }
+        int level = getScene().getLevelForMonster(monster.config_id, monster.level);
 
         // Spawn mob
         EntityMonster entity = new EntityMonster(getScene(), data, monster.pos, monster.rot, level);


### PR DESCRIPTION
## Description

Make tower mobs more annoying:
* Scale mob level according to monsterLevel in TowerLevelExcelConfigData.json. For example, 12-2 mobs should have level 98.
* Scale mob HP according to _anime game_ wiki:
    * +50%: Floors 3 - 7
    * +100%: Floors 8 - 11
    * +150%: Floors 12
* Simplify clearing burst energy. idk why i even saved a callback.

---

Preview:

| Before | After |
|-|-|
| ![img](https://github.com/longfruit/Grasscutter/blob/gifs/stuff/tower-scale-before.jpg?raw=true) | ![img](https://github.com/longfruit/Grasscutter/blob/gifs/stuff/tower-scale-after.jpg?raw=true) |

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
