### PR TITLE
Handle mob summon and limbo state

### DIFF
--- a/src/main/java/emu/grasscutter/data/binout/AbilityModifier.java
+++ b/src/main/java/emu/grasscutter/data/binout/AbilityModifier.java
@@ -42,6 +42,7 @@ public class AbilityModifier implements Serializable {
     public String stacking;
 
     public AbilityMixinData[] modifierMixins;
+    public AbilityModifierProperty properties;
 
     public ElementType elementType;
     public DynamicFloat elementDurability = DynamicFloat.ZERO;
@@ -328,6 +329,9 @@ public class AbilityModifier implements Serializable {
 
         public int skillID;
         public int resistanceListID;
+        public int monsterID;
+        public int summonTag;
+
 
         public AbilityModifierAction[] actions;
         public AbilityModifierAction[] successActions;
@@ -368,6 +372,11 @@ public class AbilityModifier implements Serializable {
             BigWorldOnly,
             ForceDrop
         }
+    }
+
+    public static class AbilityModifierProperty implements Serializable {
+        public float Actor_HpThresholdRatio;
+        // Add more properties here when GC needs them.
     }
 
     public enum State {

--- a/src/main/java/emu/grasscutter/data/binout/config/fields/ConfigCombat.java
+++ b/src/main/java/emu/grasscutter/data/binout/config/fields/ConfigCombat.java
@@ -8,4 +8,5 @@ import lombok.experimental.FieldDefaults;
 public class ConfigCombat {
     // There are more values that can be added that might be useful in the json
     ConfigCombatProperty property;
+    ConfigCombatSummon summon;
 }

--- a/src/main/java/emu/grasscutter/data/binout/config/fields/ConfigCombatSummon.java
+++ b/src/main/java/emu/grasscutter/data/binout/config/fields/ConfigCombatSummon.java
@@ -1,0 +1,15 @@
+package emu.grasscutter.data.binout.config.fields;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+import java.util.List;
+
+@Data
+public class ConfigCombatSummon {
+    List<SummonTag> summonTags;
+
+    @Getter
+    public final class SummonTag {
+        int summonTag;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/ability/Ability.java
+++ b/src/main/java/emu/grasscutter/game/ability/Ability.java
@@ -71,6 +71,24 @@ public class Ability {
                         .filter(action -> action.type == AbilityModifierAction.Type.AvatarSkillStart)
                         .map(action -> action.skillID)
                         .toList());
+
+        if (data.onAdded != null) {
+            processOnAddedAbilityModifiers();
+        }
+    }
+
+    public void processOnAddedAbilityModifiers() {
+        for (AbilityModifierAction modifierAction : data.onAdded) {
+            if (modifierAction.type == null) continue;
+
+            if (modifierAction.type == AbilityModifierAction.Type.ApplyModifier) {
+                if (modifierAction.modifierName == null) continue;
+                else if (!data.modifiers.containsKey(modifierAction.modifierName)) continue;
+
+                var modifierData = data.modifiers.get(modifierAction.modifierName);
+                owner.onAddAbilityModifier(modifierData);
+            }
+        }
     }
 
     public static String getAbilityName(AbilityString abString) {

--- a/src/main/java/emu/grasscutter/game/ability/actions/ActionSummon.java
+++ b/src/main/java/emu/grasscutter/game/ability/actions/ActionSummon.java
@@ -1,0 +1,62 @@
+package emu.grasscutter.game.ability.actions;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import emu.grasscutter.Grasscutter;
+import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.binout.AbilityModifier.AbilityModifierAction;
+import emu.grasscutter.game.ability.Ability;
+import emu.grasscutter.game.entity.*;
+import emu.grasscutter.game.world.*;
+import emu.grasscutter.server.packet.send.PacketMonsterSummonTagNotify;
+import emu.grasscutter.net.proto.EPKDEHOJFLIOuterClass.EPKDEHOJFLI;
+import emu.grasscutter.utils.*;
+
+@AbilityAction(AbilityModifierAction.Type.Summon)
+public class ActionSummon extends AbilityActionHandler {
+    @Override
+    public synchronized boolean execute(
+            Ability ability, AbilityModifierAction action, ByteString abilityData, GameEntity target) {
+        EPKDEHOJFLI summonPosRot = null;
+        try {
+            // In game version 4.0, summoned entity's
+            // position and rotation are packed in EPKDEHOJFLI.
+            // This is packet AbilityActionSummon and has two fields:
+            //  4: Vector pos
+            //  13: Vector rot
+            summonPosRot = EPKDEHOJFLI.parseFrom(abilityData);
+        } catch (InvalidProtocolBufferException e) {
+            Grasscutter.getLogger().error("Failed to parse abilityData: {}", Utils.bytesToHex(abilityData.toByteArray()));
+            return false;
+        }
+
+        var pos = new Position(summonPosRot.getPos());
+        var rot = new Position(summonPosRot.getRot());
+        var monsterId = action.monsterID;
+
+        var scene = target.getScene();
+
+        var monsterData = GameData.getMonsterDataMap().get(monsterId);
+        if (monsterData == null) {
+            Grasscutter.getLogger().error("Failed to find monster by ID {}", monsterId);
+            return false;
+        }
+
+        if (target instanceof EntityMonster ownerEntity) {
+            var level = scene.getLevelForMonster(0, ownerEntity.getLevel());
+            var entity = new EntityMonster(scene, monsterData, pos, rot, level);
+            ownerEntity.getSummonTagMap().put(action.summonTag, entity);
+            entity.setSummonedTag(action.summonTag);
+            entity.setOwnerEntityId(target.getId());
+            scene.addEntity(entity);
+            scene.getPlayers().get(0).sendPacket(new PacketMonsterSummonTagNotify(ownerEntity));
+
+            Grasscutter.getLogger().trace("Spawned entityId {} monsterId {} pos {} rot {}, target { {} }, action { {} }",
+                    entity.getId(), monsterId, pos, rot, target, action);
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/main/java/emu/grasscutter/game/entity/GameEntity.java
+++ b/src/main/java/emu/grasscutter/game/entity/GameEntity.java
@@ -1,6 +1,8 @@
 package emu.grasscutter.game.entity;
 
+import emu.grasscutter.Grasscutter;
 import emu.grasscutter.data.GameData;
+import emu.grasscutter.data.binout.*;
 import emu.grasscutter.game.ability.*;
 import emu.grasscutter.game.player.Player;
 import emu.grasscutter.game.props.*;
@@ -32,6 +34,8 @@ public abstract class GameEntity {
     @Getter @Setter private int lastMoveReliableSeq;
 
     @Getter @Setter private boolean lockHP;
+    private boolean limbo;
+    private float limboHpThreshold;
 
     @Setter(AccessLevel.PROTECTED)
     @Getter
@@ -110,6 +114,20 @@ public abstract class GameEntity {
                         });
     }
 
+    protected void setLimbo(float hpThreshold) {
+        limbo = true;
+        limboHpThreshold = hpThreshold;
+    }
+
+    public void onAddAbilityModifier(AbilityModifier data) {
+        // Set limbo state (invulnerability at a certain HP threshold)
+        // if ability modifier calls for it
+        if (data.state == AbilityModifier.State.Limbo &&
+                    data.properties != null && data.properties.Actor_HpThresholdRatio > .0f) {
+            this.setLimbo(data.properties.Actor_HpThresholdRatio);
+        }
+    }
+
     protected MotionInfo getMotionInfo() {
         return MotionInfo.newBuilder()
                 .setPos(this.getPosition().toProto())
@@ -167,11 +185,26 @@ public abstract class GameEntity {
             return; // If the event is canceled, do not damage the entity.
         }
 
+        float effectiveDamage = 0;
         float curHp = getFightProperty(FightProperty.FIGHT_PROP_CUR_HP);
-        if (curHp != Float.POSITIVE_INFINITY && !lockHP || lockHP && curHp <= event.getDamage()) {
-            // Add negative HP to the current HP property.
-            this.addFightProperty(FightProperty.FIGHT_PROP_CUR_HP, -(event.getDamage()));
+        if (limbo) {
+            float maxHp = getFightProperty(FightProperty.FIGHT_PROP_MAX_HP);
+            float curRatio = curHp / maxHp;
+            if (curRatio > limboHpThreshold) {
+                // OK if this hit takes HP below threshold.
+                effectiveDamage = event.getDamage();
+            }
+            if (effectiveDamage >= curHp && limboHpThreshold > .0f) {
+                // Don't let entity die while in limbo.
+                effectiveDamage = curHp - 1;
+            }
         }
+        else if (curHp != Float.POSITIVE_INFINITY && !lockHP || lockHP && curHp <= event.getDamage()) {
+            effectiveDamage = event.getDamage();
+        }
+
+        // Add negative HP to the current HP property.
+        this.addFightProperty(FightProperty.FIGHT_PROP_CUR_HP, -effectiveDamage);
 
         this.lastAttackType = attackType;
         this.checkIfDead();

--- a/src/main/java/emu/grasscutter/game/world/World.java
+++ b/src/main/java/emu/grasscutter/game/world/World.java
@@ -167,7 +167,7 @@ public class World implements Iterable<Player> {
      * @param idType The entity type.
      * @return The next entity ID.
      */
-    public int getNextEntityId(EntityIdType idType) {
+    public synchronized int getNextEntityId(EntityIdType idType) {
         return (idType.getId() << 24) + ++this.nextEntityId;
     }
 

--- a/src/main/java/emu/grasscutter/server/packet/send/PacketMonsterSummonTagNotify.java
+++ b/src/main/java/emu/grasscutter/server/packet/send/PacketMonsterSummonTagNotify.java
@@ -1,0 +1,23 @@
+package emu.grasscutter.server.packet.send;
+
+import emu.grasscutter.game.entity.EntityMonster;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.world.Scene;
+import emu.grasscutter.net.packet.*;
+import emu.grasscutter.net.proto.MonsterSummonTagNotifyOuterClass.MonsterSummonTagNotify;
+import java.util.*;
+import static java.util.Map.entry;
+
+public class PacketMonsterSummonTagNotify extends BasePacket {
+
+    public PacketMonsterSummonTagNotify(EntityMonster monsterEntity) {
+        super(PacketOpcodes.MonsterSummonTagNotify);
+
+        var proto =
+                MonsterSummonTagNotify.newBuilder()
+                        .setMonsterEntityId(monsterEntity.getId());
+        monsterEntity.getSummonTagMap().forEach((k, v) -> proto.putSummonTagMap(k, v == null ? 0 : 1));
+
+        this.setData(proto.build());
+    }
+}


### PR DESCRIPTION
## Description

Mob summon: Something like Monster_Apparatus_Perpetual can summon helper mobs. Ensure these helpers actually get summoned and, on their defeat, possibly change the summoner mob state. Like, temporarily enter weak state.
* Take summon tags from BinOutput/Monster/ConfigMonster_*.json and put them in SceneMonsterInfo
* Handle Summon action in ability modifiers from BinOutput/Ability/Temp/MonsterAbilities/ConfigAbility_Monster_*.json
* On summoner's kill, also kill the summoned mobs

Limbo state: Something like Monster_Invoker_Herald_Water should be invulnerable at a certain HP threshold. Like, shouldn't die when creating their elemental shield. Or, Monster_Apparatus_Perpetual's helper mobs shouldn't die before their summoner.
* Look through ConfigAbility (AbilityData in GC) like Invoker_Herald_Water_StateControl. If any AbilityModifier within specifies state Limbo and properties.Actor_HpThresholdRatio, account for this threshold in GameEntity::damage.
* Don't let the entity die while in limbo. They will be killed by other events.

---

Preview

### Water Herald
Before: https://imgur.com/CSQEqal
After: https://imgur.com/HJf5msE

### Perpetual Apparatus
Before: https://imgur.com/XnF21Vs
After: https://imgur.com/83J5XY6

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
