### PR TITLE
Fix some more dungeons

### DIFF
--- a/src/main/java/emu/grasscutter/game/dungeons/challenge/WorldChallenge.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/challenge/WorldChallenge.java
@@ -29,7 +29,7 @@ public class WorldChallenge {
     private final AtomicInteger score;
     private boolean progress;
     private boolean success;
-    private long startedAt;
+    private int startedAt;
     private int finishedTime;
 
     /**

--- a/src/main/java/emu/grasscutter/game/dungeons/challenge/factory/KillMonsterCountInTimeIncChallengeFactoryHandler.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/challenge/factory/KillMonsterCountInTimeIncChallengeFactoryHandler.java
@@ -36,6 +36,6 @@ public class KillMonsterCountInTimeIncChallengeFactoryHandler implements Challen
                 List.of(
                         new KillMonsterCountTrigger(),
                         new InTimeTrigger(),
-                        new KillMonsterTimeIncTrigger(timeInc)));
+                        new KillMonsterTimeIncTrigger(timeLimit, timeInc)));
     }
 }

--- a/src/main/java/emu/grasscutter/game/dungeons/challenge/factory/KillMonsterTimeChallengeFactoryHandler.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/challenge/factory/KillMonsterTimeChallengeFactoryHandler.java
@@ -1,11 +1,12 @@
 package emu.grasscutter.game.dungeons.challenge.factory;
 
+import emu.grasscutter.data.GameData;
 import emu.grasscutter.game.dungeons.challenge.WorldChallenge;
 import emu.grasscutter.game.dungeons.challenge.enums.ChallengeType;
 import emu.grasscutter.game.dungeons.challenge.trigger.*;
 import emu.grasscutter.game.world.Scene;
 import emu.grasscutter.scripts.data.SceneGroup;
-import java.util.List;
+import java.util.*;
 import lombok.val;
 
 public class KillMonsterTimeChallengeFactoryHandler implements ChallengeFactoryHandler {
@@ -28,6 +29,15 @@ public class KillMonsterTimeChallengeFactoryHandler implements ChallengeFactoryH
             Scene scene,
             SceneGroup group) {
         val realGroup = scene.getScriptManager().getGroupById(groupId);
+        val challengeTriggers = new ArrayList<ChallengeTrigger>();
+        challengeTriggers.addAll(List.of(new KillMonsterCountTrigger(), new InTimeTrigger()));
+
+        val challengeData = GameData.getDungeonChallengeConfigDataMap().get(challengeId);
+        val challengeType = challengeData.getChallengeType();
+        if (challengeType == ChallengeType.CHALLENGE_KILL_COUNT_FAST) {
+            challengeTriggers.add(new KillMonsterTimeIncTrigger(timeLimit, 0 /* refresh to original limit on kill */));
+        }
+
         return new WorldChallenge(
                 scene,
                 realGroup,
@@ -36,6 +46,6 @@ public class KillMonsterTimeChallengeFactoryHandler implements ChallengeFactoryH
                 List.of(targetCount, timeLimit),
                 timeLimit, // Limit
                 targetCount, // Goal
-                List.of(new KillMonsterCountTrigger(), new InTimeTrigger()));
+                challengeTriggers);
     }
 }

--- a/src/main/java/emu/grasscutter/game/dungeons/challenge/trigger/KillMonsterTimeIncTrigger.java
+++ b/src/main/java/emu/grasscutter/game/dungeons/challenge/trigger/KillMonsterTimeIncTrigger.java
@@ -6,22 +6,31 @@ import emu.grasscutter.server.packet.send.PacketChallengeDataNotify;
 
 public class KillMonsterTimeIncTrigger extends ChallengeTrigger {
 
-    private int increment;
+    private final int maxTime;
+    private final int increment;
 
-    public KillMonsterTimeIncTrigger(int increment) {
+    public KillMonsterTimeIncTrigger(int maxTime, int increment) {
+        this.maxTime = maxTime;
         this.increment = increment;
     }
 
     @Override
-    public void onBegin(WorldChallenge challenge) {
-        // challenge.getScene().broadcastPacket(new PacketChallengeDataNotify(challenge, 0,
-        // challenge.getScore().get()));
-    }
+    public void onBegin(WorldChallenge challenge) { }
 
     @Override
     public void onMonsterDeath(WorldChallenge challenge, EntityMonster monster) {
-        challenge.getScene().broadcastPacket(new PacketChallengeDataNotify(challenge, 0, increment));
-
+        var scene = challenge.getScene();
+        var elapsed = scene.getSceneTimeSeconds() - challenge.getStartedAt();
+        var timeLeft = challenge.getTimeLimit() - elapsed;
+        var increment = this.increment;
+        if (increment == 0) {
+            // Refresh time limit back to max
+            increment = maxTime - timeLeft;
+        } else if (maxTime < timeLeft + increment) {
+            // Don't add back more time than original limit
+            increment -= timeLeft + increment - maxTime;
+        }
         challenge.setTimeLimit(challenge.getTimeLimit() + increment);
+        scene.broadcastPacket(new PacketChallengeDataNotify(challenge, 2, timeLeft + increment + scene.getSceneTimeSeconds()));
     }
 }

--- a/src/main/java/emu/grasscutter/game/entity/EntityMonster.java
+++ b/src/main/java/emu/grasscutter/game/entity/EntityMonster.java
@@ -222,7 +222,9 @@ public class EntityMonster extends GameEntity {
     }
 
     @Override
-    public void onCreate() {
+    public void onTick(int sceneTime) {
+        super.onTick(sceneTime);
+
         // Lua event
         getScene()
                 .getScriptManager()


### PR DESCRIPTION
* Monds weapon mats domain: Fix time between kill not refreshing
* Inaz husk domain: Fix broken domain challenge
    * `EVENT_ANY_MONSTER_LIVE` is likely sent on tick, not on create. See scene40801_group240801001.lua:
         1. `condition_EVENT_ANY_MONSTER_LIVE_1023` checks for mob 1008 to spawn AND for variable `challenge` to be 1 
         2. Mob 1008 spawns during `action_EVENT_SELECT_OPTION_1003`, at `ScriptLib.AddExtraGroupSuite(context, 240801001, 2)`
         3. This spawn triggers `EVENT_ANY_MONSTER_LIVE` for mob 1008 but still fails the condition because `challenge` is still 0.
         4. `challenge` is set to 1 at the end of `action_EVENT_SELECT_OPTION_1003`. By now, `EVENT_ANY_MONSTER_LIVE` for mob 1008 no longer fires, causing the domain challenge to fail to start.

| ![gif](https://github.com/longfruit/Grasscutter/blob/gifs/stuff/killrefresh.gif?raw=true) | ![gif](https://github.com/longfruit/Grasscutter/blob/gifs/stuff/huskdom.gif?raw=true) |
|-|-|

## Description

Please carefully read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md) before making any pull requests.

## Issues fixed by this PR

<!--- Put the links of issues that may be fixed by this PR here (if any). -->
## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
