### PR TITLE
Created Add/Del SceneTag exec for quests | Fixed Filters for WorldBoss checking first ID only

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecAddSceneTag.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecAddSceneTag.java
@@ -1,0 +1,19 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.excels.quest.QuestData;
+import emu.grasscutter.game.quest.*;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+import java.util.Arrays;
+
+@QuestValueExec(QuestExec.QUEST_EXEC_ADD_SCENE_TAG)
+public final class ExecAddSceneTag extends QuestExecHandler {
+    @Override
+    public boolean execute(GameQuest quest, QuestData.QuestExecParam condition, String... paramStr) {
+        var param =
+                Arrays.stream(paramStr).filter(i -> !i.isBlank()).mapToInt(Integer::parseInt).toArray();
+		quest.getOwner().getProgressManager().addSceneTag(param[0], param[1]);
+		
+        return true;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecDelSceneTag.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecDelSceneTag.java
@@ -1,0 +1,19 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.excels.quest.QuestData;
+import emu.grasscutter.game.quest.*;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+import java.util.Arrays;
+
+@QuestValueExec(QuestExec.QUEST_EXEC_DEL_SCENE_TAG)
+public final class ExecDelSceneTag extends QuestExecHandler {
+    @Override
+    public boolean execute(GameQuest quest, QuestData.QuestExecParam condition, String... paramStr) {
+        var param =
+                Arrays.stream(paramStr).filter(i -> !i.isBlank()).mapToInt(Integer::parseInt).toArray();
+		quest.getOwner().getProgressManager().delSceneTag(param[0], param[1]);
+		
+        return true;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/world/WorldDataSystem.java
+++ b/src/main/java/emu/grasscutter/game/world/WorldDataSystem.java
@@ -52,8 +52,8 @@ public class WorldDataSystem extends BaseGameSystem {
         var investigationMonsterData =
                 GameData.getInvestigationMonsterDataMap().values().parallelStream()
                         .filter(imd -> imd.getMonsterIdList() != null && !imd.getMonsterIdList().isEmpty())
-                        .filter(imd -> imd.getMonsterIdList().get(0) == monsterId)
-                        .findFirst();
+                        .filter(imd -> imd.getMonsterIdList().contains(monsterId))
+                        .findAny();
 
         return investigationMonsterData
                 .map(

--- a/src/main/java/emu/grasscutter/game/world/WorldDataSystem.java
+++ b/src/main/java/emu/grasscutter/game/world/WorldDataSystem.java
@@ -52,8 +52,8 @@ public class WorldDataSystem extends BaseGameSystem {
         var investigationMonsterData =
                 GameData.getInvestigationMonsterDataMap().values().parallelStream()
                         .filter(imd -> imd.getMonsterIdList() != null && !imd.getMonsterIdList().isEmpty())
-                        .filter(imd -> imd.getMonsterIdList().contains(monsterId))
-                        .findAny();
+                        .filter(imd -> imd.getMonsterIdList().get(0) == monsterId)
+                        .findFirst();
 
         return investigationMonsterData
                 .map(


### PR DESCRIPTION
Added 2 missing classes for adding and deleting sceneTags in quests

Edit: im not sure how to make it take 1 commit only so i guess its 2 fixes then.
## Description
Issue 1:
Added 2 missing Execute Classes for quests for adding and deleting sceneTag. 
[src/main/java/emu/grasscutter/game/quest/exec/ExecAddSceneTag.java]
[src/main/java/emu/grasscutter/game/quest/exec/ExecDelSceneTag.java]

Issue 2:
Fixed Filters on InvestgationMonsters Rewards checking only the first Boss ID 
[src/main/java/emu/grasscutter/game/world/WorldDataSystem.java]

## Issues fixed by this PR
Issue 1:
World quests such as (Seirai Stormchasers) changing sceneTag such as the Thunder Manifestation platform would not change after finishing the quest.

Issue 2:
getRewardByBossId was checking with filters and using FindFirst and get[0] which caused Multi Variant Bosses to give error "Could Not found the reward of boss monster *id*"

Example of bosses effected is Primo Geovishap would only get rewards for the first boss "hydro" but not the other variants.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [x] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
