### PR TITLE
Switch order of literals to prevent NullPointerException

### DIFF
--- a/src/main/java/emu/grasscutter/command/CommandHelpers.java
+++ b/src/main/java/emu/grasscutter/command/CommandHelpers.java
@@ -58,7 +58,7 @@ public class CommandHelpers {
 
     public static float parseRelative(String input, Float current) {
         if (input.contains("~")) { // Relative
-            if (!input.equals("~")) { // Relative with offset
+            if (!"~".equals(input)) { // Relative with offset
                 current += Float.parseFloat(input.replace("~", ""));
             } // Else no offset, no modification
         } else { // Absolute
@@ -72,11 +72,11 @@ public class CommandHelpers {
         Position offset = new Position();
         Position target = new Position(curPos);
         if (inputX.contains("~")) { // Relative
-            if (!inputX.equals("~")) { // Relative with offset
+            if (!"~".equals(inputX)) { // Relative with offset
                 target.addX(Float.parseFloat(inputX.replace("~", "")));
             }
         } else if (inputX.contains("^")) {
-            if (!inputX.equals("^")) {
+            if (!"^".equals(inputX)) {
                 offset.setX(Float.parseFloat(inputX.replace("^", "")));
             }
         } else { // Absolute
@@ -84,11 +84,11 @@ public class CommandHelpers {
         }
 
         if (inputY.contains("~")) { // Relative
-            if (!inputY.equals("~")) { // Relative with offset
+            if (!"~".equals(inputY)) { // Relative with offset
                 target.addY(Float.parseFloat(inputY.replace("~", "")));
             }
         } else if (inputY.contains("^")) {
-            if (!inputY.equals("^")) {
+            if (!"^".equals(inputY)) {
                 offset.setY(Float.parseFloat(inputY.replace("^", "")));
             }
         } else { // Absolute
@@ -96,11 +96,11 @@ public class CommandHelpers {
         }
 
         if (inputZ.contains("~")) { // Relative
-            if (!inputZ.equals("~")) { // Relative with offset
+            if (!"~".equals(inputZ)) { // Relative with offset
                 target.addZ(Float.parseFloat(inputZ.replace("~", "")));
             }
         } else if (inputZ.contains("^")) {
-            if (!inputZ.equals("^")) {
+            if (!"^".equals(inputZ)) {
                 offset.setZ(Float.parseFloat(inputZ.replace("^", "")));
             }
         } else { // Absolute

--- a/src/main/java/emu/grasscutter/command/CommandMap.java
+++ b/src/main/java/emu/grasscutter/command/CommandMap.java
@@ -258,7 +258,7 @@ public final class CommandMap {
         if (label.startsWith("@")) { // @[UID]
             this.setPlayerTarget(playerId, player, label.substring(1));
             return;
-        } else if (label.equalsIgnoreCase("target")) { // target [[@]UID]
+        } else if ("target".equalsIgnoreCase(label)) { // target [[@]UID]
             if (!args.isEmpty()) {
                 String targetUidStr = args.get(0);
                 if (targetUidStr.startsWith("@")) {

--- a/src/main/java/emu/grasscutter/command/commands/DebugCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/DebugCommand.java
@@ -36,7 +36,7 @@ public final class DebugCommand implements CommandHandler {
                 // because there can be more than one entity with
                 // the given config ID.
                 var entity =
-                        args.size() > 1 && args.get(1).equals("config")
+                        args.size() > 1 && "config".equals(args.get(1))
                                 ? scene.getFirstEntityByConfigId(entityId)
                                 : scene.getEntityById(entityId);
                 if (entity == null) {

--- a/src/main/java/emu/grasscutter/command/commands/ListCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ListCommand.java
@@ -20,7 +20,7 @@ public final class ListCommand implements CommandHandler {
         boolean needUID = false;
 
         if (args.size() > 0) {
-            needUID = args.get(0).equals("uid");
+            needUID = "uid".equals(args.get(0));
         }
 
         CommandHandler.sendMessage(

--- a/src/main/java/emu/grasscutter/command/commands/ResetConstCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/ResetConstCommand.java
@@ -18,7 +18,7 @@ public final class ResetConstCommand implements CommandHandler {
 
     @Override
     public void execute(Player sender, Player targetPlayer, List<String> args) {
-        if (args.size() > 0 && args.get(0).equalsIgnoreCase("all")) {
+        if (args.size() > 0 && "all".equalsIgnoreCase(args.get(0))) {
             targetPlayer.getAvatars().forEach(this::resetConstellation);
             CommandHandler.sendMessage(sender, translate(sender, "commands.resetConst.reset_all"));
         } else {

--- a/src/main/java/emu/grasscutter/command/commands/SetConstCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/SetConstCommand.java
@@ -40,7 +40,7 @@ public final class SetConstCommand implements CommandHandler {
             }
             // Check if there's an additional argument which is "all", if it does then go
             // setAllConstellation
-            if (args.size() > 1 && args.get(1).equalsIgnoreCase("all")) {
+            if (args.size() > 1 && "all".equalsIgnoreCase(args.get(1))) {
                 this.setAllConstellation(targetPlayer, constLevel);
                 CommandHandler.sendTranslatedMessage(sender, "commands.setConst.successall", constLevel);
             } else sendUsageMessage(sender);

--- a/src/main/java/emu/grasscutter/command/commands/TeamCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TeamCommand.java
@@ -209,9 +209,9 @@ public final class TeamCommand implements CommandHandler {
 
     private List<Integer> transformToIndexes(String metaIndexes, int listLength) {
         // step 1: check if metaIndexes is a special constants
-        if (metaIndexes.equals("first")) {
+        if ("first".equals(metaIndexes)) {
             return List.of(1);
-        } else if (metaIndexes.equals("last")) {
+        } else if ("last".equals(metaIndexes)) {
             return List.of(listLength);
         }
 

--- a/src/main/java/emu/grasscutter/command/commands/TrialAvatarActivityCommand.java
+++ b/src/main/java/emu/grasscutter/command/commands/TrialAvatarActivityCommand.java
@@ -99,7 +99,7 @@ public final class TrialAvatarActivityCommand implements CommandHandler {
                             translate(
                                     sender, "commands.trialAvatarActivity.success_dungeon", Integer.parseInt(param)));
                 } else {
-                    if (!param.equals("all")) {
+                    if (!"all".equals(param)) {
                         CommandHandler.sendMessage(
                                 sender, translate(sender, "commands.trialAvatarActivity.invalid_param"));
                         return;
@@ -131,7 +131,7 @@ public final class TrialAvatarActivityCommand implements CommandHandler {
                             translate(
                                     sender, "commands.trialAvatarActivity.success_reward", Integer.parseInt(param)));
                 } else {
-                    if (!param.toLowerCase().equals("all")) {
+                    if (!"all".equals(param.toLowerCase())) {
                         CommandHandler.sendMessage(
                                 sender, translate(sender, "commands.trialAvatarActivity.invalid_param"));
                         return;

--- a/src/main/java/emu/grasscutter/scripts/data/SceneGroup.java
+++ b/src/main/java/emu/grasscutter/scripts/data/SceneGroup.java
@@ -89,7 +89,7 @@ public final class SceneGroup {
         this.bindings = ScriptLoader.getEngine().createBindings();
 
         CompiledScript cs;
-        if (overrideScriptPath != null && !overrideScriptPath.equals("")) {
+        if (overrideScriptPath != null && !"".equals(overrideScriptPath)) {
             cs = ScriptLoader.getScript(overrideScriptPath, true);
         } else {
             cs =

--- a/src/main/java/emu/grasscutter/server/game/GameServer.java
+++ b/src/main/java/emu/grasscutter/server/game/GameServer.java
@@ -184,7 +184,7 @@ public final class GameServer extends KcpServer implements Iterable<Player> {
 
     private static InetSocketAddress getAdapterInetSocketAddress() {
         InetSocketAddress inetSocketAddress;
-        if (GAME_INFO.bindAddress.equals("")) {
+        if ("".equals(GAME_INFO.bindAddress)) {
             inetSocketAddress = new InetSocketAddress(GAME_INFO.bindPort);
         } else {
             inetSocketAddress = new InetSocketAddress(GAME_INFO.bindAddress, GAME_INFO.bindPort);

--- a/src/main/java/emu/grasscutter/server/http/handlers/AnnouncementsHandler.java
+++ b/src/main/java/emu/grasscutter/server/http/handlers/AnnouncementsHandler.java
@@ -64,7 +64,7 @@ public final class AnnouncementsHandler implements Router {
         StringJoiner stringJoiner = new StringJoiner("/");
         for (String pathName : path) {
             // Filter the illegal payload to prevent directory traversal
-            if (!pathName.isEmpty() && !pathName.equals("..") && !pathName.contains("\\")) {
+            if (!pathName.isEmpty() && !"..".equals(pathName) && !pathName.contains("\\")) {
                 stringJoiner.add(pathName);
             }
         }

--- a/src/main/java/emu/grasscutter/utils/FileUtils.java
+++ b/src/main/java/emu/grasscutter/utils/FileUtils.java
@@ -75,7 +75,7 @@ public final class FileUtils {
                             (p, a) -> {
                                 var filename = p.getFileName();
                                 if (filename == null) return false;
-                                return filename.toString().equals("ExcelBinOutput");
+                                return "ExcelBinOutput".equals(filename.toString());
                             })) {
                 var excelBinOutput = pathStream.findFirst();
                 if (excelBinOutput.isPresent()) {

--- a/src/main/java/emu/grasscutter/utils/StartupArguments.java
+++ b/src/main/java/emu/grasscutter/utils/StartupArguments.java
@@ -113,7 +113,7 @@ public interface StartupArguments {
      * @return False to continue execution.
      */
     private static boolean enableDebug(String parameter) {
-        if (parameter != null && parameter.equals("all")) {
+        if (parameter != null && "all".equals(parameter)) {
             // Override default debug configs
             GAME_INFO.isShowLoopPackets = DEBUG_MODE_INFO.isShowLoopPackets;
             GAME_INFO.isShowPacketPayload = DEBUG_MODE_INFO.isShowPacketPayload;

--- a/src/main/java/emu/grasscutter/utils/lang/Language.java
+++ b/src/main/java/emu/grasscutter/utils/lang/Language.java
@@ -421,7 +421,7 @@ public final class Language {
         if (translations.containsKey(key)) return translations.get(key);
         String valueNotFoundPattern = "This value does not exist. Please report this to the Discord: ";
         String result = valueNotFoundPattern + key;
-        if (!languageCode.equals("en-US")) {
+        if (!"en-US".equals(languageCode)) {
             String englishValue = getLanguage("en-US").get(key);
             if (!englishValue.contains(valueNotFoundPattern)) {
                 result += "\nhere is english version:\n" + englishValue;


### PR DESCRIPTION
## Description

This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [https://cwe.mitre.org/data/definitions/476.html](https://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2FGrasscutter%7Ca3860996efaa5bff1869632529e552508ca12057)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [ ] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
