### PR TITLE
daily check ins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ patches/*.patch
 
 # Artifact Signatures
 *.asc
+
+# Feature proposals
+feature_proposals.md

--- a/src/main/java/emu/grasscutter/game/mail/BirthdayMailSystem.java
+++ b/src/main/java/emu/grasscutter/game/mail/BirthdayMailSystem.java
@@ -1,0 +1,137 @@
+package emu.grasscutter.game.mail;
+
+import emu.grasscutter.Grasscutter;
+import emu.grasscutter.game.player.Player;
+import emu.grasscutter.game.props.ActionReason;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * System for handling birthday gifts for players.
+ * Checks if today is a player's birthday and sends a gift if it is.
+ */
+public class BirthdayMailSystem {
+    // Mail content constants
+    private static final String MAIL_TITLE = "Best Wishes on Your Birthday";
+    private static final String MAIL_CONTENT = "Happy Birthday, Traveler! Please find your gift attached to this message. Thank you for all your support. We wish you a brighter future, no matter what you are going through.";
+    private static final String MAIL_SENDER = "Server";
+    
+    // Gift item ID - Cake for Traveler
+    private static final int BIRTHDAY_GIFT_ID = 118008;
+    private static final int BIRTHDAY_GIFT_COUNT = 1;
+    
+    /**
+     * Checks if today is the player's birthday and sends a gift if it is.
+     * Should be called when a player logs in.
+     *
+     * @param player The player to check
+     */
+    public static void checkBirthdayAndSendGift(Player player) {
+        if (player == null || !player.hasBirthday()) {
+            return;
+        }
+        
+        // Get current date
+        LocalDate currentDate = LocalDate.now(ZoneId.systemDefault());
+        int currentDay = currentDate.getDayOfMonth();
+        int currentMonth = currentDate.getMonthValue();
+        
+        // Get player's birthday
+        int birthdayDay = player.getBirthday().getDay();
+        int birthdayMonth = player.getBirthday().getMonth();
+        
+        // Check if today is the player's birthday
+        if (currentDay == birthdayDay && currentMonth == birthdayMonth) {
+            // Check if player already received birthday gift today
+            if (!hasReceivedBirthdayGiftToday(player)) {
+                sendBirthdayGift(player);
+            }
+        }
+    }
+    
+    /**
+     * Sends a birthday gift to the player.
+     *
+     * @param player The player to send the gift to
+     */
+    private static void sendBirthdayGift(Player player) {
+        // Create mail content
+        Mail.MailContent mailContent = new Mail.MailContent(MAIL_TITLE, MAIL_CONTENT, MAIL_SENDER);
+        
+        // Create mail item list with birthday cake
+        List<Mail.MailItem> mailItems = new ArrayList<>();
+        mailItems.add(new Mail.MailItem(BIRTHDAY_GIFT_ID, BIRTHDAY_GIFT_COUNT));
+        
+        // Calculate expiration time (7 days from now)
+        long expireTime = System.currentTimeMillis() / 1000 + (7 * 24 * 60 * 60);
+        
+        // Create mail
+        Mail birthdayMail = new Mail(mailContent, mailItems, expireTime);
+        
+        // Send mail to player
+        player.getMailHandler().sendMail(birthdayMail);
+        
+        // Log the action
+        Grasscutter.getLogger().info("Birthday gift sent to " + player.getNickname() + " (UID: " + player.getUid() + ")");
+        
+        // Mark that player received birthday gift today
+        markBirthdayGiftReceived(player);
+    }
+    
+    /**
+     * Checks if the player has already received a birthday gift today.
+     * Uses player properties to store this information.
+     *
+     * @param player The player to check
+     * @return True if the player has received a birthday gift today, false otherwise
+     */
+    private static boolean hasReceivedBirthdayGiftToday(Player player) {
+        // Get current date as a string in format YYYYMMDD
+        LocalDate currentDate = LocalDate.now(ZoneId.systemDefault());
+        String dateString = String.format("%04d%02d%02d", 
+                currentDate.getYear(), 
+                currentDate.getMonthValue(), 
+                currentDate.getDayOfMonth());
+        
+        // Convert to integer for storage in player properties
+        int dateValue = Integer.parseInt(dateString);
+        
+        // Check if player has a property for the last birthday gift date
+        Integer lastGiftDate = player.getProperties().get(PlayerProperties.LAST_BIRTHDAY_GIFT_DATE);
+        
+        return lastGiftDate != null && lastGiftDate == dateValue;
+    }
+    
+    /**
+     * Marks that the player has received a birthday gift today.
+     *
+     * @param player The player to mark
+     */
+    private static void markBirthdayGiftReceived(Player player) {
+        // Get current date as a string in format YYYYMMDD
+        LocalDate currentDate = LocalDate.now(ZoneId.systemDefault());
+        String dateString = String.format("%04d%02d%02d", 
+                currentDate.getYear(), 
+                currentDate.getMonthValue(), 
+                currentDate.getDayOfMonth());
+        
+        // Convert to integer for storage in player properties
+        int dateValue = Integer.parseInt(dateString);
+        
+        // Store the date in player properties
+        player.getProperties().put(PlayerProperties.LAST_BIRTHDAY_GIFT_DATE, dateValue);
+        
+        // Save player data
+        player.save();
+    }
+    
+    /**
+     * Constants for player properties related to birthday gifts.
+     */
+    private static class PlayerProperties {
+        public static final int LAST_BIRTHDAY_GIFT_DATE = 10001; // Custom property ID
+    }
+}

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -11,6 +11,7 @@ import emu.grasscutter.game.ability.AbilityManager;
 import emu.grasscutter.game.achievement.Achievements;
 import emu.grasscutter.game.activity.ActivityManager;
 import emu.grasscutter.game.avatar.*;
+import emu.grasscutter.game.mail.BirthdayMailSystem;
 import emu.grasscutter.game.battlepass.BattlePassManager;
 import emu.grasscutter.game.city.CityInfoData;
 import emu.grasscutter.game.entity.GameEntity;
@@ -1469,6 +1470,9 @@ public class Player implements PlayerHook, FieldFetch {
 
         // First notify packets sent
         this.hasSentLoginPackets = true;
+        
+        // Check if today is player's birthday and send gift if needed
+        BirthdayMailSystem.checkBirthdayAndSendGift(this);
 
         // Set session state
         session.setState(SessionState.ACTIVE);

--- a/src/main/java/emu/grasscutter/game/player/Player.java
+++ b/src/main/java/emu/grasscutter/game/player/Player.java
@@ -12,6 +12,7 @@ import emu.grasscutter.game.achievement.Achievements;
 import emu.grasscutter.game.activity.ActivityManager;
 import emu.grasscutter.game.avatar.*;
 import emu.grasscutter.game.mail.BirthdayMailSystem;
+import emu.grasscutter.game.systems.DailyCheckInSystem;
 import emu.grasscutter.game.battlepass.BattlePassManager;
 import emu.grasscutter.game.city.CityInfoData;
 import emu.grasscutter.game.entity.GameEntity;
@@ -1473,6 +1474,9 @@ public class Player implements PlayerHook, FieldFetch {
         
         // Check if today is player's birthday and send gift if needed
         BirthdayMailSystem.checkBirthdayAndSendGift(this);
+        
+        // Check daily check-in and send reward if eligible
+        DailyCheckInSystem.checkDailyRewardAndSend(this);
 
         // Set session state
         session.setState(SessionState.ACTIVE);

--- a/src/main/java/emu/grasscutter/game/systems/DailyCheckInSystem.java
+++ b/src/main/java/emu/grasscutter/game/systems/DailyCheckInSystem.java
@@ -1,0 +1,209 @@
+package emu.grasscutter.game.systems;
+
+import emu.grasscutter.Grasscutter;
+import emu.grasscutter.game.mail.Mail;
+import emu.grasscutter.game.player.Player;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * System for handling daily check-in rewards for players.
+ * Players receive rewards for each day they log in, with a monthly cycle.
+ */
+public class DailyCheckInSystem {
+    // Mail content constants
+    private static final String MAIL_TITLE = "Daily Check-In Reward";
+    private static final String MAIL_CONTENT = "Thank you for logging in today, Traveler! Here's your daily check-in reward.";
+    private static final String MAIL_SENDER = "Check-In System";
+    
+    // Player property for storing last check-in date
+    private static final int LAST_CHECK_IN_DATE_PROP = 10002;
+    // Player property for storing current check-in streak
+    private static final int CHECK_IN_STREAK_PROP = 10003;
+    
+    // Map of day number to reward item data
+    private static final Map<Integer, CheckInReward> CHECK_IN_REWARDS = new HashMap<>();
+    
+    static {
+        // Initialize the rewards map
+        CHECK_IN_REWARDS.put(1, new CheckInReward(104002, 3, "Adventurer's Experience"));
+        CHECK_IN_REWARDS.put(2, new CheckInReward(104012, 3, "Fine Enhancement Ore"));
+        CHECK_IN_REWARDS.put(3, new CheckInReward(202, 5000, "Mora"));
+        CHECK_IN_REWARDS.put(4, new CheckInReward(201, 20, "Primogem"));
+        CHECK_IN_REWARDS.put(5, new CheckInReward(108032, 3, "Sweet Madame"));
+        CHECK_IN_REWARDS.put(6, new CheckInReward(104002, 2, "Adventurer's Experience"));
+        CHECK_IN_REWARDS.put(7, new CheckInReward(202, 8000, "Mora"));
+        CHECK_IN_REWARDS.put(8, new CheckInReward(104002, 3, "Adventurer's Experience"));
+        CHECK_IN_REWARDS.put(9, new CheckInReward(104012, 3, "Fine Enhancement Ore"));
+        CHECK_IN_REWARDS.put(10, new CheckInReward(202, 5000, "Mora"));
+        CHECK_IN_REWARDS.put(11, new CheckInReward(201, 20, "Primogem"));
+        CHECK_IN_REWARDS.put(12, new CheckInReward(108026, 2, "Fried Radish Balls"));
+        CHECK_IN_REWARDS.put(13, new CheckInReward(104002, 3, "Adventurer's Experience"));
+        CHECK_IN_REWARDS.put(14, new CheckInReward(202, 8000, "Mora"));
+        CHECK_IN_REWARDS.put(15, new CheckInReward(104002, 5, "Adventurer's Experience"));
+        CHECK_IN_REWARDS.put(16, new CheckInReward(104012, 5, "Fine Enhancement Ore"));
+        CHECK_IN_REWARDS.put(17, new CheckInReward(202, 5000, "Mora"));
+        CHECK_IN_REWARDS.put(18, new CheckInReward(201, 20, "Primogem"));
+        CHECK_IN_REWARDS.put(19, new CheckInReward(108002, 3, "Fisherman's Toast"));
+        CHECK_IN_REWARDS.put(20, new CheckInReward(104002, 3, "Adventurer's Experience"));
+        CHECK_IN_REWARDS.put(21, new CheckInReward(202, 8000, "Mora"));
+        CHECK_IN_REWARDS.put(22, new CheckInReward(104002, 5, "Adventurer's Experience"));
+        CHECK_IN_REWARDS.put(23, new CheckInReward(104012, 5, "Fine Enhancement Ore"));
+        CHECK_IN_REWARDS.put(24, new CheckInReward(202, 5000, "Mora"));
+        CHECK_IN_REWARDS.put(25, new CheckInReward(104003, 3, "Hero's Wit"));
+        CHECK_IN_REWARDS.put(26, new CheckInReward(108081, 3, "Almond Tofu"));
+        CHECK_IN_REWARDS.put(27, new CheckInReward(104002, 3, "Adventurer's Experience"));
+        CHECK_IN_REWARDS.put(28, new CheckInReward(104003, 3, "Hero's Wit"));
+        CHECK_IN_REWARDS.put(29, new CheckInReward(202, 5000, "Mora"));
+        CHECK_IN_REWARDS.put(30, new CheckInReward(202, 5000, "Mora"));
+        CHECK_IN_REWARDS.put(31, new CheckInReward(202, 5000, "Mora"));
+    }
+    
+    /**
+     * Checks if the player can claim a daily check-in reward and sends it if eligible.
+     * Should be called when a player logs in.
+     *
+     * @param player The player to check
+     */
+    public static void checkDailyRewardAndSend(Player player) {
+        if (player == null) {
+            return;
+        }
+        
+        // Get current date
+        LocalDate currentDate = LocalDate.now(ZoneId.systemDefault());
+        String currentDateString = currentDate.format(DateTimeFormatter.BASIC_ISO_DATE);
+        int currentDateValue = Integer.parseInt(currentDateString);
+        
+        // Get last check-in date from player properties
+        Integer lastCheckInDate = player.getProperties().get(LAST_CHECK_IN_DATE_PROP);
+        
+        // If player has never checked in or it's a different day
+        if (lastCheckInDate == null || lastCheckInDate != currentDateValue) {
+            // Get current streak
+            int currentStreak = player.getProperties().getOrDefault(CHECK_IN_STREAK_PROP, 0);
+            
+            // Check if this is a consecutive day
+            boolean isConsecutiveDay = isConsecutiveDay(lastCheckInDate, currentDateValue);
+            
+            // Update streak
+            if (isConsecutiveDay) {
+                currentStreak++;
+                // If streak is greater than the number of days in a month, reset to 1
+                if (currentStreak > 31) {
+                    currentStreak = 1;
+                }
+            } else {
+                // Reset streak if not consecutive
+                currentStreak = 1;
+            }
+            
+            // Send reward based on current streak
+            sendDailyReward(player, currentStreak);
+            
+            // Update player properties
+            player.getProperties().put(LAST_CHECK_IN_DATE_PROP, currentDateValue);
+            player.getProperties().put(CHECK_IN_STREAK_PROP, currentStreak);
+            
+            // Save player data
+            player.save();
+            
+            // Log the check-in
+            Grasscutter.getLogger().info("Player {} (UID: {}) claimed day {} check-in reward", 
+                    player.getNickname(), player.getUid(), currentStreak);
+        }
+    }
+    
+    /**
+     * Checks if two dates are consecutive days.
+     *
+     * @param lastDateValue The previous date as YYYYMMDD
+     * @param currentDateValue The current date as YYYYMMDD
+     * @return True if the dates are consecutive days, false otherwise
+     */
+    private static boolean isConsecutiveDay(Integer lastDateValue, int currentDateValue) {
+        if (lastDateValue == null) {
+            return false;
+        }
+        
+        try {
+            // Parse the date values
+            String lastDateStr = String.valueOf(lastDateValue);
+            String currentDateStr = String.valueOf(currentDateValue);
+            
+            LocalDate lastDate = LocalDate.parse(lastDateStr, DateTimeFormatter.BASIC_ISO_DATE);
+            LocalDate currentDate = LocalDate.parse(currentDateStr, DateTimeFormatter.BASIC_ISO_DATE);
+            
+            // Check if the dates are consecutive
+            return lastDate.plusDays(1).equals(currentDate);
+        } catch (Exception e) {
+            Grasscutter.getLogger().error("Error checking consecutive days", e);
+            return false;
+        }
+    }
+    
+    /**
+     * Sends a daily check-in reward to the player.
+     *
+     * @param player The player to send the reward to
+     * @param day The day number in the check-in cycle
+     */
+    private static void sendDailyReward(Player player, int day) {
+        // Get the reward for the current day
+        CheckInReward reward = CHECK_IN_REWARDS.get(day);
+        if (reward == null) {
+            Grasscutter.getLogger().error("No reward found for day {}", day);
+            return;
+        }
+        
+        // Create mail content
+        String content = MAIL_CONTENT + "\n\nDay " + day + ": " + reward.getCount() + "x " + reward.getName();
+        Mail.MailContent mailContent = new Mail.MailContent(MAIL_TITLE, content, MAIL_SENDER);
+        
+        // Create mail item list with the reward
+        List<Mail.MailItem> mailItems = new ArrayList<>();
+        mailItems.add(new Mail.MailItem(reward.getItemId(), reward.getCount()));
+        
+        // Calculate expiration time (7 days from now)
+        long expireTime = System.currentTimeMillis() / 1000 + (7 * 24 * 60 * 60);
+        
+        // Create mail
+        Mail checkInMail = new Mail(mailContent, mailItems, expireTime);
+        
+        // Send mail to player
+        player.getMailHandler().sendMail(checkInMail);
+    }
+    
+    /**
+     * Class representing a daily check-in reward.
+     */
+    private static class CheckInReward {
+        private final int itemId;
+        private final int count;
+        private final String name;
+        
+        public CheckInReward(int itemId, int count, String name) {
+            this.itemId = itemId;
+            this.count = count;
+            this.name = name;
+        }
+        
+        public int getItemId() {
+            return itemId;
+        }
+        
+        public int getCount() {
+            return count;
+        }
+        
+        public String getName() {
+            return name;
+        }
+    }
+}


### PR DESCRIPTION
Created a new "DailyCheckInSystem" class in the "emu.grasscutter.game.systems" package that:
        - Keeps track of consecutive player logins
        - Stores information about the last login and the current series of logins in the player properties
        - Contains a full table of rewards for each day of the month (31 days)
        - Sends the corresponding rewards via the mail system
Integrated the system with the player login process:
        - Added import of the new class to Player.java
        - Added a call to "DailyCheckInSystem.checkDailyRewardAndSend(this)" to the "on Login()" method
The system automatically checks if the player has logged in today and sends the reward if this is the first login of the day
Implemented the logic for consecutive logins:
        - The system keeps track of whether the logins are consecutive (day after day)
        - If the player misses a day, the counter is reset to 1
After 31 days, the cycle starts over

Default rewards are:
Day 1 Adventurer's Experience x3
Day 2 Fine Enhancement Ore x3
Day 3 Mora x5000
Day 4 Primogem x20
Day 5 Sweet Madame x3
Day 6 Adventurer's Experience x2
Day 7 Mora x8000
Day 8 Adventurer's Experience x3
Day 9 Fine Enhancement Ore x3
Day 10 Mora x5000
Day 11 Primogem x20
Day 12 Fried Radish Balls x2
Day 13 Adventurer's Experience x3
Day 14 Mora x8000
Day 15 Adventurer's Experience x5
Day 16 Fine Enhancement Ore x5
Day 17 Mora x5000
Day 18 Primogem x20
Day 19 Fisherman's Toast x3
Day 20 Adventurer's Experience x3
Day 21 Mora x8000
Day 22 Adventurer's Experience x5
Day 23 Fine Enhancement Ore x5
Day 24 Mora x5000
Day 25 Hero's Wit x3
Day 26 Almond Tofu x3
Day 27 Adventurer's Experience x3
Day 28 Hero's Wit x3
Day 29 Mora x5000
Day 30 Mora x5000
Day 31 Mora x5000
