### PR TITLE
Add Docker Support

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -46,6 +46,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,51 @@
+---
+name: Build Docker Container
+on:
+  push:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v4
+
+      - name: Generate Docker Meta
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/kashalls/grasscutter
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3.1.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v5.2.0
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -20,7 +20,7 @@ jobs:
         uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ghcr.io/kashalls/grasscutter
+          images: ghcr.io/${{ github.repository_owner }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ tmp/
 
 /*.jar
 /*.sh
+!entrypoint.sh
 
 GM Handbook*.txt
 handbook.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Builder
 FROM gradle:jdk17-alpine as builder
 
+RUN apk add --update nodejs
+
 WORKDIR /app
 COPY ./ /app/
 
@@ -20,8 +22,6 @@ RUN git clone --branch ${DATA_BRANCH} --depth 1 ${DATA_REPOSITORY}
 FROM amazoncorretto:17-alpine
 
 WORKDIR /app
-
-RUN apk add --update nodejs
 
 # Copy built assets
 COPY --from=builder /app/grasscutter-1.7.4.jar /app/grasscutter.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM gradle:8.5.0-jdk17-alpine as builder
+FROM gradle:8.6-jdk17-alpine as builder
 
 WORKDIR /app
 COPY ./ /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Builder
+FROM gradle:8.5.0-jdk17-alpine as builder
+
+WORKDIR /app
+COPY ./ /app/
+
+RUN gradle jar --no-daemon
+
+# Fetch Data
+FROM bitnami/git:2.43.0-debian-11-r1 as data
+
+ARG DATA_REPOSITORY=https://gitlab.com/YuukiPS/GC-Resources.git
+ARG DATA_BRANCH=4.0
+
+WORKDIR /app
+
+RUN git clone --branch ${DATA_BRANCH} --depth 1 ${DATA_REPOSITORY}
+
+# Result Container
+FROM amazoncorretto:17-alpine
+
+RUN apt-get update && apt-get install unzip
+
+WORKDIR /app
+
+# Copy built assets
+COPY --from=builder /app/grasscutter-1.7.4.jar /app/grasscutter.jar
+COPY --from=builder /app/keystore.p12 /app/keystore.p12
+
+# Copy the resources
+COPY --from=data /app/GC-Resources/Resources /app/resources/
+
+# Copy startup files
+COPY ./entrypoint.sh /app/
+
+CMD [ "sh", "/app/entrypoint.sh" ]
+
+EXPOSE 80 443 8888 22102

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM gradle:8.6-jdk17-alpine as builder
+FROM gradle:jdk17-alpine as builder
 
 WORKDIR /app
 COPY ./ /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ FROM amazoncorretto:17-alpine
 
 WORKDIR /app
 
+RUN apk add --update nodejs
+
 # Copy built assets
 COPY --from=builder /app/grasscutter-1.7.4.jar /app/grasscutter.jar
 COPY --from=builder /app/keystore.p12 /app/keystore.p12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Builder
 FROM gradle:jdk17-alpine as builder
 
-RUN apk add --update nodejs
+RUN apk add --update nodejs npm
 
 WORKDIR /app
 COPY ./ /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ RUN git clone --branch ${DATA_BRANCH} --depth 1 ${DATA_REPOSITORY}
 # Result Container
 FROM amazoncorretto:17-alpine
 
-RUN apt-get update && apt-get install unzip
-
 WORKDIR /app
 
 # Copy built assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM amazoncorretto:17-alpine
 WORKDIR /app
 
 # Copy built assets
-COPY --from=builder /app/grasscutter-1.7.4.jar /app/grasscutter.jar
+COPY --from=builder /app/grasscutter-*.jar /app/grasscutter.jar
 COPY --from=builder /app/keystore.p12 /app/keystore.p12
 
 # Copy the resources

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#/bin/sh
+
+java -jar /app/grasscutter.jar


### PR DESCRIPTION
## Description
This PR extends off of #2455, simply adding support for building the required containers and publishing them to ghcr.io

This PR introduces a github workflow to build and publish a docker container that runs grasscutter on `amd64` platforms. The base builder container that gradle provides isn't supported for arm64, therefore we can't build for Raspberry Pi's/ARM-based platforms. This might be fixed in the future.

Configuration file can be loaded by using `-v C:\\Grasscutter\\test.json:/app/config.json`

## Issues fixed by this PR
See #2455 

## Type of changes
- [ ] Bug fix
- [ ] New feature 
- [X] Enhancement
- [ ] Documentation

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X ] My pull request is unique and no other pull requests have been opened for these changes
- [X] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [X] I am responsible for any copyright issues with my code if it occurs in the future.
